### PR TITLE
Handle expired one-time reminders when resuming paused schedules

### DIFF
--- a/Wydarzynier/handlers/przypominienHandlers.js
+++ b/Wydarzynier/handlers/przypominienHandlers.js
@@ -962,8 +962,13 @@ async function handleEditScheduledResume(interaction, sharedState) {
     const scheduledId = interaction.customId.replace('edit_scheduled_resume_', '');
 
     try {
-        await przypomnieniaMenedzer.resumeScheduled(scheduledId);
+        const resumeResult = await przypomnieniaMenedzer.resumeScheduled(scheduledId);
         await tablicaMenedzer.ensureControlPanel();
+
+        if (resumeResult && resumeResult.deleted) {
+            await interaction.update({ content: '⏰ Jednorazowe przypomnienie wygasło podczas wstrzymania i zostało usunięte.', components: [] });
+            return;
+        }
 
         const updated = przypomnieniaMenedzer.getScheduledWithTemplate(scheduledId);
         if (!updated) {
@@ -2426,7 +2431,16 @@ async function handleBoardScheduledResume(interaction, sharedState) {
     const scheduledId = interaction.customId.replace('scheduled_resume_', '');
 
     try {
-        await przypomnieniaMenedzer.resumeScheduled(scheduledId);
+        const resumeResult = await przypomnieniaMenedzer.resumeScheduled(scheduledId);
+
+        if (resumeResult && resumeResult.deleted) {
+            await tablicaMenedzer.ensureControlPanel();
+            await interaction.followUp({
+                content: '⏰ Jednorazowe przypomnienie wygasło podczas wstrzymania i zostało usunięte.',
+                ephemeral: true
+            });
+            return;
+        }
 
         const updated = przypomnieniaMenedzer.getScheduledWithTemplate(scheduledId);
         await tablicaMenedzer.updateEmbed(updated);

--- a/Wydarzynier/services/harmonogram.js
+++ b/Wydarzynier/services/harmonogram.js
@@ -72,6 +72,21 @@ class Harmonogram {
                 }
             }
         }
+
+        // Usuń jednorazowe wstrzymane przypomnienia, których czas wykonania minął
+        const allScheduled = this.przypomnieniaMenedzer.getAllScheduled();
+        for (const sch of allScheduled) {
+            if (sch.status !== 'paused' || sch.isManual) continue;
+            if (sch.interval && !sch.isOneTime) continue;
+            const nextTriggerTime = new Date(sch.nextTrigger);
+            if (now >= nextTriggerTime) {
+                await this.tablicaMenedzer.deleteEmbed(sch);
+                await this.przypomnieniaMenedzer.deleteScheduled(sch.id);
+                await this.przypomnieniaMenedzer.deleteTemplate(sch.templateId);
+                await this.tablicaMenedzer.ensureControlPanel();
+                this.logger.info(`Jednorazowe wstrzymane przypomnienie ${sch.id} wygasło - usunięto`);
+            }
+        }
     }
 
     async triggerScheduled(scheduled) {

--- a/Wydarzynier/services/przypomnieniaMenedzer.js
+++ b/Wydarzynier/services/przypomnieniaMenedzer.js
@@ -368,7 +368,49 @@ class PrzypomnieniaMenedzer {
 
     // Wznów zaplanowane przypomnienie
     async resumeScheduled(id) {
-        return await this.updateScheduled(id, { status: 'active' });
+        const scheduled = this.getScheduled(id);
+        if (!scheduled) return false;
+
+        const now = new Date();
+        const nextTrigger = new Date(scheduled.nextTrigger);
+
+        if (nextTrigger > now) {
+            return await this.updateScheduled(id, { status: 'active' });
+        }
+
+        // nextTrigger minął podczas wstrzymania
+        if (scheduled.isOneTime || !scheduled.interval) {
+            await this.deleteScheduled(id);
+            await this.deleteTemplate(scheduled.templateId);
+            this.logger.info(`Jednorazowe przypomnienie ${id} wygasło podczas wstrzymania - usunięto`);
+            return { deleted: true };
+        }
+
+        // Cykliczne: przesuń nextTrigger do następnej przyszłej daty
+        let current = nextTrigger;
+        let triggerCount = scheduled.triggerCount || 0;
+
+        while (current <= now) {
+            if (scheduled.interval === 'msc') {
+                const originalDay = scheduled.monthlyDay || getWarsawComponents(current).day;
+                current = addOneMonthWarsaw(current, originalDay);
+            } else if (scheduled.interval === 'ee') {
+                const cyclePosition = triggerCount % 9;
+                const intervalMs = cyclePosition === 8
+                    ? 4 * 24 * 60 * 60 * 1000
+                    : 3 * 24 * 60 * 60 * 1000;
+                current = new Date(current.getTime() + intervalMs);
+            } else {
+                current = new Date(current.getTime() + scheduled.intervalMs);
+            }
+            triggerCount++;
+        }
+
+        return await this.updateScheduled(id, {
+            status: 'active',
+            nextTrigger: current.toISOString(),
+            triggerCount
+        });
     }
 
     // Zaktualizuj następne wyzwolenie dla zaplanowanego przypomnienia
@@ -454,7 +496,7 @@ class PrzypomnieniaMenedzer {
         return this.data.scheduled.filter(s => s.status === 'active').length;
     }
 
-    // ==================== WIADOMOŚCI DO USUNIĘCIA (TYP 1 - USTANDARYZOWANE) ====================
+    // ==================== WIADOMOŚCI DO USU_NIĘCIA (TYP 1 - USTANDARYZOWANE) ====================
 
     // Dodaj wiadomość do usunięcia po 23h 50min
     async addMessageToDelete(messageId, channelId) {


### PR DESCRIPTION
## Summary
This PR improves the handling of one-time reminders that expire while paused. When resuming a paused reminder, the system now checks if the scheduled trigger time has passed and handles it appropriately based on reminder type.

## Key Changes

- **Enhanced `resumeScheduled()` method** in `PrzypomnieniaMenedzer`:
  - Added validation to check if reminder exists before resuming
  - Detects when `nextTrigger` has passed during pause period
  - For one-time reminders: automatically deletes expired reminders and their templates
  - For recurring reminders: recalculates `nextTrigger` to the next future occurrence, accounting for special interval types ('msc' for monthly, 'ee' for 9-cycle pattern)
  - Returns a result object indicating if reminder was deleted

- **Updated resume handlers** in `przypominienHandlers.js`:
  - `handleEditScheduledResume()`: Checks resume result and displays appropriate message if reminder was deleted
  - `handleBoardScheduledResume()`: Similar handling with ephemeral follow-up message for deleted reminders

- **Added cleanup in `Harmonogram`**:
  - Periodic check during schedule execution to remove one-time paused reminders that have expired
  - Cleans up associated embeds and templates
  - Logs deletion events for monitoring

## Implementation Details

- Respects special interval calculations for monthly ('msc') and 9-cycle ('ee') patterns when recalculating next trigger
- Maintains `triggerCount` accuracy when advancing recurring reminders
- Provides user feedback when one-time reminders expire during pause
- Prevents orphaned reminder data by cleaning up templates and embeds

https://claude.ai/code/session_018CcVa94ajDB5kWY6Fhngyr