### PR TITLE
Adjust reminder time windows and add final hour catch-up logic

### DIFF
--- a/Stalker/services/reminderUsageService.js
+++ b/Stalker/services/reminderUsageService.js
@@ -139,8 +139,9 @@ class ReminderUsageService {
 
         // Logika limitów:
         // - Więcej niż 6h (>360 min) - za wcześnie, blokada
-        // - Między 1h a 6h (60-360 min) - można wysłać PIERWSZE przypomnienie (ostatnie 6h)
-        // - Mniej niż 1h (0-60 min) - można wysłać DRUGIE przypomnienie (ostatnia 1h)
+        // - Między 2h a 6h (120-360 min) - można wysłać PIERWSZE przypomnienie
+        // - Między 1h a 2h (60-120 min) - można wysłać DRUGIE przypomnienie
+        // - Mniej niż 1h (0-60 min) - tylko catch-up dla pierwszego, drugie zablokowane
         // - Po deadline (<0 min) - blokada
 
         if (minutesToDeadline < 0) {
@@ -169,12 +170,12 @@ class ReminderUsageService {
             };
         }
 
-        if (minutesToDeadline >= 60 && minutesToDeadline < 360) {
-            // Między 1h a 6h - można wysłać PIERWSZE przypomnienie
+        if (minutesToDeadline >= 120 && minutesToDeadline < 360) {
+            // Między 2h a 6h - można wysłać PIERWSZE przypomnienie
             if (usageCount === 0) {
                 return {
                     canSend: true,
-                    reason: '✅ Pierwsze przypomnienie (ostatnie 6h przed deadline)',
+                    reason: '✅ Pierwsze przypomnienie (6h-2h przed deadline)',
                     minutesToDeadline,
                     reminderNumber: 1
                 };
@@ -184,7 +185,7 @@ class ReminderUsageService {
                 const senderMention = firstUsage.sentBy ? ` przez <@${firstUsage.sentBy}>` : '';
                 return {
                     canSend: false,
-                    reason: `✅ Pierwsze przypomnienie już wysłane o **${new Date(firstUsage.timestamp).toLocaleTimeString('pl-PL', { timeZone: this.config.timezone })}**${senderMention}.\n\nDrugie przypomnienie klan może wysłać w **ostatniej godzinie** przed deadline (16:50-17:50).`,
+                    reason: `✅ Pierwsze przypomnienie już wysłane o **${new Date(firstUsage.timestamp).toLocaleTimeString('pl-PL', { timeZone: this.config.timezone })}**${senderMention}.\n\nDrugie przypomnienie klan może wysłać w **oknie 1h-2h przed deadline** (15:50-16:50).`,
                     minutesToDeadline
                 };
             } else {
@@ -204,8 +205,41 @@ class ReminderUsageService {
             }
         }
 
+        if (minutesToDeadline >= 60 && minutesToDeadline < 120) {
+            // Między 1h a 2h - można wysłać DRUGIE przypomnienie
+            if (usageCount === 0) {
+                return {
+                    canSend: true,
+                    reason: '✅ Pierwsze przypomnienie (okno 1h-2h przed deadline)',
+                    minutesToDeadline,
+                    reminderNumber: 1
+                };
+            } else if (usageCount === 1) {
+                return {
+                    canSend: true,
+                    reason: '✅ Drugie przypomnienie (okno 1h-2h przed deadline)',
+                    minutesToDeadline,
+                    reminderNumber: 2
+                };
+            } else {
+                // Już wysłano oba przypomnienia
+                const firstUsage = todayUsage[0];
+                const secondUsage = todayUsage[1];
+                const sender1 = firstUsage.sentBy ? ` - <@${firstUsage.sentBy}>` : '';
+                const sender2 = secondUsage.sentBy ? ` - <@${secondUsage.sentBy}>` : '';
+                return {
+                    canSend: false,
+                    reason: `❌ Klan wykorzystał już oba dzienne przypomnienia:\n\n` +
+                           `**1.** ${new Date(firstUsage.timestamp).toLocaleTimeString('pl-PL', { timeZone: this.config.timezone })}${sender1} (${firstUsage.minutesToDeadline} min do deadline)\n` +
+                           `**2.** ${new Date(secondUsage.timestamp).toLocaleTimeString('pl-PL', { timeZone: this.config.timezone })}${sender2} (${secondUsage.minutesToDeadline} min do deadline)\n\n` +
+                           `Każdy klan może użyć komendy /remind maksymalnie **2 razy dziennie**.`,
+                    minutesToDeadline
+                };
+            }
+        }
+
         if (minutesToDeadline >= 0 && minutesToDeadline < 60) {
-            // Mniej niż 1h - można wysłać DRUGIE przypomnienie
+            // Ostatnia godzina - catch-up dla pierwszego, drugie zablokowane (okno 15:50-16:50 minęło)
             if (usageCount === 0) {
                 return {
                     canSend: true,
@@ -214,11 +248,12 @@ class ReminderUsageService {
                     reminderNumber: 1
                 };
             } else if (usageCount === 1) {
+                const firstUsage = todayUsage[0];
+                const senderMention = firstUsage.sentBy ? ` przez <@${firstUsage.sentBy}>` : '';
                 return {
-                    canSend: true,
-                    reason: '✅ Drugie przypomnienie (ostatnia godzina przed deadline)',
-                    minutesToDeadline,
-                    reminderNumber: 2
+                    canSend: false,
+                    reason: `✅ Pierwsze przypomnienie już wysłane o **${new Date(firstUsage.timestamp).toLocaleTimeString('pl-PL', { timeZone: this.config.timezone })}**${senderMention}.\n\n❌ Okno na drugie przypomnienie (15:50-16:50) już minęło.`,
+                    minutesToDeadline
                 };
             } else {
                 // Już wysłano oba przypomnienia


### PR DESCRIPTION
## Summary
Refactored the reminder usage service to implement a more granular time-window system for sending reminders before the deadline. The changes introduce a new catch-up mechanism in the final hour and adjust the time windows for first and second reminders.

## Key Changes
- **First reminder window**: Adjusted from 1h-6h (60-360 min) to 2h-6h (120-360 min) before deadline
- **Second reminder window**: Moved to 1h-2h (60-120 min) before deadline, replacing the previous final-hour slot
- **Final hour catch-up**: Added new logic for the 0-60 minute window that:
  - Allows first reminder if not yet sent (catch-up mechanism)
  - Blocks second reminder if the 1h-2h window has already passed
  - Prevents any reminders if both have already been used
- **Updated user messaging**: All reminder reason messages now reflect the new time windows and clarify when each reminder window is available

## Implementation Details
- Reorganized conditional blocks to handle the new 0-60 minute window separately with dedicated logic
- Maintained backward compatibility with existing usage tracking
- Enhanced user feedback to clearly indicate when reminder windows have closed
- All timezone handling and sender mention formatting preserved

https://claude.ai/code/session_012ZzfjWV6avRTwjDaa3BUEy