### PR TITLE
Implement mutex-based role updates with diff-based reconciliation

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -63,7 +63,10 @@
 3. **Role TOP (opcjonalne)** - `roleService.js`:
    - 5 poziomów (top1, top2, top3, top4-10, top11-30), auto-update
    - Role są **opcjonalne per serwer** — jeśli serwer nie ma skonfigurowanych ról, bot je pomija
-   - `updateTopRoles(guild, sortedPlayers, guildTopRoles)` — przyjmuje konfigurację ról danego serwera
+   - `updateTopRoles(guild, _sortedPlayers, guildTopRoles)` — zawsze pobiera świeże dane z rankingu (parametr `sortedPlayers` ignorowany)
+   - **Mutex per-guild** (`_locks` Map): jeśli aktualizacja dla danego serwera jest już w toku, kolejna zostaje oznaczona jako `hasPending`; po zakończeniu bieżącej uruchamiana jest automatycznie z najświeższym rankingiem (via `setImmediate`). Wyklucza race condition przy równoczesnych rekordach.
+   - **Diff-based update**: zamiast resetować wszystkie role i przyznawać od nowa, oblicza różnicę między aktualnym stanem (z Discord cache `role.members`) a pożądanym (z rankingu). Tylko faktyczne zmiany trafiają do API. Jeśli gracz nie zmienił pozycji, zero API calls.
+   - **Równoległe operacje**: usunięcia i dodania wykonywane przez `Promise.allSettled` — szybsze niż sekwencyjne `await`. Batch fetch wszystkich memberów wymagających roli naraz (`guild.members.fetch({ user: [...] })`).
    - **Ogłoszenie rekordu** (`rankingService.createRecordEmbed`):
      - Kolor embeda wg pozycji: 🥇 złoty (TOP1), 🥈 srebrny (TOP2), 🥉 brązowy (TOP3), niebieski (TOP4-10), zielony (TOP11+)
      - Tytuł: `🏆 GRATULACJE!` + opis z headerem markdown

--- a/EndersEcho/services/roleService.js
+++ b/EndersEcho/services/roleService.js
@@ -6,120 +6,181 @@ class RoleService {
     constructor(config, rankingService) {
         this.config = config;
         this.rankingService = rankingService;
+        // Per-guild mutex: zapobiega równoległym aktualizacjom ról dla tego samego serwera.
+        // Jeśli aktualizacja jest w toku i przyjdzie kolejna, ustawia hasPending=true,
+        // dzięki czemu po zakończeniu bieżącej zostanie uruchomiona ponowna z najświeższym rankingiem.
+        this._locks = new Map();
     }
 
     /**
      * Aktualizuje role TOP na podstawie aktualnego rankingu serwera.
      * Jeśli guildTopRoles jest null (brak konfiguracji ról), metoda nie robi nic.
+     * Wywołania nakładające się na siebie są kolejkowane (pending), nie gubione.
      * @param {Guild} guild - Serwer Discord
-     * @param {Array} sortedPlayers - Posortowani gracze
+     * @param {Array|null} _sortedPlayers - Nieużywane — metoda zawsze pobiera świeże dane
      * @param {Object|null} guildTopRoles - Konfiguracja ról dla tego serwera (lub null)
      */
-    async updateTopRoles(guild, sortedPlayers, guildTopRoles = null) {
-        // Jeśli serwer nie ma skonfigurowanych ról TOP — pomijamy
+    async updateTopRoles(guild, _sortedPlayers, guildTopRoles = null) {
         if (!guildTopRoles || Object.keys(guildTopRoles).length === 0) {
             logger.info(`ℹ️ Serwer ${guild.name} nie ma skonfigurowanych ról TOP — pomijam aktualizację`);
             return true;
         }
 
-        try {
-            const top1Role = guildTopRoles.top1 ? guild.roles.cache.get(guildTopRoles.top1) : null;
-            const top2Role = guildTopRoles.top2 ? guild.roles.cache.get(guildTopRoles.top2) : null;
-            const top3Role = guildTopRoles.top3 ? guild.roles.cache.get(guildTopRoles.top3) : null;
-            const top4to10Role = guildTopRoles.top4to10 ? guild.roles.cache.get(guildTopRoles.top4to10) : null;
-            const top11to30Role = guildTopRoles.top11to30 ? guild.roles.cache.get(guildTopRoles.top11to30) : null;
+        const guildId = guild.id;
+        let lock = this._locks.get(guildId);
+        if (!lock) {
+            lock = { running: false, hasPending: false, pendingGuild: null, pendingTopRoles: null };
+            this._locks.set(guildId, lock);
+        }
 
-            // Zbierz tylko role, które faktycznie istnieją na serwerze
-            const allTopRoles = [top1Role, top2Role, top3Role, top4to10Role, top11to30Role].filter(Boolean);
-
-            if (allTopRoles.length === 0) {
-                logger.warn(`⚠️ Żadna skonfigurowana rola TOP nie istnieje na serwerze ${guild.name}`);
-                return false;
-            }
-
-            const playerIds = new Set(sortedPlayers.map(player => player.userId));
-            let playersRemovedFromRanking = false;
-
-            // Usuń role TOP od graczy którzy zniknęli z rankingu
-            for (const role of allTopRoles) {
-                const membersWithRole = role.members;
-                for (const [memberId, member] of membersWithRole) {
-                    if (!playerIds.has(memberId)) {
-                        try {
-                            await member.roles.remove(role);
-                            logger.info(`🗑️ Usunięto rolę ${role.name} od ${member.user.tag} (zniknął z rankingu)`);
-                        } catch (error) {
-                            logger.error(`Błąd usuwania roli ${role.name} od ${member.user.tag}:`, error.message);
-                        }
-                    }
-                }
-            }
-
-            // Reset ról graczy w rankingu
-            for (const role of allTopRoles) {
-                const membersWithRole = role.members;
-                for (const [memberId, member] of membersWithRole) {
-                    if (playerIds.has(memberId)) {
-                        try {
-                            await member.roles.remove(role);
-                        } catch (error) {
-                            logger.error(`Błąd resetowania roli ${role.name} od ${member.user.tag}:`, error.message);
-                        }
-                    }
-                }
-            }
-
-            // Przyznaj nowe role na podstawie pozycji
-            for (let i = 0; i < sortedPlayers.length; i++) {
-                const player = sortedPlayers[i];
-                const position = i + 1;
-                let targetRole = null;
-
-                if (position === 1) targetRole = top1Role;
-                else if (position === 2) targetRole = top2Role;
-                else if (position === 3) targetRole = top3Role;
-                else if (position >= 4 && position <= 10) targetRole = top4to10Role;
-                else if (position >= 11 && position <= 30) targetRole = top11to30Role;
-
-                if (targetRole) {
-                    try {
-                        const member = await guild.members.fetch(player.userId);
-                        if (member) {
-                            await member.roles.add(targetRole);
-                        }
-                    } catch (error) {
-                        logger.error(`Błąd przyznawania roli ${targetRole.name} użytkownikowi ${player.userName || `ID:${player.userId}`}:`, error.message);
-
-                        if (error.code === 10007 || error.message.includes('Unknown Member') || error.message.includes('Unknown User')) {
-                            logger.warn(`⚠️ Użytkownik ${player.userName || `ID:${player.userId}`} nie jest na serwerze — usuwam z rankingu`);
-
-                            if (this.rankingService) {
-                                try {
-                                    await this.rankingService.removePlayerFromRanking(player.userId, guild.id);
-                                    logger.success(`✅ Usunięto użytkownika ${player.userName || `ID:${player.userId}`} z rankingu`);
-                                    playersRemovedFromRanking = true;
-                                } catch (removeError) {
-                                    logger.error(`❌ Błąd podczas usuwania użytkownika z rankingu:`, removeError.message);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Przeładuj jeśli ktoś został usunięty z rankingu
-            if (playersRemovedFromRanking && this.rankingService) {
-                logger.info('🔄 Przeładowywanie rankingu po usunięciu nieaktywnych użytkowników');
-                const updatedPlayers = await this.rankingService.getSortedPlayers(guild.id);
-                return await this.updateTopRoles(guild, updatedPlayers, guildTopRoles);
-            }
-
-            logger.info('✅ Aktualizacja ról TOP zakończona pomyślnie');
+        if (lock.running) {
+            lock.hasPending = true;
+            lock.pendingGuild = guild;
+            lock.pendingTopRoles = guildTopRoles;
+            logger.info(`⏳ Aktualizacja ról TOP dla ${guild.name} już w toku — zaplanowano ponowną po zakończeniu`);
             return true;
+        }
 
+        lock.running = true;
+        lock.hasPending = false;
+
+        try {
+            const players = await this.rankingService.getSortedPlayers(guildId);
+            await this._applyRoleDiff(guild, players, guildTopRoles);
         } catch (error) {
             logger.error('❌ Błąd podczas aktualizacji ról TOP:', error);
             return false;
+        } finally {
+            lock.running = false;
+            if (lock.hasPending) {
+                const pendingGuild = lock.pendingGuild;
+                const pendingTopRoles = lock.pendingTopRoles;
+                lock.hasPending = false;
+                lock.pendingGuild = null;
+                lock.pendingTopRoles = null;
+                setImmediate(() => this.updateTopRoles(pendingGuild, null, pendingTopRoles));
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Oblicza diff między aktualnym a pożądanym stanem ról i wykonuje tylko niezbędne zmiany.
+     * Zamiast resetować wszystkie role i przyznawać od nowa, zmienia tylko to co faktycznie się różni.
+     * Operacje usuwania i dodawania wykonywane są równolegle (Promise.allSettled).
+     */
+    async _applyRoleDiff(guild, sortedPlayers, guildTopRoles) {
+        const roleMap = {
+            top1:     guildTopRoles.top1     ? guild.roles.cache.get(guildTopRoles.top1)     : null,
+            top2:     guildTopRoles.top2     ? guild.roles.cache.get(guildTopRoles.top2)     : null,
+            top3:     guildTopRoles.top3     ? guild.roles.cache.get(guildTopRoles.top3)     : null,
+            top4to10: guildTopRoles.top4to10 ? guild.roles.cache.get(guildTopRoles.top4to10) : null,
+            top11to30:guildTopRoles.top11to30? guild.roles.cache.get(guildTopRoles.top11to30): null,
+        };
+
+        const allTopRoles = Object.values(roleMap).filter(Boolean);
+        if (allTopRoles.length === 0) {
+            logger.warn(`⚠️ Żadna skonfigurowana rola TOP nie istnieje na serwerze ${guild.name}`);
+            return;
+        }
+
+        // Pożądany stan: userId -> role (null = brak roli TOP)
+        const desired = new Map();
+        for (let i = 0; i < sortedPlayers.length; i++) {
+            const pos = i + 1;
+            let role = null;
+            if (pos === 1)                    role = roleMap.top1;
+            else if (pos === 2)               role = roleMap.top2;
+            else if (pos === 3)               role = roleMap.top3;
+            else if (pos >= 4 && pos <= 10)   role = roleMap.top4to10;
+            else if (pos >= 11 && pos <= 30)  role = roleMap.top11to30;
+            desired.set(sortedPlayers[i].userId, role);
+        }
+
+        // Aktualny stan z cache Discorda: userId -> role
+        const current = new Map();
+        for (const role of allTopRoles) {
+            for (const [memberId] of role.members) {
+                current.set(memberId, role);
+            }
+        }
+
+        // Diff: co usunąć, co dodać
+        const toRemove = []; // { member, role }
+        const toAdd = [];    // { userId, role }
+
+        for (const [memberId, currentRole] of current) {
+            const desiredRole = desired.get(memberId) ?? null;
+            if (desiredRole !== currentRole) {
+                toRemove.push({ member: currentRole.members.get(memberId), role: currentRole });
+            }
+        }
+
+        for (const [userId, desiredRole] of desired) {
+            if (!desiredRole) continue;
+            if (current.get(userId) !== desiredRole) {
+                toAdd.push({ userId, role: desiredRole });
+            }
+        }
+
+        if (toRemove.length === 0 && toAdd.length === 0) {
+            logger.info('✅ Role TOP bez zmian');
+            return;
+        }
+
+        // Usunięcia równolegle
+        if (toRemove.length > 0) {
+            await Promise.allSettled(
+                toRemove.map(({ member, role }) =>
+                    member.roles.remove(role).catch(err =>
+                        logger.error(`Błąd usuwania roli ${role.name} od ${member.user.tag}:`, err.message)
+                    )
+                )
+            );
+        }
+
+        // Dodania — batch fetch + równolegle
+        const removedFromRanking = [];
+        if (toAdd.length > 0) {
+            const ids = toAdd.map(({ userId }) => userId);
+            let members = new Map();
+            try {
+                members = await guild.members.fetch({ user: ids });
+            } catch (err) {
+                logger.error('Błąd batch fetch members:', err.message);
+            }
+
+            await Promise.allSettled(
+                toAdd.map(async ({ userId, role }) => {
+                    const member = members.get(userId);
+                    if (!member) {
+                        logger.warn(`⚠️ ${userId} nie jest na serwerze — usuwam z rankingu`);
+                        if (this.rankingService) {
+                            await this.rankingService.removePlayerFromRanking(userId, guild.id).catch(e =>
+                                logger.error(`Błąd usuwania z rankingu:`, e.message)
+                            );
+                            removedFromRanking.push(userId);
+                        }
+                        return;
+                    }
+                    await member.roles.add(role).catch(err =>
+                        logger.error(`Błąd przyznawania roli ${role.name} użytkownikowi ${member.user.tag}:`, err.message)
+                    );
+                })
+            );
+        }
+
+        logger.info(`✅ Role TOP zaktualizowane — usunięto: ${toRemove.length}, dodano: ${toAdd.length}`);
+
+        // Jeśli usunięto kogoś z rankingu, zaplanuj ponowny diff z odświeżonymi danymi
+        if (removedFromRanking.length > 0) {
+            const lock = this._locks.get(guild.id);
+            if (lock && !lock.hasPending) {
+                lock.hasPending = true;
+                lock.pendingGuild = guild;
+                lock.pendingTopRoles = guildTopRoles;
+            }
         }
     }
 
@@ -135,10 +196,10 @@ class RoleService {
             const toArr = (role) => role ? Array.from(role.members.values()) : [];
 
             return {
-                top1: toArr(get('top1')),
-                top2: toArr(get('top2')),
-                top3: toArr(get('top3')),
-                top4to10: toArr(get('top4to10')),
+                top1:      toArr(get('top1')),
+                top2:      toArr(get('top2')),
+                top3:      toArr(get('top3')),
+                top4to10:  toArr(get('top4to10')),
                 top11to30: toArr(get('top11to30'))
             };
         } catch (error) {


### PR DESCRIPTION
## Summary
Refactored the role update system in `RoleService` to prevent race conditions and improve efficiency. The service now uses per-guild mutexes to serialize role updates and implements a diff-based approach that only applies necessary changes instead of resetting and reapplying all roles.

## Key Changes

- **Per-guild mutex locking** (`_locks` Map): Prevents concurrent role updates for the same server. When an update is already running and another is requested, it's marked as pending and automatically re-executed with fresh ranking data after the current update completes.

- **Diff-based role reconciliation** (new `_applyRoleDiff` method): Instead of removing all roles and reapplying them, the system now:
  - Computes the desired role state based on current rankings
  - Compares against the actual state from Discord's role member cache
  - Only executes necessary add/remove operations
  - Performs removals and additions in parallel using `Promise.allSettled`

- **Batch member fetching**: When adding roles, fetches all required members in a single batch operation rather than individually, improving performance.

- **Fresh data on every call**: The `updateTopRoles` method now always fetches the latest ranking data via `rankingService.getSortedPlayers()` rather than relying on passed-in parameters, ensuring consistency.

- **Automatic re-sync on ranking changes**: If users are removed from the ranking during role assignment (e.g., they left the server), the system automatically schedules a re-sync with updated data.

## Implementation Details

- The mutex uses a lock object tracking `running`, `hasPending`, and pending guild/config state
- Pending updates are scheduled via `setImmediate` to avoid blocking
- All role operations are wrapped in `Promise.allSettled` to handle partial failures gracefully
- Improved logging shows the number of roles added/removed in each update
- Code formatting improvements for readability (aligned object properties)

https://claude.ai/code/session_01FWEpXvL5rmNANie6CWBvgu