### PR TITLE
Improve points removal logic and feedback in /points command

### DIFF
--- a/Stalker/CLAUDE.md
+++ b/Stalker/CLAUDE.md
@@ -10,7 +10,7 @@
      - Automatyczny fallback na tradycyjny OCR gdy AI zawiedzie
      - Dotyczy komend: `/punish`, `/remind`, `/faza1`, `/faza2`
      - Walidacja wyników: 0–999999 (obsługuje wyniki 5-cyfrowe i wyższe)
-2. **Punkty** - `punishmentService.js`: 2pts=kara, 3pts=ban loterii, cron czyszczenie (pn 00:00)
+2. **Punkty** - `punishmentService.js`: 2pts=kara, 3pts=ban loterii, cron czyszczenie (pn 00:00). `/points` z ujemną wartością: gdy `points` spada do 0 → `lifetime_points` też zerowane do 0 (czyste konto). Odpowiedź pokazuje nowe `points` i status `lifetime_points`.
 3. **Urlopy** - `vacationService.js`: Przycisk → rola 15min, cooldown 6h
 4. **Dekoder** - `decodeService.js`: `/decode` dla Survivor.io (LZMA decompress)
 5. **Kolejkowanie OCR** - `queueService.js`: Jeden user/guild, progress bar, 15min timeout, przyciski komend. Anulowanie w trakcie przetwarzania: embed aktualizowany do stanu "❌ Sesja anulowana" z usuniętymi przyciskami po zakończeniu bieżącego zdjęcia. **Dwa kanały kolejki** — główny (ID: `1437122516974829679`) z pełnym zestawem przycisków moderatora, dodatkowy (ID: `1491801320602992690`) z przyciskiem "🎒 Skanuj ekwipunek". Oba embedy aktualizowane równolegle. Jeden użytkownik może korzystać z OCR na raz w całym serwerze.

--- a/Stalker/handlers/interactionHandlers.js
+++ b/Stalker/handlers/interactionHandlers.js
@@ -439,8 +439,11 @@ async function handlePointsCommand(interaction, config, databaseService, punishm
             await interaction.editReply({ content: `✅ Dodano ${amount} punktów dla ${user}.` });
         } else if (amount < 0) {
             // Usuń punkty
-            await punishmentService.removePointsManually(interaction.guild, user.id, Math.abs(amount));
-            await interaction.editReply({ content: `✅ Usunięto ${Math.abs(amount)} punktów dla ${user}.` });
+            const afterRemoval = await punishmentService.removePointsManually(interaction.guild, user.id, Math.abs(amount));
+            const newPoints = afterRemoval ? afterRemoval.points : 0;
+            const newLifetime = afterRemoval ? (afterRemoval.lifetime_points || 0) : 0;
+            const lifetimeInfo = newLifetime === 0 ? ' (lifetime: 0 ✅)' : ` (lifetime: ${newLifetime})`;
+            await interaction.editReply({ content: `✅ Usunięto ${Math.abs(amount)} punktów dla ${user}. Pozostało: **${newPoints} pkt**${lifetimeInfo}` });
         } else {
             // amount === 0
             const userData = await databaseService.getUserPunishments(interaction.guild.id, user.id);

--- a/Stalker/services/databaseService.js
+++ b/Stalker/services/databaseService.js
@@ -511,8 +511,12 @@ class DatabaseService {
         }
 
         punishments[guildId][userId].points = Math.max(0, punishments[guildId][userId].points - points);
-        // Odejmij także od lifetime_points
-        punishments[guildId][userId].lifetime_points = Math.max(0, punishments[guildId][userId].lifetime_points - points);
+        // Gdy punkty spadają do 0 — zeruj też lifetime_points (czyste konto)
+        if (punishments[guildId][userId].points === 0) {
+            punishments[guildId][userId].lifetime_points = 0;
+        } else {
+            punishments[guildId][userId].lifetime_points = Math.max(0, punishments[guildId][userId].lifetime_points - points);
+        }
 
         punishments[guildId][userId].history.push({
             points: -points,

--- a/Stalker/services/databaseService.js
+++ b/Stalker/services/databaseService.js
@@ -510,11 +510,14 @@ class DatabaseService {
             punishments[guildId][userId].lifetime_points = 0;
         }
 
-        punishments[guildId][userId].points = Math.max(0, punishments[guildId][userId].points - points);
-        // Gdy punkty spadają do 0 — zeruj też lifetime_points (czyste konto)
-        if (punishments[guildId][userId].points === 0) {
+        const oldPoints = punishments[guildId][userId].points;
+        punishments[guildId][userId].points = Math.max(0, oldPoints - points);
+
+        if (oldPoints > 0 && punishments[guildId][userId].points === 0) {
+            // Punkty aktywne spadły do 0 — zeruj też lifetime (czyste konto)
             punishments[guildId][userId].lifetime_points = 0;
         } else {
+            // Points już były 0 lub nadal > 0 — odejmuj proporcjonalnie tylko od lifetime
             punishments[guildId][userId].lifetime_points = Math.max(0, punishments[guildId][userId].lifetime_points - points);
         }
 


### PR DESCRIPTION
## Summary
Enhanced the points removal system to properly handle lifetime points cleanup and improved user feedback when points are removed via the `/points` command.

## Key Changes

- **Points removal logic** (`databaseService.js`):
  - When active points drop to 0 after removal, lifetime points are now also reset to 0 (clean slate)
  - When active points were already 0 or remain above 0, lifetime points are decremented proportionally
  - This prevents users from accumulating lifetime points while having 0 active points

- **Command feedback** (`interactionHandlers.js`):
  - `/points` command now returns detailed information after point removal
  - Shows remaining active points and lifetime points status
  - Displays "lifetime: 0 ✅" when account is fully cleaned, otherwise shows the remaining lifetime value
  - Provides clearer visibility into the punishment state after removal

- **Documentation** (`CLAUDE.md`):
  - Updated points system documentation to reflect the new behavior

## Implementation Details
The logic distinguishes between two scenarios:
1. **Full cleanup**: When points reach 0, lifetime is also zeroed (fresh start)
2. **Partial reduction**: When points remain above 0, only lifetime is decremented by the removal amount

This ensures that the lifetime points counter accurately reflects the user's punishment history while allowing for complete account resets when all active points are removed.

https://claude.ai/code/session_01X9WtNiPXJ9v7i1UAUAAsWH