### PR TITLE
Remove REST API timeout and retry configuration

### DIFF
--- a/Wydarzynier/index.js
+++ b/Wydarzynier/index.js
@@ -29,10 +29,6 @@ const client = new Client({
         GatewayIntentBits.DirectMessages,
     ],
     partials: [Partials.Message, Partials.Reaction, Partials.User, Partials.Channel],
-    rest: {
-        timeout: 60000, // 60 sekund timeout dla REST API
-        retries: 3      // 3 próby w przypadku błędu
-    }
 });
 
 const lobbyService = new LobbyService(config);


### PR DESCRIPTION
## Summary
Removed the explicit REST API timeout and retry configuration from the Discord client initialization, allowing the client to use default values instead.

## Changes
- Removed the `rest` configuration object that was setting:
  - `timeout: 60000` (60 second timeout for REST API calls)
  - `retries: 3` (retry attempts on failure)

## Details
The REST API configuration block has been deleted from the Client constructor options. This allows the Discord.js client to fall back to its default timeout and retry behavior, which may be more appropriate for the application's needs or align with updated library defaults.

https://claude.ai/code/session_01CptFAezg7MsS29npDSY4hR