### PR TITLE
Refactor logging: consolidate OCR debug logs and improve user display names

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -315,7 +315,10 @@ Rzetelne porównania: [Langfuse Datasets](https://langfuse.com/docs/datasets/get
 - **Logger (ogólny):** `createBotLogger('EndersEcho')` — tylko konsola + plik; jeśli ustawiony `ENDERSECHO_LOG_WEBHOOK_URL`, EndersEcho jest **pomijany** w głównym webhooku botów
 - **Logger (per-serwer):** `logService._gl(guildId).info(msg)` lub przez metody `logService.logCommandUsage/logScoreUpdate/logOCRError/logRankingError(... , guildId)` — trafia do dedykowanego webhooka z avatarem serwera i separatorem
 - **GuildLogger:** `services/guildLogger.js` — zarządza kolejką webhooka, avatarem (ICON) i separatorem przy zmianie serwera
-- **OCR Debug:** Brak komendy — logowanie OCR jest wyłączone
+- **Nick w logach:** Zawsze używaj `interaction.member?.displayName || interaction.user.displayName || interaction.user.username` — nigdy samego `interaction.user.username`
+- **Logi /update (8 linii happy path):** start → `[AI Test] Test wzorca: "OK"` → AI OCR wynik+boss+total → logScoreUpdate → ogłoszenie → Role TOP → Global Top 3
+- **Logi /update (odrzucenie, 3 linie):** start → `[AI Test] Test wzorca: "NOK: reason"` → `❌ Odrzucono: NOT_SIMILAR/FAKE_PHOTO/...`
+- **OCR Debug:** Brak komendy — logi pośrednie AI OCR (Total, Boss/score z parseAIResponse) są usunięte; szczegóły widoczne tylko w logach błędów
 - **Ranking per-serwer:** `rankingService.loadRanking(guildId)` / `saveRanking(guildId, ranking)`
 - **Ranking globalny:** `rankingService.getGlobalRanking()` (merge wszystkich serwerów, best per player)
 - **Role opcjonalne:** Zawsze przekazuj `guildConfig?.topRoles || null` do `roleService.updateTopRoles()`

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -1139,7 +1139,8 @@ class InteractionHandler {
             tempImagePath = path.join(this.config.ocr.tempDir, `temp_${Date.now()}_${attachment.name}`);
             await downloadFile(attachment.url, tempImagePath);
 
-            gl.info(`🤖 [/${commandName}] Uruchamiam analizę z weryfikacją wzorca dla ${interaction.user.username}${dryRun ? ' (tryb testowy)' : ''}`);
+            const displayNameForLog = interaction.member?.displayName || interaction.user.displayName || interaction.user.username;
+            gl.info(`🤖 [/${commandName}] Uruchamiam analizę z weryfikacją wzorca dla ${displayNameForLog}${dryRun ? ' (tryb testowy)' : ''}`);
 
             // ── Operations Gateway (authorize + root span + record) ───────────
             const op = await this.botOps.run({
@@ -1171,6 +1172,7 @@ class InteractionHandler {
             }
 
             if (aiResult.error === 'NOT_SIMILAR') {
+                gl.warn(`❌ [/${commandName}] Odrzucono: NOT_SIMILAR`);
                 await this._sendInvalidScreenReport(interaction, tempImagePath, 'NOT_SIMILAR', gl, aiResult.rejectionReason);
                 const notSimilarDesc = aiResult.rejectionReason
                     ? `**${msgs.testNotSimilarReasonLabel}:** ${aiResult.rejectionReason}`
@@ -1187,6 +1189,7 @@ class InteractionHandler {
             }
 
             if (!aiResult.isValidVictory) {
+                gl.warn(`❌ [/${commandName}] Odrzucono: ${aiResult.error || 'VALIDATION_FAILED'}`);
                 await this._sendInvalidScreenReport(interaction, tempImagePath, aiResult.error, gl);
                 await interaction.editReply(msgs.invalidScreenshot);
                 return;
@@ -1194,7 +1197,7 @@ class InteractionHandler {
 
             const bestScore = aiResult.score;
             const bossName = aiResult.bossName;
-            gl.success(`✅ [/${commandName}] AI OCR: wynik="${bestScore}", boss="${bossName}"`);
+            gl.success(`✅ [/${commandName}] AI OCR: wynik="${bestScore}", boss="${bossName}"${aiResult.total ? `, total="${aiResult.total}"` : ''}`);
 
             const guildId = interaction.guildId;
             const userId = interaction.user.id;
@@ -1221,8 +1224,6 @@ class InteractionHandler {
                 ));
                 await this.logService.logScoreUpdate(userName, bestScore, isNewRecord, guildId);
             }
-
-            gl.info(`🎯 Przygotowuję odpowiedź dla użytkownika - isNewRecord: ${isNewRecord}${dryRun ? ' (tryb testowy)' : ''}`);
 
             if (!isNewRecord) {
                 try {
@@ -1350,7 +1351,7 @@ class InteractionHandler {
             try {
                 const updatedPlayers = await this.rankingService.getSortedPlayers(interaction.guildId);
                 await this.roleService.updateTopRoles(interaction.guild, updatedPlayers, guildConfig?.topRoles || null);
-                await this.logService.logMessage('success', 'Role TOP zostały zaktualizowane po nowym rekordzie', interaction);
+                gl.success(`✅ [${userName}] Role TOP zaktualizowane po nowym rekordzie`);
             } catch (roleError) {
                 await this.logService.logMessage('error', `Błąd aktualizacji ról TOP: ${roleError.message}`, interaction);
             }
@@ -1363,15 +1364,11 @@ class InteractionHandler {
                 const prevGlobalUserIndex = prevGlobalRanking.findIndex(p => p.userId === userId);
                 const prevGlobalPosition = prevGlobalUserIndex !== -1 ? prevGlobalUserIndex + 1 : null;
 
-                gl.info(`🌐 Global Top 3 check: userId=${userId}, prevPos=${prevGlobalPosition ?? 'brak'}, newPos=${newGlobalPosition ?? 'brak'}`);
-
                 if (newGlobalPosition && newGlobalPosition <= 3) {
                     const prevGlobalUser = prevGlobalRanking.find(p => p.userId === userId);
                     const newGlobalUser = newGlobalRanking[newGlobalUserIndex];
                     const globalScoreChanged = !prevGlobalUser || newGlobalUser.scoreValue > prevGlobalUser.scoreValue;
                     const positionChanged = prevGlobalPosition !== newGlobalPosition;
-
-                    gl.info(`🌐 W Top 3: globalScoreChanged=${globalScoreChanged}, positionChanged=${positionChanged} (${prevGlobalPosition ?? 'brak'} → ${newGlobalPosition})`);
 
                     if (globalScoreChanged && positionChanged) {
                         const sourceGuildName = interaction.guild.name;
@@ -1380,7 +1377,7 @@ class InteractionHandler {
                         const allNotifGuilds = this.config.getAllGuilds()
                             .filter(g => g.globalTop3Notifications !== false)
                             .filter(g => interaction.client.guilds.cache.has(g.id));
-                        gl.info(`🌐 Wysyłam powiadomienia Global Top 3 do ${allNotifGuilds.length} serwerów`);
+                        gl.info(`🌐 Global Top 3: ${prevGlobalPosition ?? 'brak'}→${newGlobalPosition} — wysyłam do ${allNotifGuilds.length} serwerów`);
 
                         for (const guildCfg of allNotifGuilds) {
                             try {
@@ -1434,10 +1431,10 @@ class InteractionHandler {
                             }
                         }
                     } else {
-                        gl.info(`🌐 Warunki nie spełnione — nie wysyłam powiadomień`);
+                        gl.info(`🌐 Global Top 3: pos=${newGlobalPosition} (bez zmian) — warunki nie spełnione`);
                     }
                 } else {
-                    gl.info(`🌐 Gracz poza Top 3 (pos=${newGlobalPosition ?? 'brak'}) — nie wysyłam powiadomień`);
+                    gl.info(`🌐 Global Top 3: pos=${newGlobalPosition ?? 'brak'} — nie wysyłam powiadomień`);
                 }
             } catch (globalCheckError) {
                 gl.error(`❌ Błąd sprawdzania/wysyłania Global Top 3: ${globalCheckError.message}`);

--- a/EndersEcho/services/aiOcrService.js
+++ b/EndersEcho/services/aiOcrService.js
@@ -275,7 +275,6 @@ Odpowiedz WYŁĄCZNIE w tym formacie (3 linie, nic więcej):
         let total = null;
         if (lines.length >= 3) {
             total = this.normalizeScore(lines[2].replace(/^total[:\s]*/i, '').trim(), log);
-            if (total) log.info(`✅ [AI OCR] Total: "${total}"`);
         }
 
         score = this.normalizeScore(score, log);
@@ -403,18 +402,14 @@ Odpowiedz WYŁĄCZNIE w tym formacie (3 linie, nic więcej):
             const wzorBase64 = wzorBuffer.toString('base64');
             const mediaType = 'image/png';
 
-            log.info('[AI Test] Porównuję zdjęcie z wzorcem...');
             const { isSimilar, rejectionReason, usage: u1 } = await this._compareWithTemplate(wzorBase64, uploadedBase64, mediaType, log, telemetryMeta, lang);
             tokenUsage.promptTokens  += u1.promptTokens;
             tokenUsage.outputTokens  += u1.outputTokens;
             tokenUsage.thoughtTokens += u1.thoughtTokens;
 
             if (!isSimilar) {
-                log.warn(`[AI Test] Zdjęcie niepodobne do wzorca: ${rejectionReason || 'brak powodu'}`);
                 return { bossName: null, score: null, confidence: 0, isValidVictory: false, error: 'NOT_SIMILAR', rejectionReason, tokenUsage };
             }
-
-            log.info('[AI Test] Zdjęcie podobne do wzorca → wyciągam dane...');
 
             const extractRes = await this._extractData(uploadedBase64, mediaType, 'eng', telemetryMeta);
             tokenUsage.promptTokens  += extractRes.promptTokens;
@@ -422,12 +417,6 @@ Odpowiedz WYŁĄCZNIE w tym formacie (3 linie, nic więcej):
             tokenUsage.thoughtTokens += extractRes.thoughtTokens;
 
             const result = this.parseAIResponse(extractRes.text, log);
-
-            if (result.isValidVictory) {
-                log.info(`[AI Test] Boss="${result.bossName}" score="${result.score}"`);
-            } else {
-                log.warn(`[AI Test] Nie udało się wyciągnąć danych: ${result.error}`);
-            }
 
             return { ...result, tokenUsage };
 
@@ -492,7 +481,7 @@ ${exampleReasons.join('\n')}
 
         const response = res.text.trim();
         const upper = response.toUpperCase();
-        log.info(`[AI Test] Odpowiedź porównania: "${response}"`);
+        log.info(`[AI Test] Test wzorca: "${response}"`);
         const isSimilar = upper.startsWith('OK') && !upper.startsWith('NOK');
         let rejectionReason = null;
         if (!isSimilar) {


### PR DESCRIPTION
## Summary
This PR improves logging clarity and consistency across the OCR validation flow by removing verbose intermediate debug logs and ensuring user display names are consistently used throughout the application.

## Key Changes

**Logging Improvements:**
- Removed intermediate AI OCR debug logs (`Total`, `Boss/score` extraction details, template comparison response details) from `aiOcrService.js` to reduce noise
- Added strategic warning logs at rejection points in `interactionHandlers.js` (`NOT_SIMILAR`, `VALIDATION_FAILED`) for better error tracking
- Consolidated Global Top 3 notification logs into single, more informative messages instead of multiple debug statements
- Removed redundant info log about preparing user response
- Updated template comparison log message from verbose to concise: `"Porównuję zdjęcie z wzorcem..."` → `"Test wzorca: ..."`

**User Display Name Handling:**
- Changed all user logging to use `interaction.member?.displayName || interaction.user.displayName || interaction.user.username` instead of just `interaction.user.username`
- Ensures server nicknames are displayed in logs when available, improving readability and user identification

**Success Message Enhancement:**
- Updated AI OCR success log to conditionally include `total` score when available: `wynik="X", boss="Y"[, total="Z"]`
- Changed role update log from generic service message to guild logger with user context

## Implementation Details
- The logging changes follow a "happy path" pattern: start → template test → AI OCR result → score update → announcements → role updates → global top 3 checks
- Rejection paths now clearly log the specific rejection reason (NOT_SIMILAR, VALIDATION_FAILED, etc.)
- Documentation in `CLAUDE.md` updated to reflect the new logging patterns and user display name convention

https://claude.ai/code/session_014uNiTshdk8j9ANHJhtbpFV