### PR TITLE
Strip trailing slashes from APP_API_URL configuration

### DIFF
--- a/utils/appSync.js
+++ b/utils/appSync.js
@@ -16,7 +16,7 @@
  *     callers to pass a deterministic `id`. Use eventId() to generate one.
  *
  * Config:
- *   APP_API_URL — base URL of the web API (no trailing slash).
+ *   APP_API_URL — base URL of the web API (trailing slash is stripped automatically).
  *   BOT_API_KEY — shared secret; must match the API's env var.
  *   When either is missing, all calls silently no-op (keeps dev/test easy).
  */
@@ -26,7 +26,8 @@ const { createBotLogger } = require('./consoleLogger');
 
 const logger = createBotLogger('AppSync');
 
-const APP_API_URL = process.env.APP_API_URL;
+// Strip any accidental trailing slash so URL construction never produces //.
+const APP_API_URL = process.env.APP_API_URL?.replace(/\/+$/, '');
 const BOT_API_KEY = process.env.BOT_API_KEY;
 
 const DEFAULT_RETRIES = 3;


### PR DESCRIPTION
## Summary
Updated the `APP_API_URL` configuration handling to automatically strip trailing slashes, preventing double slashes in constructed URLs.

## Changes
- Modified `APP_API_URL` initialization to use `.replace(/\/+$/, '')` to remove any trailing slashes from the environment variable
- Updated the JSDoc comment to reflect that trailing slashes are now stripped automatically, rather than requiring callers to avoid them
- Added an explanatory comment clarifying the purpose of the trailing slash removal

## Implementation Details
The change uses optional chaining (`?.`) and a regex replacement to safely remove one or more trailing slashes from the configured URL. This ensures that URL construction throughout the module will never produce double slashes (`//`) when appending paths, improving robustness and reducing the chance of URL-related bugs.

https://claude.ai/code/session_01LKM7vvP3Rth9kxkJhTamgv