### PR TITLE
Add /test command for AI OCR image analysis preview

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -11,6 +11,10 @@
        - **KROK 3:** Wyciąga nazwę bossa, wynik (Best) i Total (500 tokenów)
      - **Walidacja score vs Total:** Jeśli odczytany Best > Total → automatyczna korekta
      - Zalety: 100% pewność walidacji, fallback na tradycyjny OCR
+   - **Komenda /test (admin):** Używa `analyzeTestImage()` w `aiOcrService.js`:
+     - **KROK 1:** Porównanie z wzorcem `files/Wzór.jpg` — jeden request z dwoma obrazami (10 tokenów)
+     - **KROK 2:** Ekstrakcja danych (boss + score) — bez sprawdzania Victory, autentyczności i japońskiego (500 tokenów)
+     - Zwraca ephemeral podgląd: boss, score, czy byłby to rekord (read-only, bez zapisu)
 
 2. **Rankingi Multi-Server** - `rankingService.js`:
    - **Per-serwer:** Osobny plik `data/ranking_{guildId}.json` dla każdego serwera
@@ -64,7 +68,7 @@
    - **Anuluj** → czyści sesję
    - Dane między modalem a przyciskami przechowywane w `_infoSessions` Map (RAM, per userId)
 
-**Komendy:** `/update`, `/ranking`, `/remove`, `/ocr-debug`, `/notifications`, `/info`, `/block-ocr`
+**Komendy:** `/update`, `/ranking`, `/remove`, `/ocr-debug`, `/notifications`, `/info`, `/block-ocr`, `/test`
 
 **Struktura danych:**
 ```

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -90,6 +90,15 @@ class InteractionHandler {
                 .setName('block-ocr')
                 .setDescription('Zablokuj / odblokuj komendę /update na wszystkich serwerach (tylko dla wybranych)')
                 .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+
+            new SlashCommandBuilder()
+                .setName('test')
+                .setDescription('Testuje analizę screenshota bez zapisu wyników (tylko dla adminów)')
+                .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+                .addAttachmentOption(option =>
+                    option.setName('obraz')
+                        .setDescription('Screenshot do przetestowania')
+                        .setRequired(true)),
         ];
 
         const rest = new REST().setToken(this.config.token);
@@ -120,6 +129,11 @@ class InteractionHandler {
             }
             if (interaction.commandName === 'block-ocr') {
                 await this.handleBlockOcrCommand(interaction);
+                return;
+            }
+
+            if (interaction.commandName === 'test') {
+                await this.handleTestCommand(interaction);
                 return;
             }
 
@@ -503,6 +517,150 @@ class InteractionHandler {
                 await interaction.editReply(msgs.updateError);
             } catch (replyError) {
                 gl.error(`Błąd podczas wysyłania komunikatu o błędzie: ${replyError.message}`);
+            }
+        }
+    }
+
+    /**
+     * Obsługuje komendę /test — testuje analizę obrazu bez zapisu wyników (tylko admin)
+     * @param {CommandInteraction} interaction
+     */
+    async handleTestCommand(interaction) {
+        const gl = this.logService._gl(interaction.guildId);
+
+        if (!interaction.member.permissions.has('Administrator')) {
+            await interaction.reply({ content: '❌ Tylko administratorzy mogą używać tej komendy.', flags: ['Ephemeral'] });
+            return;
+        }
+
+        if (!this.aiOcrService.enabled) {
+            await interaction.reply({ content: '❌ Komenda `/test` wymaga włączonego AI OCR (`USE_ENDERSECHO_AI_OCR=true`).', flags: ['Ephemeral'] });
+            return;
+        }
+
+        const attachment = interaction.options.getAttachment('obraz');
+
+        const isImage = this.config.images.supportedExtensions.some(ext =>
+            attachment.name.toLowerCase().endsWith(ext)
+        );
+
+        if (!isImage) {
+            await interaction.reply({ content: '❌ Przesłany plik nie jest obrazem. Obsługiwane formaty: PNG, JPG, JPEG, GIF, BMP.', flags: ['Ephemeral'] });
+            return;
+        }
+
+        if (attachment.size > this.config.images.maxSize) {
+            const maxSizeMB = Math.round(this.config.images.maxSize / (1024 * 1024));
+            await interaction.reply({ content: `❌ Plik jest zbyt duży. Maksymalny rozmiar: ${maxSizeMB}MB.`, flags: ['Ephemeral'] });
+            return;
+        }
+
+        await interaction.deferReply({ flags: ['Ephemeral'] });
+        await interaction.editReply({ content: '🔍 Analizuję zdjęcie (tryb testowy)...' });
+
+        let tempImagePath = null;
+
+        try {
+            await fs.mkdir(this.config.ocr.tempDir, { recursive: true });
+
+            tempImagePath = path.join(this.config.ocr.tempDir, `test_${Date.now()}_${attachment.name}`);
+            await downloadFile(attachment.url, tempImagePath);
+
+            gl.info(`[/test] Uruchamiam analizę testową dla ${interaction.user.username}`);
+
+            const aiResult = await this.aiOcrService.analyzeTestImage(tempImagePath, gl);
+
+            if (aiResult.error === 'NOT_SIMILAR') {
+                const embed = new EmbedBuilder()
+                    .setColor(0xFF0000)
+                    .setTitle('🔬 Wynik testu')
+                    .setDescription('❌ **Zdjęcie nie pasuje do wzorca**\n\nAI uznało, że przesłany screenshot nie przedstawia ekranu wyników bossa (różni się od wzorca `Wzór.jpg`).')
+                    .setTimestamp();
+
+                await interaction.editReply({ content: '', embeds: [embed] });
+                return;
+            }
+
+            if (!aiResult.isValidVictory) {
+                const embed = new EmbedBuilder()
+                    .setColor(0xFF8C00)
+                    .setTitle('🔬 Wynik testu')
+                    .setDescription(`❌ **Nie udało się odczytać danych**\n\nZdjęcie zostało rozpoznane jako pasujące do wzorca, ale AI nie mogło wyciągnąć wyników.\n\n**Błąd:** \`${aiResult.error || 'UNKNOWN'}\``)
+                    .setTimestamp();
+
+                await interaction.editReply({ content: '', embeds: [embed] });
+                return;
+            }
+
+            // Odczyt rankingu (tylko do odczytu — bez zapisu)
+            const guildId = interaction.guildId;
+            const userId = interaction.user.id;
+            const userName = interaction.member?.displayName || interaction.user.displayName || interaction.user.username;
+
+            const ranking = await this.rankingService.loadRanking(guildId);
+            const existingEntry = ranking[userId] || null;
+
+            let wouldBeRecord = false;
+            let recordDiff = null;
+
+            if (existingEntry) {
+                const newVal = this.aiOcrService.parseScoreToNumber(aiResult.score);
+                const oldVal = existingEntry.scoreValue ?? this.aiOcrService.parseScoreToNumber(existingEntry.score);
+                if (newVal !== null && oldVal !== null) {
+                    wouldBeRecord = newVal > oldVal;
+                    if (!wouldBeRecord) {
+                        const diffRaw = oldVal - newVal;
+                        const units = [
+                            { label: 'Sx', val: 1e21 }, { label: 'Qi', val: 1e18 },
+                            { label: 'Q', val: 1e15 }, { label: 'T', val: 1e12 },
+                            { label: 'B', val: 1e9  }, { label: 'M', val: 1e6  },
+                            { label: 'K', val: 1e3  }
+                        ];
+                        const unit = units.find(u => diffRaw >= u.val) || { label: '', val: 1 };
+                        recordDiff = `${(diffRaw / unit.val).toFixed(2)}${unit.label}`;
+                    }
+                }
+            } else {
+                wouldBeRecord = true;
+            }
+
+            const statusLine = wouldBeRecord
+                ? '🏆 **Byłby to nowy rekord!**'
+                : `📊 Wynik niższy od obecnego rekordu (różnica: -${recordDiff ?? '?'})`;
+
+            const embed = new EmbedBuilder()
+                .setColor(wouldBeRecord ? 0xFFD700 : 0xFF9900)
+                .setTitle('🔬 Wynik testu (podgląd bez zapisu)')
+                .setDescription(`✅ **Zdjęcie pasuje do wzorca** — dane odczytane poprawnie.\n\n${statusLine}`)
+                .addFields(
+                    { name: '👤 Gracz', value: userName, inline: true },
+                    { name: '🎯 Boss', value: aiResult.bossName || '—', inline: true },
+                    { name: '📈 Odczytany wynik', value: aiResult.score || '—', inline: true },
+                    { name: '📋 Obecny rekord', value: existingEntry ? existingEntry.score : '*(brak wpisu)*', inline: true },
+                    { name: '🔒 Zapis', value: '**Wyłączony** — to tylko podgląd', inline: true }
+                )
+                .setTimestamp()
+                .setFooter({ text: 'Tryb testowy /test — wyniki nie są zapisywane' });
+
+            const safeUserName = userName.replace(/[^a-zA-Z0-9]/g, '_');
+            const fileExtension = attachment.name.split('.').pop() || 'png';
+            const imageAttachment = new AttachmentBuilder(tempImagePath, {
+                name: `test_${safeUserName}_${Date.now()}.${fileExtension}`
+            });
+
+            embed.setImage(`attachment://${imageAttachment.name}`);
+
+            await interaction.editReply({ content: '', embeds: [embed], files: [imageAttachment] });
+            gl.info(`[/test] Zakończono testową analizę dla ${interaction.user.username}: boss="${aiResult.bossName}" score="${aiResult.score}" wouldBeRecord=${wouldBeRecord}`);
+
+        } catch (error) {
+            gl.error(`[/test] Błąd: ${error.message}`);
+            try {
+                await interaction.editReply({ content: `❌ Błąd podczas analizy: \`${error.message}\`` });
+            } catch { /* ignoruj */ }
+        } finally {
+            if (tempImagePath) {
+                await fs.unlink(tempImagePath).catch(() => {});
             }
         }
     }

--- a/EndersEcho/services/aiOcrService.js
+++ b/EndersEcho/services/aiOcrService.js
@@ -287,6 +287,71 @@ Odczytaj nazwę bossa, dokładny wynik (Best) wraz z jednostką, oraz Total i na
         log.warn(`[AI OCR] validateTotal: nie udało się skorygować "${score}"`);
         return score;
     }
+
+    async analyzeTestImage(imagePath, log = logger) {
+        if (!this.enabled) throw new Error('AI OCR nie jest włączony');
+
+        const wzorPath = path.join(__dirname, '../files/Wzór.jpg');
+
+        try {
+            const [uploadedBuffer, wzorBuffer] = await Promise.all([
+                sharp(imagePath).png().toBuffer(),
+                sharp(wzorPath).png().toBuffer()
+            ]);
+
+            const uploadedBase64 = uploadedBuffer.toString('base64');
+            const wzorBase64 = wzorBuffer.toString('base64');
+            const mediaType = 'image/png';
+
+            log.info('[AI Test] Porównuję zdjęcie z wzorcem...');
+            const isSimilar = await this._compareWithTemplate(wzorBase64, uploadedBase64, mediaType, log);
+
+            if (!isSimilar) {
+                log.warn('[AI Test] Zdjęcie niepodobne do wzorca');
+                return { bossName: null, score: null, confidence: 0, isValidVictory: false, error: 'NOT_SIMILAR' };
+            }
+
+            log.info('[AI Test] Zdjęcie podobne do wzorca → wyciągam dane...');
+
+            const extractResponse = await this._extractData(uploadedBase64, mediaType, 'eng');
+            const result = this.parseAIResponse(extractResponse, log);
+
+            if (result.isValidVictory) {
+                log.info(`[AI Test] Boss="${result.bossName}" score="${result.score}"`);
+            } else {
+                log.warn(`[AI Test] Nie udało się wyciągnąć danych: ${result.error}`);
+            }
+
+            return result;
+
+        } catch (error) {
+            log.error(`[AI Test] Błąd analizy obrazu: ${error.message}`);
+            throw error;
+        }
+    }
+
+    async _compareWithTemplate(wzorBase64, uploadedBase64, mediaType, log = logger) {
+        const prompt = `Otrzymujesz dwa screenshoty z gry. Pierwsze zdjęcie to wzorzec — przykład prawidłowego screenshota z ekranem wyników bossa. Drugie zdjęcie to zdjęcie przesłane przez użytkownika.
+
+Sprawdź wyłącznie czy oba zdjęcia przedstawiają ten sam typ ekranu z gry (ekran wyników bossa). Nie oceniaj autentyczności ani prawdziwości wyniku.
+
+Jeśli oba zdjęcia wyglądają jak ekran wyników bossa w tej samej grze — napisz tylko jedno słowo: "OK"
+Jeśli zdjęcia przedstawiają różne typy ekranów lub drugie zdjęcie nie jest ekranem wyników bossa — napisz tylko jedno słowo: "NOK"`;
+
+        const message = await this.client.messages.create({
+            model: this.model,
+            max_tokens: 10,
+            messages: [{ role: 'user', content: [
+                { type: 'image', source: { type: 'base64', media_type: mediaType, data: wzorBase64 } },
+                { type: 'image', source: { type: 'base64', media_type: mediaType, data: uploadedBase64 } },
+                { type: 'text', text: prompt }
+            ]}]
+        });
+
+        const response = message.content[0].text.trim().toUpperCase();
+        log.info(`[AI Test] Odpowiedź porównania: "${response}"`);
+        return !response.includes('NOK');
+    }
 }
 
 module.exports = AIOCRService;

--- a/Muteusz/config/all_commands.json
+++ b/Muteusz/config/all_commands.json
@@ -597,6 +597,12 @@
           "description": "Przełącza szczegółowe logowanie OCR",
           "usage": "/ocr-debug",
           "requiredPermission": "administrator"
+        },
+        {
+          "name": "/test",
+          "description": "Testuje analizę screenshota przez AI — porównuje z wzorcem i wyciąga dane (boss + wynik) bez zapisu. Pokazuje ephemeral podgląd czy byłby to nowy rekord.",
+          "usage": "/test obraz:[screenshot do przetestowania]",
+          "requiredPermission": "administrator"
         }
       ]
     }


### PR DESCRIPTION
## Summary
Added a new `/test` slash command that allows administrators to test AI OCR image analysis without saving results to the ranking database. This provides a preview of how the bot would process a screenshot, including boss name detection, score extraction, and whether it would be a new record.

## Key Changes

- **New `/test` command** in `interactionHandlers.js`:
  - Admin-only command that accepts an image attachment
  - Validates file type (PNG, JPG, JPEG, GIF, BMP) and size
  - Returns ephemeral reply with analysis results
  - Shows boss name, detected score, current record, and record comparison
  - Includes the analyzed image in the response for reference

- **New `analyzeTestImage()` method** in `aiOcrService.js`:
  - Two-step AI analysis process:
    1. Template comparison with `files/Wzór.jpg` (10 tokens) — validates image matches boss result screen format
    2. Data extraction (500 tokens) — extracts boss name and score without victory validation
  - Returns structured result with boss name, score, and error details
  - Includes new `_compareWithTemplate()` helper method for image similarity checking

- **Template comparison logic** (`_compareWithTemplate()`):
  - Sends both template and user image to Claude API
  - Uses minimal prompt to determine if both images show the same type of game screen
  - Returns simple OK/NOK response to minimize token usage

- **Result display**:
  - Shows whether image matches template
  - Displays extracted boss name and score
  - Indicates if result would be a new record with difference calculation
  - Clearly marks as "test mode" with no data saved
  - Includes analyzed image as attachment for verification

- **Documentation updates**:
  - Updated `CLAUDE.md` with `/test` command workflow and token usage
  - Added `/test` to command list in `all_commands.json`

## Implementation Details

- Temporary image files are downloaded and cleaned up after analysis
- Admin permission check performed before processing
- Requires `USE_ENDERSECHO_AI_OCR=true` to be enabled
- Uses ephemeral replies to keep test results private
- Ranking data is read-only (no writes to database)
- Comprehensive error handling with user-friendly messages

https://claude.ai/code/session_012qBHzmqxQAysnmqvaiCpkW