### PR TITLE
Fix Discord interaction timeout in reminder confirmation handler

### DIFF
--- a/Stalker/CLAUDE.md
+++ b/Stalker/CLAUDE.md
@@ -48,6 +48,7 @@
 - Format: `✅ NickName • 14:27` - pokazuje kiedy użytkownik potwierdził (oba przypomnienia w jednym embedzie)
 - Struktura: `tracking.reminders[]` - tablica z obu przypomnieniami (reminderNumber, sentAt, users)
 - Aktualizacja przez usunięcie i ponowne wysłanie embeda (świeża pozycja na dole czatu)
+- **`handleConfirmReminderButton` używa `deferUpdate()` natychmiast** - przed wszystkimi operacjami sieciowymi/I/O, potem `editReply()` / `followUp()`. Zapobiega wygasaniu interakcji Discord (limit 3s) gdy fetch guild lub I/O pliku trwa dłużej.
 
 **Mapowanie Nicków** - System automatycznego mapowania użytkowników po zmianie nicku Discord:
 - `databaseService.js`: Indeks graczy `player_index.json` (userId → latestNick + allNicks)

--- a/Stalker/handlers/interactionHandlers.js
+++ b/Stalker/handlers/interactionHandlers.js
@@ -11372,6 +11372,10 @@ async function handleConfirmReminderButton(interaction, sharedState) {
 
         logger.info(`[CONFIRM_REMINDER] 📝 Parsowanie customId: userId=${userId}, roleId=${roleId}, guildId=${guildId || 'BRAK (stary format)'}`);
 
+        // Odłóż aktualizację natychmiast — operacje sieciowe i I/O poniżej mogą
+        // przekroczyć 3-sekundowy limit odpowiedzi Discord i powodować wygaśnięcie interakcji.
+        await interaction.deferUpdate();
+
         // Pobierz guild
         let guild = interaction.guild; // W kanale guild jest dostępny
 
@@ -11404,7 +11408,7 @@ async function handleConfirmReminderButton(interaction, sharedState) {
 
         if (!guild) {
             logger.error(`[CONFIRM_REMINDER] ❌ Nie znaleziono serwera (guildId: ${guildId || 'BRAK'})`);
-            await interaction.reply({
+            await interaction.followUp({
                 content: '❌ Błąd - nie znaleziono serwera.',
                 flags: MessageFlags.Ephemeral
             });
@@ -11422,19 +11426,10 @@ async function handleConfirmReminderButton(interaction, sharedState) {
 
         // Jeśli już po deadline dzisiaj
         if (polandTime >= deadline) {
-            // Zaktualizuj wiadomość - usuń przycisk i dodaj informację o wygaśnięciu
-            try {
-                await interaction.update({
-                    content: interaction.message.content + '\n\n⏰ **Czas na potwierdzenie minął!**',
-                    components: []
-                });
-            } catch (updateError) {
-                // Jeśli nie można zaktualizować wiadomości, wyślij odpowiedź ephemeral
-                await interaction.reply({
-                    content: `⏰ **Za późno by potwierdzić odbiór!**\n\nPotwierdzenia można wysyłać tylko do godziny **${config.bossDeadline.hour}:${String(config.bossDeadline.minute).padStart(2, '0')}**.\n\nDeadline już minął - potwierdzenie nie zostało zapisane.`,
-                    flags: MessageFlags.Ephemeral
-                });
-            }
+            await interaction.editReply({
+                content: interaction.message.content + '\n\n⏰ **Czas na potwierdzenie minął!**',
+                components: []
+            });
             logger.info(`⏰ ${interaction.user.tag} próbował potwierdzić po deadline (${polandTime.toLocaleTimeString('pl-PL')})`);
             return;
         }
@@ -11482,19 +11477,10 @@ async function handleConfirmReminderButton(interaction, sharedState) {
 
         // Sprawdź czy użytkownik już potwierdził w tej sesji
         if (confirmations.sessions[sessionKey]?.confirmedUsers?.includes(userId)) {
-            // Zaktualizuj wiadomość - usuń przycisk jeśli jeszcze istnieje
-            try {
-                await interaction.update({
-                    content: interaction.message.content + '\n\n✅ **Odbiór już został potwierdzony!**',
-                    components: []
-                });
-            } catch (updateError) {
-                // Jeśli nie można zaktualizować wiadomości, wyślij odpowiedź ephemeral
-                await interaction.reply({
-                    content: '✅ Już potwierdziłeś odbiór tego przypomnienia!',
-                    flags: MessageFlags.Ephemeral
-                });
-            }
+            await interaction.editReply({
+                content: interaction.message.content + '\n\n✅ **Odbiór już został potwierdzony!**',
+                components: []
+            });
             logger.info(`⚠️ ${interaction.user.tag} próbował potwierdzić ponownie (już potwierdził)`);
             return;
         }
@@ -11504,7 +11490,7 @@ async function handleConfirmReminderButton(interaction, sharedState) {
 
         if (!confirmationChannelId) {
             logger.error(`❌ Brak kanału potwierdzenia dla roli: ${roleId}`);
-            await interaction.reply({
+            await interaction.followUp({
                 content: '❌ Błąd konfiguracji - brak kanału potwierdzenia.',
                 flags: MessageFlags.Ephemeral
             });
@@ -11516,7 +11502,7 @@ async function handleConfirmReminderButton(interaction, sharedState) {
 
         if (!confirmationChannel) {
             logger.error(`❌ Nie znaleziono kanału potwierdzenia: ${confirmationChannelId}`);
-            await interaction.reply({
+            await interaction.followUp({
                 content: '❌ Błąd - nie znaleziono kanału potwierdzenia.',
                 flags: MessageFlags.Ephemeral
             });
@@ -11592,7 +11578,7 @@ async function handleConfirmReminderButton(interaction, sharedState) {
         }
 
         // Zaktualizuj wiadomość DM - usuń przycisk i pokaż potwierdzenie
-        await interaction.update({
+        await interaction.editReply({
             content: interaction.message.content + '\n\n✅ **Odbiór potwierdzony!**',
             components: []
         });
@@ -11602,17 +11588,10 @@ async function handleConfirmReminderButton(interaction, sharedState) {
     } catch (error) {
         logger.error('[CONFIRM_REMINDER] ❌ Błąd obsługi potwierdzenia:', error);
         try {
-            if (interaction.replied || interaction.deferred) {
-                await interaction.followUp({
-                    content: '❌ Wystąpił błąd podczas potwierdzania odbioru.',
-                    flags: MessageFlags.Ephemeral
-                });
-            } else {
-                await interaction.reply({
-                    content: '❌ Wystąpił błąd podczas potwierdzania odbioru.',
-                    flags: MessageFlags.Ephemeral
-                });
-            }
+            await interaction.followUp({
+                content: '❌ Wystąpił błąd podczas potwierdzania odbioru.',
+                flags: MessageFlags.Ephemeral
+            });
         } catch (replyError) {
             logger.error('[CONFIRM_REMINDER] ❌ Nie udało się wysłać odpowiedzi:', replyError);
         }


### PR DESCRIPTION
## Summary
Fixed a critical issue in the reminder confirmation button handler where network operations and file I/O could exceed Discord's 3-second interaction response timeout, causing interactions to expire.

## Key Changes
- **Added `deferUpdate()` call** at the start of `handleConfirmReminderButton()` to immediately acknowledge the interaction before performing any long-running operations
- **Replaced `interaction.update()` with `interaction.editReply()`** for all message updates after deferral (3 occurrences):
  - When confirmation deadline has passed
  - When user has already confirmed in current session
  - When confirmation is successfully recorded
- **Replaced `interaction.reply()` with `interaction.followUp()`** for error responses (3 occurrences):
  - Guild not found error
  - Confirmation channel not configured error
  - Confirmation channel not found error
- **Simplified error handling** in the catch block by removing the `interaction.replied || interaction.deferred` check (now always deferred, so always use `followUp()`)
- **Updated documentation** in CLAUDE.md to explain the deferral pattern

## Implementation Details
The fix follows Discord.js best practices for handling interactions that may take longer than 3 seconds:
1. `deferUpdate()` is called immediately to acknowledge the button click
2. All subsequent operations use `editReply()` (for deferred updates) or `followUp()` (for additional messages)
3. This prevents "interaction failed" errors when guild fetching or file I/O operations exceed the timeout window

https://claude.ai/code/session_01E7Md1JU9UGs84eioZa2mc3