### PR TITLE
Add user blocking system for OCR abuse prevention

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -68,7 +68,14 @@
    - **Anuluj** → czyści sesję
    - Dane między modalem a przyciskami przechowywane w `_infoSessions` Map (RAM, per userId)
 
-**Komendy:** `/update`, `/ranking`, `/remove`, `/ocr-debug`, `/notifications`, `/info`, `/block-ocr`, `/test`
+**Komendy:** `/update`, `/ranking`, `/remove`, `/ocr-debug`, `/notifications`, `/info`, `/block-ocr`, `/test`, `/unblock`
+
+**System blokowania per-użytkownik** — `userBlockService.js` + `data/user_blocks.json`:
+- Raport odrzuconego screena zawiera przyciski **Zatwierdź** i **Zablokuj użytkownika** (widoczne na kanale `ENDERSECHO_INVALID_REPORT_CHANNEL_ID`)
+- **Zablokuj** otwiera modal z polem czasu (np. `1h`, `7d`, `30m` — puste = permanentnie)
+- Zablokowany użytkownik przy próbie `/update` widzi komunikat o blokadzie i konieczności kontaktu z adminem
+- `/unblock` (admin) — lista zablokowanych posortowana od najkrótszej kary do permanentnych, select menu do odblokowania
+- Persistencja przeżywa restart bota
 
 **Struktura danych:**
 ```

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -8,7 +8,7 @@ const logger = createBotLogger('EndersEcho');
 const path = require('path');
 
 class InteractionHandler {
-    constructor(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService) {
+    constructor(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService) {
         this.config = config;
         this.ocrService = ocrService;
         this.aiOcrService = aiOcrService;
@@ -16,6 +16,7 @@ class InteractionHandler {
         this.logService = logService;
         this.roleService = roleService;
         this.notificationService = notificationService;
+        this.userBlockService = userBlockService;
         this.ocrBlockService = new OcrBlockService(config);
         // Tymczasowe sesje dla /info (userId -> { title, description, icon, image })
         this._infoSessions = new Map();
@@ -99,6 +100,11 @@ class InteractionHandler {
                     option.setName('obraz')
                         .setDescription('Screenshot do przetestowania')
                         .setRequired(true)),
+
+            new SlashCommandBuilder()
+                .setName('unblock')
+                .setDescription('Wyświetla zablokowanych użytkowników i umożliwia ich odblokowanie (tylko dla adminów)')
+                .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
         ];
 
         const rest = new REST().setToken(this.config.token);
@@ -137,6 +143,11 @@ class InteractionHandler {
                 return;
             }
 
+            if (interaction.commandName === 'unblock') {
+                await this.handleUnblockCommand(interaction);
+                return;
+            }
+
             if (!this.isAllowedChannel(interaction.channel.id, interaction.guildId)) {
                 await interaction.reply({
                     content: this.msgs(interaction.guildId).channelNotAllowed,
@@ -159,6 +170,11 @@ class InteractionHandler {
         } else if (interaction.isModalSubmit()) {
             if (interaction.customId === 'info_modal') {
                 await this._handleInfoModalSubmit(interaction);
+                return;
+            }
+            if (interaction.customId.startsWith('ee_block_modal_')) {
+                await this._handleBlockUserModal(interaction);
+                return;
             }
         }
     }
@@ -202,6 +218,15 @@ class InteractionHandler {
         const gl = this.logService._gl(interaction.guildId);
 
         const msgs = this.msgs(interaction.guildId);
+
+        if (this.userBlockService.isBlocked(interaction.user.id)) {
+            await interaction.reply({
+                content: '🚫 Twoje konto zostało zablokowane z powodu próby przesłania fałszywego zdjęcia. W celu odblokowania skontaktuj się z administratorem serwera.',
+                flags: ['Ephemeral']
+            });
+            return;
+        }
+
         const attachment = interaction.options.getAttachment('obraz');
 
         const isImage = this.config.images.supportedExtensions.some(ext =>
@@ -717,6 +742,46 @@ class InteractionHandler {
         try {
             const customId = interaction.customId;
 
+            // === Przyciski raportów odrzuconych screenów ===
+            if (customId.startsWith('ee_approve_')) {
+                if (!interaction.member.permissions.has('Administrator')) {
+                    await interaction.reply({ content: '❌ Brak uprawnień.', flags: ['Ephemeral'] });
+                    return;
+                }
+                const adminName = interaction.member?.displayName || interaction.user.username;
+                await interaction.update({
+                    content: `✅ Zatwierdzone przez **${adminName}**`,
+                    embeds: interaction.message.embeds,
+                    components: []
+                });
+                return;
+            }
+
+            if (customId.startsWith('ee_block_')) {
+                if (!interaction.member.permissions.has('Administrator')) {
+                    await interaction.reply({ content: '❌ Brak uprawnień.', flags: ['Ephemeral'] });
+                    return;
+                }
+                const parts = customId.split('_');
+                const targetUserId = parts[2];
+                const targetGuildId = parts[3];
+                const modal = new ModalBuilder()
+                    .setCustomId(`ee_block_modal_${targetUserId}_${targetGuildId}`)
+                    .setTitle('Zablokuj użytkownika')
+                    .addComponents(
+                        new ActionRowBuilder().addComponents(
+                            new TextInputBuilder()
+                                .setCustomId('duration')
+                                .setLabel('Czas blokady (np. 1h, 7d, 30m) — puste = permanentnie')
+                                .setStyle(TextInputStyle.Short)
+                                .setRequired(false)
+                                .setPlaceholder('Zostaw puste dla blokady permanentnej')
+                        )
+                    );
+                await interaction.showModal(modal);
+                return;
+            }
+
             // === Przyciski /info ===
             if (customId === 'info_send') {
                 await this._handleInfoSend(interaction);
@@ -953,9 +1018,28 @@ class InteractionHandler {
      * Obsługuje select menu i inne interakcje z powiadomieniami
      */
     async handleSelectMenuInteraction(interaction) {
-        if (!this.isAllowedChannel(interaction.channel.id, interaction.guildId)) return;
         try {
             const customId = interaction.customId;
+
+            if (customId === 'ee_unblock_select') {
+                if (!interaction.member.permissions.has('Administrator')) {
+                    await interaction.reply({ content: '❌ Brak uprawnień.', flags: ['Ephemeral'] });
+                    return;
+                }
+                const targetUserId = interaction.values[0];
+                const entry = this.userBlockService.getBlockedUsers().find(e => e.userId === targetUserId);
+                const success = await this.userBlockService.unblockUser(targetUserId);
+                const username = entry?.username || targetUserId;
+                await interaction.update({
+                    content: success ? `✅ Odblokowano użytkownika **${username}**.` : '⚠️ Użytkownik nie był zablokowany.',
+                    embeds: [],
+                    components: []
+                });
+                return;
+            }
+
+            if (!this.isAllowedChannel(interaction.channel.id, interaction.guildId)) return;
+
             if (customId === 'notif_server_select') {
                 await this._handleNotifServerSelect(interaction);
             } else if (customId.startsWith('notif_player_select_')) {
@@ -1397,6 +1481,94 @@ class InteractionHandler {
         await interaction.update({ content: 'Anulowano.', embeds: [], components: [] });
     }
 
+    async _handleBlockUserModal(interaction) {
+        const parts = interaction.customId.split('_');
+        const targetUserId = parts[3];
+        const targetGuildId = parts[4];
+        const durationStr = interaction.fields.getTextInputValue('duration').trim();
+
+        let targetGuild;
+        try {
+            targetGuild = await interaction.client.guilds.fetch(targetGuildId);
+        } catch {
+            targetGuild = null;
+        }
+
+        let targetUsername = targetUserId;
+        try {
+            const member = await targetGuild?.members.fetch(targetUserId);
+            targetUsername = member?.displayName || member?.user.username || targetUserId;
+        } catch {
+            try {
+                const user = await interaction.client.users.fetch(targetUserId);
+                targetUsername = user.username;
+            } catch { /* zostaw userId */ }
+        }
+
+        const guildName = targetGuild?.name || targetGuildId;
+
+        const blockedUntil = await this.userBlockService.blockUser(
+            targetUserId, targetUsername, targetGuildId, guildName, durationStr
+        );
+
+        const timeLabel = blockedUntil
+            ? `do <t:${Math.floor(blockedUntil / 1000)}:F>`
+            : '**permanentnie**';
+
+        const adminName = interaction.member?.displayName || interaction.user.username;
+
+        await interaction.update({
+            content: `🔒 Użytkownik **${targetUsername}** zablokowany ${timeLabel} przez **${adminName}**`,
+            embeds: interaction.message.embeds,
+            components: []
+        });
+
+        logger.info(`🔒 Zablokowano ${targetUsername} (${targetUserId}) ${blockedUntil ? `do ${new Date(blockedUntil).toISOString()}` : 'permanentnie'} przez ${adminName}`);
+    }
+
+    async handleUnblockCommand(interaction) {
+        if (!interaction.member.permissions.has('Administrator')) {
+            await interaction.reply({ content: '❌ Tylko administratorzy mogą używać tej komendy.', flags: ['Ephemeral'] });
+            return;
+        }
+
+        const blocked = this.userBlockService.getBlockedUsers();
+
+        if (blocked.length === 0) {
+            await interaction.reply({ content: '✅ Brak zablokowanych użytkowników.', flags: ['Ephemeral'] });
+            return;
+        }
+
+        const options = blocked.slice(0, 25).map(entry => {
+            const timeLabel = this.userBlockService.formatTimeRemaining(entry.blockedUntil);
+            const desc = `${entry.guildName} | Pozostało: ${timeLabel}`;
+            return {
+                label: entry.username.slice(0, 100),
+                description: desc.slice(0, 100),
+                value: entry.userId
+            };
+        });
+
+        const select = new StringSelectMenuBuilder()
+            .setCustomId('ee_unblock_select')
+            .setPlaceholder('Wybierz użytkownika do odblokowania')
+            .addOptions(options);
+
+        const row = new ActionRowBuilder().addComponents(select);
+
+        const embed = new EmbedBuilder()
+            .setColor(0xFF4444)
+            .setTitle('🔒 Zablokowani użytkownicy OCR')
+            .setDescription(blocked.slice(0, 25).map((entry, i) => {
+                const timeLabel = this.userBlockService.formatTimeRemaining(entry.blockedUntil);
+                return `${i + 1}. **${entry.username}** — ${entry.guildName} | \`${timeLabel}\``;
+            }).join('\n'))
+            .setFooter({ text: `Łącznie: ${blocked.length} zablokowanych` })
+            .setTimestamp();
+
+        await interaction.reply({ embeds: [embed], components: [row], flags: ['Ephemeral'] });
+    }
+
     async handleBlockOcrCommand(interaction) {
         const allowedIds = this.config.blockOcrUserIds;
         if (!allowedIds.length || !allowedIds.includes(interaction.user.id)) {
@@ -1502,7 +1674,21 @@ class InteractionHandler {
                 .setImage(`attachment://${fileName}`)
                 .setFooter({ text: `ID użytkownika: ${interaction.user.id}` });
 
-            await channel.send({ embeds: [embed], files: [fileAttachment] });
+            const approveBtn = new ButtonBuilder()
+                .setCustomId(`ee_approve_${interaction.user.id}`)
+                .setLabel('Zatwierdź')
+                .setEmoji('✅')
+                .setStyle(ButtonStyle.Secondary);
+
+            const blockBtn = new ButtonBuilder()
+                .setCustomId(`ee_block_${interaction.user.id}_${interaction.guildId}`)
+                .setLabel('Zablokuj użytkownika')
+                .setEmoji('🔒')
+                .setStyle(ButtonStyle.Danger);
+
+            const reportRow = new ActionRowBuilder().addComponents(approveBtn, blockBtn);
+
+            await channel.send({ embeds: [embed], files: [fileAttachment], components: [reportRow] });
             gl.info(`✅ 📋 Wysłano raport o odrzuconym screenie (${reason}) dla ${serverNick}`);
         } catch (err) {
             gl.warn(`⚠️ Nie można wysłać raportu o odrzuconym screenie: ${err.message}`);

--- a/EndersEcho/index.js
+++ b/EndersEcho/index.js
@@ -7,6 +7,7 @@ const LogService = require('./services/logService');
 const GuildLogger = require('./services/guildLogger');
 const RoleService = require('./services/roleService');
 const NotificationService = require('./services/notificationService');
+const UserBlockService = require('./services/userBlockService');
 const InteractionHandler = require('./handlers/interactionHandlers');
 const { createBotLogger } = require('../utils/consoleLogger');
 
@@ -27,7 +28,8 @@ const guildLogger = new GuildLogger(config);
 const logService = new LogService(config, guildLogger);
 const roleService = new RoleService(config, rankingService);
 const notificationService = new NotificationService(config);
-const interactionHandler = new InteractionHandler(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService);
+const userBlockService = new UserBlockService(config);
+const interactionHandler = new InteractionHandler(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService);
 
 /**
  * Inicjalizuje bota EndersEcho

--- a/EndersEcho/services/userBlockService.js
+++ b/EndersEcho/services/userBlockService.js
@@ -1,0 +1,102 @@
+const fs = require('fs');
+const fsAsync = require('fs').promises;
+const path = require('path');
+const { createBotLogger } = require('../../utils/consoleLogger');
+
+const logger = createBotLogger('EndersEcho');
+
+class UserBlockService {
+    constructor(config) {
+        this.filePath = path.join(config.ranking.dataDir, 'user_blocks.json');
+        this._blocks = {};
+        this._loadSync();
+    }
+
+    _loadSync() {
+        try {
+            const data = fs.readFileSync(this.filePath, 'utf8');
+            this._blocks = JSON.parse(data);
+            const count = Object.keys(this._blocks).length;
+            if (count > 0) {
+                logger.info(`🔒 Załadowano ${count} zablokowanych użytkowników OCR`);
+            }
+        } catch {
+            this._blocks = {};
+        }
+    }
+
+    async _save() {
+        await fsAsync.writeFile(this.filePath, JSON.stringify(this._blocks, null, 2), 'utf8');
+    }
+
+    // Parsuje string czasu: "30m", "2h", "7d", "2w". Puste = permanentny.
+    parseDuration(durationStr) {
+        if (!durationStr || !durationStr.trim()) return null;
+        const match = durationStr.trim().toLowerCase().match(/^(\d+)\s*(m|h|d|w)$/);
+        if (!match) return null;
+        const value = parseInt(match[1]);
+        const multipliers = { m: 60 * 1000, h: 3600 * 1000, d: 86400 * 1000, w: 604800 * 1000 };
+        return Date.now() + value * multipliers[match[2]];
+    }
+
+    isBlocked(userId) {
+        const entry = this._blocks[userId];
+        if (!entry) return false;
+        if (entry.blockedUntil !== null && Date.now() > entry.blockedUntil) {
+            delete this._blocks[userId];
+            this._save().catch(() => {});
+            return false;
+        }
+        return true;
+    }
+
+    async blockUser(userId, username, guildId, guildName, durationStr) {
+        const blockedUntil = this.parseDuration(durationStr);
+        this._blocks[userId] = {
+            userId,
+            username,
+            guildId,
+            guildName,
+            blockedAt: new Date().toISOString(),
+            blockedUntil
+        };
+        await this._save();
+        return blockedUntil;
+    }
+
+    async unblockUser(userId) {
+        if (!this._blocks[userId]) return false;
+        delete this._blocks[userId];
+        await this._save();
+        return true;
+    }
+
+    getBlockedUsers() {
+        const now = Date.now();
+        for (const [userId, entry] of Object.entries(this._blocks)) {
+            if (entry.blockedUntil !== null && now > entry.blockedUntil) {
+                delete this._blocks[userId];
+            }
+        }
+        return Object.values(this._blocks).sort((a, b) => {
+            if (a.blockedUntil === null && b.blockedUntil === null) return 0;
+            if (a.blockedUntil === null) return 1;
+            if (b.blockedUntil === null) return -1;
+            return a.blockedUntil - b.blockedUntil;
+        });
+    }
+
+    formatTimeRemaining(blockedUntil) {
+        if (blockedUntil === null) return '∞ Permanentnie';
+        const remaining = blockedUntil - Date.now();
+        if (remaining <= 0) return 'Wygasła';
+        const days = Math.floor(remaining / 86400000);
+        const hours = Math.floor((remaining % 86400000) / 3600000);
+        const minutes = Math.floor((remaining % 3600000) / 60000);
+        if (days > 0) return `${days}d ${hours}h`;
+        if (hours > 0) return `${hours}h ${minutes}m`;
+        return `${minutes}m`;
+    }
+}
+
+module.exports = UserBlockService;

--- a/Muteusz/config/all_commands.json
+++ b/Muteusz/config/all_commands.json
@@ -603,6 +603,12 @@
           "description": "Testuje analizę screenshota przez AI — porównuje z wzorcem i wyciąga dane (boss + wynik) bez zapisu. Pokazuje ephemeral podgląd czy byłby to nowy rekord.",
           "usage": "/test obraz:[screenshot do przetestowania]",
           "requiredPermission": "administrator"
+        },
+        {
+          "name": "/unblock",
+          "description": "Wyświetla listę zablokowanych użytkowników (posortowaną od najkrótszej kary do permanentnych) i umożliwia ich odblokowanie.",
+          "usage": "/unblock",
+          "requiredPermission": "administrator"
         }
       ]
     }


### PR DESCRIPTION
## Summary
Implements a user blocking system to prevent OCR abuse by allowing administrators to temporarily or permanently block users who submit false screenshots. Blocked users are prevented from using the `/update` command and can only be unblocked by server administrators.

## Key Changes

- **New `UserBlockService`** (`userBlockService.js`):
  - Manages user blocks with persistent JSON storage (`user_blocks.json`)
  - Supports temporary blocks with duration parsing (e.g., `1h`, `7d`, `30m`) or permanent blocks
  - Provides methods to block/unblock users and check block status
  - Auto-expires temporary blocks on access

- **Enhanced Report Flow** in `InteractionHandler`:
  - Added **Approve** and **Block User** buttons to rejected screenshot reports
  - Clicking **Block User** opens a modal for administrators to specify block duration
  - Modal submission (`_handleBlockUserModal`) processes the block with optional expiration time

- **New `/unblock` Command**:
  - Admin-only command displaying all blocked users sorted by remaining time
  - Select menu to choose and unblock users
  - Shows block duration and guild information

- **Block Enforcement**:
  - `/update` command checks if user is blocked before processing
  - Blocked users receive a clear message directing them to contact server administrators
  - Automatic cleanup of expired temporary blocks

- **Documentation Updates**:
  - Updated `CLAUDE.md` with blocking system architecture
  - Added `/unblock` command to `all_commands.json`

## Implementation Details

- Block data persists across bot restarts via JSON file storage
- Temporary blocks automatically expire and are cleaned up on next access
- Duration parsing supports minutes (m), hours (h), days (d), and weeks (w)
- Admin actions (approve/block) are logged with admin name and timestamp
- Select menu limited to 25 most recent blocks for Discord API compliance

https://claude.ai/code/session_012qBHzmqxQAysnmqvaiCpkW