### PR TITLE
Add error handling to bot initialization handlers

### DIFF
--- a/Konklawe/index.js
+++ b/Konklawe/index.js
@@ -122,7 +122,11 @@ async function initializeServices() {
  */
 async function onReady() {
     logger.success('✅ Konklawe gotowy - gra w hasła, błogosławienia JP2');
-    await commandService.registerSlashCommands();
+    try {
+        await commandService.registerSlashCommands();
+    } catch (error) {
+        logger.error('❌ Błąd rejestracji komend Konklawe:', error);
+    }
 
     // Przywróć nicki dla wygasłych klątw (efektów które wygasły podczas offline bota)
     try {

--- a/Kontroler/index.js
+++ b/Kontroler/index.js
@@ -190,17 +190,21 @@ async function updateActivationMessage(client, robotUsers, botLabel, customIdPre
  */
 function setupEventHandlers() {
     client.once('ready', async () => {
-        await onReady();
-        // Inicjalizuj serwis loterii z klientem Discord
-        await lotteryService.initialize(client);
-        // Inicjalizuj serwis głosowania z klientem Discord
-        await votingService.initialize(client);
-        await registerSlashCommands(client, config);
+        try {
+            await onReady();
+            // Inicjalizuj serwis loterii z klientem Discord
+            await lotteryService.initialize(client);
+            // Inicjalizuj serwis głosowania z klientem Discord
+            await votingService.initialize(client);
+            await registerSlashCommands(client, config);
 
-        await updateActivationMessage(
-            client, config.robot1Users, 'Kontroler', 'robot_activate_kontroler_',
-            path.join(__dirname, 'data', 'robot_activation_msg.json')
-        );
+            await updateActivationMessage(
+                client, config.robot1Users, 'Kontroler', 'robot_activate_kontroler_',
+                path.join(__dirname, 'data', 'robot_activation_msg.json')
+            );
+        } catch (error) {
+            logger.error('❌ Błąd krytyczny podczas inicjalizacji Kontroler:', error);
+        }
     });
     client.on('messageCreate', async (message) => {
         if (message.channel.type === ChannelType.DM && !message.author.bot) {

--- a/Muteusz/index.js
+++ b/Muteusz/index.js
@@ -88,8 +88,9 @@ async function isAdminMember(guild, userId) {
 }
 
 client.once(Events.ClientReady, async () => {
+  try {
     await logService.logMessage('success', `Bot ${client.user.tag} jest online!`);
-    
+
     // Załaduj członków do cache
     try {
         let totalMembers = 0;
@@ -142,6 +143,9 @@ client.once(Events.ClientReady, async () => {
     await setupReportButtonMessage(client, config);
 
     logger.success('✅ Muteusz gotowy - moderacja, media (100MB), zarządzanie rolami, blokowanie obrazów i słów, Chaos Mode, system zgłoszeń');
+  } catch (error) {
+    logger.error('❌ Błąd krytyczny podczas inicjalizacji Muteusz:', error);
+  }
 });
 
 client.on(Events.MessageCreate, async (message) => {

--- a/Rekruter/index.js
+++ b/Rekruter/index.js
@@ -134,8 +134,9 @@ async function updateActivationMessage(client, robotUsers, botLabel, customIdPre
 }
 
 client.once('ready', async () => {
+  try {
     logger.success('✅ Rekruter gotowy - rekrutacja z OCR, boost tracking');
-    
+
     // Rejestracja komend slash
     await registerSlashCommands(client, config);
     
@@ -206,6 +207,9 @@ client.once('ready', async () => {
         client, config.robot2Users, 'Rekruter', 'robot_activate_rekruter_',
         path.join(__dirname, 'data', 'robot_activation_msg.json')
     );
+  } catch (error) {
+    logger.error('❌ Błąd krytyczny podczas inicjalizacji Rekruter:', error);
+  }
 });
 
 client.on('interactionCreate', async interaction => {

--- a/Stalker/index.js
+++ b/Stalker/index.js
@@ -140,6 +140,7 @@ const sharedState = {
 };
 
 client.once(Events.ClientReady, async () => {
+  try {
     logger.success('✅ Stalker gotowy - kary za bossów (OCR), urlopy');
 
     // Inicjalizacja serwisów
@@ -251,6 +252,9 @@ client.once(Events.ClientReady, async () => {
 
     // Usunięto automatyczne odświeżanie cache'u członków - teraz odbywa się przed użyciem komend
 
+  } catch (error) {
+    logger.error('❌ Błąd krytyczny podczas inicjalizacji Stalker:', error);
+  }
 });
 
 client.on(Events.InteractionCreate, async (interaction) => {

--- a/Szkolenia/index.js
+++ b/Szkolenia/index.js
@@ -55,11 +55,19 @@ client.once(Events.ClientReady, async () => {
         logger.error('❌ Błąd pobierania wątków:', error.message);
     }
 
-    await registerSlashCommands(client);
+    try {
+        await registerSlashCommands(client);
+    } catch (error) {
+        logger.error('❌ Błąd rejestracji komend Szkolenia:', error);
+    }
 
     logger.success('✅ Szkolenia gotowy - wątki szkoleniowe, AI Chat');
 
-    await checkThreads(client, sharedState, config, true);
+    try {
+        await checkThreads(client, sharedState, config, true);
+    } catch (error) {
+        logger.error('❌ Błąd sprawdzania wątków przy starcie:', error);
+    }
 
     const cronExpression = `${config.timing.checkMinute} ${config.timing.checkHour} * * *`;
     cron.schedule(cronExpression, () => {

--- a/Wydarzynier/index.js
+++ b/Wydarzynier/index.js
@@ -152,6 +152,7 @@ async function updateActivationMessage(client, robotUsers, botLabel, customIdPre
 }
 
 client.once(Events.ClientReady, async () => {
+  try {
     logger.success('✅ Wydarzynier gotowy - lobby partii, bazar, przypomnienia, eventy');
 
     // Wczytaj lobby i timery z plików
@@ -190,6 +191,9 @@ client.once(Events.ClientReady, async () => {
         path.join(__dirname, 'data', 'robot_activation_msg.json')
     );
 
+  } catch (error) {
+    logger.error('❌ Błąd krytyczny podczas inicjalizacji Wydarzynier:', error);
+  }
 });
 
 client.on(Events.InteractionCreate, async (interaction) => {


### PR DESCRIPTION
## Summary
This PR adds comprehensive error handling to the `ready` event handlers across all bot modules. Previously, initialization failures would crash the bots silently. Now, critical errors during startup are caught and logged, improving observability and stability.

## Key Changes
- **Kontroler**: Wrapped entire `ready` event handler in try-catch block to catch initialization errors from `onReady()`, lottery service, voting service, slash commands, and activation message updates
- **Szkolenia**: Added separate try-catch blocks for `registerSlashCommands()` and `checkThreads()` calls to handle registration and thread validation errors independently
- **Konklawe**: Added try-catch around `commandService.registerSlashCommands()` to prevent crashes from command registration failures
- **Muteusz**: Wrapped entire `ready` event handler in try-catch to catch errors from member caching, role setup, and report button initialization
- **Rekruter**: Wrapped entire `ready` event handler in try-catch to handle errors from slash command registration and activation message updates
- **Stalker**: Wrapped entire `ready` event handler in try-catch to catch errors from service initialization and cache operations
- **Wydarzynier**: Wrapped entire `ready` event handler in try-catch to handle errors from lobby/timer loading and activation message updates

## Implementation Details
- All error handlers log messages using the existing `logger.error()` function with consistent formatting: `❌ Błąd krytyczny podczas inicjalizacji [BotName]:`
- Error handling is granular where appropriate (Szkolenia) to allow partial initialization on non-critical failures
- Error handling is comprehensive where needed (other bots) to ensure the entire initialization process is protected
- Minor formatting improvements (whitespace cleanup) included in some files

https://claude.ai/code/session_01QKda1PXDxEyN1UG9gtsgPn