### PR TITLE
Fix ranking snapshot sync to use UTC day boundaries

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -17,7 +17,7 @@
    - **Globalny:** `getGlobalRanking()` — najlepszy wynik gracza ze wszystkich serwerów (z adnotacją skąd pochodzi)
    - Eksport do `shared_data/endersecho_ranking.json` (globalny, format: `{updatedAt, players: [{rank, userId, username, score, scoreValue, bossName, timestamp, sourceGuildId}]}`)
    - Eksport przy każdym zapisie i przy starcie bota
-   - **Sync do Web API:** Po eksporcie `saveSharedRanking()` wypycha każdego gracza do `/api/bot/endersecho-snapshot` (upsert po `discordId+snapshotDate`). Cicho no-op gdy brak `APP_API_URL`/`BOT_API_KEY`. Zobacz shared `utils/appSync.js`.
+   - **Sync do Web API:** Po eksporcie `saveSharedRanking()` wypycha każdego gracza do `/api/bot/endersecho-snapshot` (upsert po `discordId+snapshotDate`). `snapshotDate` jest przycinany do doby UTC (00:00Z) — restart bota i wielokrotne zapisy w ciągu dnia aktualizują ten sam wiersz zamiast tworzyć duplikaty. Gracze bez prawidłowego `scoreValue` (NaN/undefined) są pomijani, żeby nie generować błędów walidacji 400 (`scoreNumeric: Invalid`). Cicho no-op gdy brak `APP_API_URL`/`BOT_API_KEY`. Zobacz shared `utils/appSync.js`.
    - **Migracja:** Przy pierwszym starcie stary `ranking.json` jest automatycznie migrowany do `ranking_{guild1Id}.json`
 
 3. **Role TOP (opcjonalne)** - `roleService.js`:

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -121,16 +121,23 @@ class RankingService {
             const sharedPath = path.join(sharedDir, 'endersecho_ranking.json');
             await fs.writeFile(sharedPath, JSON.stringify(sharedData, null, 2), 'utf8');
 
-            // Mirror do web API — endpoint upsertowy po (discordId, snapshotDate),
-            // więc bezpiecznie wypychamy całą listę przy każdym eksporcie.
+            // Mirror do web API — endpoint upsertowy po (discordId, snapshotDate).
+            // snapshotDate przycinamy do doby UTC, żeby restart bota i wielokrotne
+            // zapisy w ciągu dnia aktualizowały ten sam wiersz zamiast tworzyć duplikaty.
             // scoreNumeric jako string żeby API mogło sparsować do BigInt
             // (wyniki EE sięgają quintillion+).
+            const now = new Date();
+            const snapshotDate = new Date(Date.UTC(
+                now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()
+            )).toISOString();
             for (const player of players) {
+                const score = Math.floor(Number(player.scoreValue));
+                if (!Number.isFinite(score) || score < 0) continue;
                 appSync.endersEchoSnapshot({
                     discordId: player.userId,
-                    snapshotDate: sharedData.updatedAt,
+                    snapshotDate,
                     rank: player.rank,
-                    scoreNumeric: String(Math.floor(player.scoreValue)),
+                    scoreNumeric: String(score),
                     totalPlayers: players.length,
                 });
             }


### PR DESCRIPTION
## Summary
Improved the ranking snapshot synchronization to Web API by normalizing `snapshotDate` to UTC day boundaries and adding validation for score values. This prevents duplicate records when the bot restarts or exports multiple times within the same day.

## Key Changes
- **Snapshot date normalization:** Changed from using `sharedData.updatedAt` (precise timestamp) to a UTC day boundary (00:00Z). This ensures that multiple exports within the same calendar day update the same database record instead of creating duplicates.
- **Score validation:** Added checks to skip players with invalid `scoreValue` (NaN, undefined, or negative). This prevents API validation errors (400 `scoreNumeric: Invalid`) from being sent to the Web API.
- **Code refactoring:** Extracted score calculation (`Math.floor(Number(player.scoreValue))`) into a variable for reuse and clarity.
- **Documentation update:** Updated `CLAUDE.md` to explain the snapshot date truncation behavior and score validation logic.

## Implementation Details
The snapshot date is now calculated as:
```javascript
const now = new Date();
const snapshotDate = new Date(Date.UTC(
    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()
)).toISOString();
```

This ensures consistent upsert behavior on the API side (keyed by `discordId + snapshotDate`), making the sync idempotent across bot restarts and multiple daily exports.

https://claude.ai/code/session_01RN8uF64XzcUzJrAaEod8hp