### PR TITLE
Normalize APP_API_URL to handle trailing slashes and /api segment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -683,7 +683,7 @@ async function saveCXResult(userId, score) {
 ```env
 # Production — default target dla wszystkich pushów (hot-path + backfill bez api_url).
 # Ten sam BOT_API_KEY działa dla staging i produkcji, więc osobnych env-ów nie potrzebujemy.
-APP_API_URL=https://api.polski-squad.example   # bez trailing slash
+APP_API_URL=https://api.polski-squad.example   # trailing slash i końcowe /api są strippowane automatycznie
 BOT_API_KEY=<min. 32-znakowy sekret, identyczny z BOT_API_KEY w API>
 ```
 

--- a/utils/appSync.js
+++ b/utils/appSync.js
@@ -16,7 +16,9 @@
  *     callers to pass a deterministic `id`. Use eventId() to generate one.
  *
  * Config:
- *   APP_API_URL — base URL of the web API (trailing slash is stripped automatically).
+ *   APP_API_URL — base URL of the web API. Trailing slash and a trailing `/api`
+ *     segment are stripped automatically, so `https://host`, `https://host/`
+ *     and `https://host/api/` are all equivalent.
  *   BOT_API_KEY — shared secret; must match the API's env var.
  *   When either is missing, all calls silently no-op (keeps dev/test easy).
  *
@@ -47,8 +49,13 @@ async function sleep(ms) {
  * @param {{ apiUrl?: string, apiKey?: string }} [overrides]
  */
 function createAppSync(overrides = {}) {
-    // Strip any accidental trailing slash so URL construction never produces //.
-    const apiUrl = (overrides.apiUrl ?? process.env.APP_API_URL)?.replace(/\/+$/, '') || null;
+    // Normalize base URL: strip trailing slashes and an optional trailing `/api`,
+    // so both `https://host` and `https://host/api/` produce the same final path
+    // (`/api/bot/...`) instead of accidentally doubling `/api/api/bot/...`.
+    const rawUrl = overrides.apiUrl ?? process.env.APP_API_URL;
+    const apiUrl = rawUrl
+        ? rawUrl.replace(/\/+$/, '').replace(/\/api$/, '') || null
+        : null;
     const apiKey = overrides.apiKey ?? process.env.BOT_API_KEY ?? null;
 
     /**


### PR DESCRIPTION
## Summary
Updated URL normalization logic in `createAppSync()` to handle both trailing slashes and an optional trailing `/api` segment, ensuring consistent API endpoint construction regardless of how the base URL is configured.

## Changes
- **Enhanced URL normalization**: Modified `appSync.js` to strip both trailing slashes and a trailing `/api` segment from `APP_API_URL`, preventing accidental duplication of the `/api` path in final endpoint URLs
- **Updated documentation**: Clarified in code comments and `CLAUDE.md` that `https://host`, `https://host/`, and `https://host/api/` are all equivalent configurations

## Implementation Details
The normalization now applies two sequential replacements:
1. Strip all trailing slashes: `/+$/`
2. Strip optional trailing `/api` segment: `/api$/`

This ensures that whether users configure the URL as `https://api.example`, `https://api.example/`, or `https://api.example/api/`, the final constructed paths (e.g., `/api/bot/...`) remain consistent and correct.

https://claude.ai/code/session_01Q3mNsxvad86stqozofQzaq