### PR TITLE
Fix race condition in ranking updates with per-guild operation queue

### DIFF
--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -11,6 +11,16 @@ class RankingService {
     constructor(config) {
         this.config = config;
         this.activeRankings = new Map();
+        // Kolejka operacji per-guild — zapobiega race condition przy równoczesnych /update
+        this._writeQueues = new Map();
+    }
+
+    // Serializuje operacje dla danego guildId — następna zaczyna się dopiero gdy poprzednia skończy
+    _enqueue(guildId, fn) {
+        const prev = this._writeQueues.get(guildId) ?? Promise.resolve();
+        const next = prev.then(fn, fn);
+        this._writeQueues.set(guildId, next);
+        return next;
     }
 
     /**
@@ -785,38 +795,41 @@ class RankingService {
      * @param {string|null} bossName
      */
     async updateUserRanking(guildId, userId, userName, bestScore, bossName = null) {
-        if (this.config.ocr.detailedLogging.enabled) {
-            logger.info(`🔍 DEBUG: updateUserRanking - guildId: ${guildId}, userId: ${userId}, bestScore: "${bestScore}"`);
-        }
-
-        const ranking = await this.loadRanking(guildId);
-        const newScoreValue = this.parseScoreValue(bestScore);
-        const currentScore = ranking[userId];
-
-        let isNewRecord = false;
-
-        if (!currentScore) {
-            isNewRecord = true;
-        } else {
-            const currentScoreValue = this.parseScoreValue(currentScore.score);
-            if (newScoreValue > currentScoreValue) {
-                isNewRecord = true;
+        // Całe read-modify-write w kolejce per-guild — eliminuje race condition przy równoczesnych /update
+        return this._enqueue(guildId, async () => {
+            if (this.config.ocr.detailedLogging.enabled) {
+                logger.info(`🔍 DEBUG: updateUserRanking - guildId: ${guildId}, userId: ${userId}, bestScore: "${bestScore}"`);
             }
-        }
 
-        if (isNewRecord) {
-            ranking[userId] = {
-                score: bestScore,
-                username: userName,
-                timestamp: new Date().toISOString(),
-                scoreValue: newScoreValue,
-                userId,
-                bossName: bossName || this.config.messages.unknownBossLabel
-            };
-            await this.saveRanking(guildId, ranking);
-        }
+            const ranking = await this.loadRanking(guildId);
+            const newScoreValue = this.parseScoreValue(bestScore);
+            const currentScore = ranking[userId];
 
-        return { isNewRecord, ranking, currentScore };
+            let isNewRecord = false;
+
+            if (!currentScore) {
+                isNewRecord = true;
+            } else {
+                const currentScoreValue = this.parseScoreValue(currentScore.score);
+                if (newScoreValue > currentScoreValue) {
+                    isNewRecord = true;
+                }
+            }
+
+            if (isNewRecord) {
+                ranking[userId] = {
+                    score: bestScore,
+                    username: userName,
+                    timestamp: new Date().toISOString(),
+                    scoreValue: newScoreValue,
+                    userId,
+                    bossName: bossName || this.config.messages.unknownBossLabel
+                };
+                await this.saveRanking(guildId, ranking);
+            }
+
+            return { isNewRecord, ranking, currentScore };
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR fixes a race condition in the `updateUserRanking` method that could occur when multiple ranking update requests are processed simultaneously for the same guild. The fix implements a per-guild operation queue that serializes read-modify-write operations.

## Key Changes
- Added `_writeQueues` Map to track pending operations per guild ID
- Implemented `_enqueue()` helper method that serializes async operations for a given guild using Promise chaining
- Wrapped the entire `updateUserRanking` logic in the per-guild queue to ensure atomic read-modify-write operations
- This prevents concurrent updates from overwriting each other or reading stale data

## Implementation Details
The solution uses a simple but effective Promise-based queue pattern:
- Each guild maintains its own queue of pending operations
- New operations are chained to the previous promise using `.then(fn, fn)` to ensure they execute sequentially regardless of success/failure
- The queue is stored in the `_writeQueues` Map with the guild ID as the key
- All ranking data loading, modification, and saving now happens atomically within the queue, eliminating the window where concurrent requests could interfere with each other

https://claude.ai/code/session_01Rjhtr4kFy8sbahes2NLBCn