### PR TITLE
Consolidate admin commands into unified Admin Panel in /configure

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -107,56 +107,86 @@
    - Subskrypcje są trwałe (plik JSON) — przeżywają restart bota
    - Limit: max 25 subskrypcji wyświetlanych naraz w select menu (Discord API limit)
 
-6. **Komenda /info** — wysyłanie wiadomości informacyjnej na wszystkie serwery (`interactionHandlers.js`):
-   - Widoczna tylko dla administratorów (`setDefaultMemberPermissions(Administrator)`)
-   - Wykonać może tylko użytkownik o ID z `ENDERSECHO_INFO_USER_ID` w .env
-   - `/info` → modal z 4 polami: Tytuł (opcjonalnie), Opis (wymagany), Ikona URL (opcjonalnie), Obraz URL (opcjonalnie)
-   - Po wypełnieniu → ephemeral podgląd z czerwonym embedem + 3 przyciski: **Wyślij**, **Edytuj**, **Anuluj**
-   - **Wyślij** → wysyła embed na `allowedChannelId` każdego serwera z `config.guilds`, raportuje wynik
-   - **Edytuj** → pokazuje modal ponownie z wypełnionymi danymi z sesji
-   - **Anuluj** → czyści sesję
-   - Dane między modalem a przyciskami przechowywane w `_infoSessions` Map (RAM, per userId)
+6. **Panel Admina (info/ocr/limit/remove/unblock/tokens)** — dostępne przez `/configure` → `⚙️ Panel Admina`:
+   - **Wyślij Info (head admin):** użytkownik z `ENDERSECHO_BLOCK_OCR_USER_IDS` → modal → podgląd PL+ENG → wyślij na wszystkie serwery. `_infoSessions` Map (RAM) trzyma dane między modalem a przyciskami
+   - **OCR on/off (head admin):** `ENDERSECHO_BLOCK_OCR_USER_IDS` → select serwera → toggle per komenda. Stan w `guild_configs.json` przez `OcrBlockService`
+   - **Limit (head admin):** `ENDERSECHO_BLOCK_OCR_USER_IDS` → modal → globalny dzienny limit per user per UTC dzień. Persistencja: `data/usage_limits.json`
+   - **Usuń gracza (admin):** Administrator → select gracza z rankingu → potwierdzenie → usunięcie + aktualizacja ról TOP
+   - **Odblokuj (admin):** Administrator → select zablokowanego → odblokowanie. Persistencja: `data/user_blocks.json`
+   - **Tokeny AI (admin/head admin):** Administrator lub `ENDERSECHO_BLOCK_OCR_USER_IDS` → embed ze statystykami. Admin = tylko swój serwer, Head Admin = wszystkie serwery + breakdown
 
-**Komendy:** `/update`, `/ranking`, `/remove`, `/subscribe`, `/info`, `/ocr-on-off`, `/limit`, `/test`, `/unblock`, `/tokens`, `/configure`
+**Komendy slash:** `/configure`, `/ranking`, `/subscribe`, `/test`, `/update`
 
-**Komenda /tokens** — statystyki zużycia tokenów AI (admin):
-- Wyświetla dzienny i miesięczny koszt w $ per serwer oraz sumy łączne
-- Dane zbierane tylko przy `/update` (AI OCR) i zapisywane w `data/token_usage.json`
-- Podział na: tokeny wejściowe (In), wyjściowe (Out) i myślenia (Think)
-- Cennik: `services/tokenUsageService.js` → stałe `PRICING` (In $0.15, Out $0.60, Think $0.35 / 1M tokenów)
+**Panel Admina** — dostępny przez `/configure` → przycisk `⚙️ Panel Admina` (ostatni rząd):
+- Dostęp: każdy admin Discord (Administrator) który może otworzyć `/configure`
+- Tryb Admin: `🗑️ Usuń gracza`, `🔓 Odblokuj`, `📊 Tokeny AI`
+- Tryb Head Admin (`ENDERSECHO_BLOCK_OCR_USER_IDS`): wszystko z Admin + `📢 Wyślij Info`, `🔄 OCR on/off`, `📏 Limit`
+- Panel zastępuje widok konfiguracji (edit wiadomości), zawsze możliwy powrót do wizarda przez `◀️ Wróć do konfiguracji`
 
-**Komenda /limit** — dzienny limit użyć /update i /test (`usageLimitService.js`):
-- Widoczna tylko dla administratorów, wykonać może wyłącznie użytkownik z `ENDERSECHO_BLOCK_OCR_USER_IDS`
-- `/limit` → modal z polem „Liczba prób dziennie" (puste = brak limitu)
+**Operacje w Panelu Admina:**
+
+**🗑️ Usuń gracza** (Admin):
+- StringSelectMenu z listą do 25 graczy z rankingu serwera
+- Krok potwierdzenia przed usunięciem → aktualizacja ról TOP
+
+**🔓 Odblokuj** (Admin):
+- StringSelectMenu z listą zablokowanych użytkowników (czas pozostały + serwer)
+- Select: `panel_unblock_select`
+
+**📊 Tokeny AI** (Admin/Head Admin):
+- Embed ze statystykami dzienny/miesięczny koszt AI per serwer
+- Admin widzi tylko swój serwer; Head Admin widzi wszystkie + breakdown
+- Nawigacja `tk_*` zachowuje przycisk `◀️ Powrót do panelu`
+- Dane z `data/token_usage.json`, cennik: In $0.15, Out $0.60, Think $0.35 / 1M tokenów
+
+**📢 Wyślij Info** (Head Admin):
+- Otwiera modal z 4 polami: Tytuł, Opis PL, Opis ENG, Ikona URL, Obraz URL
+- Podgląd embeda + przyciski Wyślij / Edytuj / Anuluj
+- Wysyła na `allowedChannelId` każdego serwera w odpowiednim języku
+- Dostęp: `ENDERSECHO_BLOCK_OCR_USER_IDS` (ta sama zmienna co Head Admin)
+
+**🔄 OCR on/off** (Head Admin):
+- StringSelectMenu z serwerami (ikona 🔒/🔓 + stan update/test)
+- Po wyborze serwera: przyciski włącz/wyłącz dla `/update`, `/test`, obu
+- Ogłoszenie na kanał bota serwera po odblokowaniu
+
+**📏 Limit** (Head Admin):
+- Modal z polem „Liczba prób dziennie" (puste = brak limitu)
 - Limit globalny per-użytkownik per-dzień (UTC), wspólny dla /update i /test
-- Po przekroczeniu → ephemeral z informacją i prośbą o próbę jutro
-- Persistencja: `data/usage_limits.json` (`{ limit, dailyUsage: { "userId_YYYY-MM-DD": count } }`)
-- Stare wpisy usage automatycznie czyszczone przy każdym zapisie (tylko dzisiaj zostaje)
+- Persistencja: `data/usage_limits.json`
 
-**Komenda /configure** — wizard konfiguracji serwera (admin, dowolny kanał):
+**CustomIDs Panelu Admina:**
+| CustomId | Opis |
+|---|---|
+| `cfg_admin_panel` | Otwórz panel (z configure dashboard) |
+| `panel_back` | Wróć do panelu (z dowolnej operacji) |
+| `panel_back_configure` | Wróć do wizarda /configure |
+| `panel_remove` | Pokaż listę graczy do usunięcia |
+| `panel_remove_select` | StringSelectMenu — wybór gracza |
+| `panel_remove_confirm_{userId}` | Potwierdzenie usunięcia |
+| `panel_unblock` | Pokaż listę zablokowanych |
+| `panel_unblock_select` | StringSelectMenu — wybór do odblokowania |
+| `panel_tokens` | Pokaż statystyki tokenów |
+| `panel_info` | Otwórz modal /info (head admin) |
+| `panel_ocr` | Pokaż listę serwerów OCR (head admin) |
+| `panel_ocr_guild_select` | StringSelectMenu — wybór serwera |
+| `panel_ocr_{en\|dis}_{update\|test\|both}_{guildId}` | Wykonaj OCR toggle |
+| `panel_limit` | Otwórz modal limitu (head admin) |
+
+**Komenda /configure** — wizard konfiguracji serwera + Panel Admina (admin, dowolny kanał):
 - 7-krokowy dashboard ephemeral z przyciskami szarymi→zielonymi po ukończeniu kroku
-- **Krok 1:** Kanał bota (ChannelSelectMenu) — dla /update, /ranking, /subscribe
-- **Krok 2:** Tag serwera (1–4 znaki lub emoji, modal) — wyświetlany w globalnym rankingu
-- **Krok 3:** Język (pol/eng) — wszystkie komunikaty i opisy komend; tłumaczony na pol gdy `state.lang === 'pol'`
-- **Krok 4:** Role TOP (opcjonalne, modal 5 pól ID ról) z wyjaśnieniem systemu
-- **Krok 5:** Powiadomienia Global TOP3 (Tak/Nie) — per-guild flaga `globalTop3Notifications`
-- **Krok 6:** Kanał raportów odrzuconych screenów (opcjonalny, ChannelSelectMenu)
+- **Krok 1:** Język (pol/eng) — wszystkie komunikaty i opisy komend
+- **Krok 2:** Kanał bota (ChannelSelectMenu) — dla /update, /ranking, /subscribe
+- **Krok 3:** Kanał raportów odrzuconych screenów (opcjonalny, ChannelSelectMenu)
+- **Krok 4:** Tag serwera (1–4 znaki lub emoji, modal) — wyświetlany w globalnym rankingu
+- **Krok 5:** Role TOP (opcjonalne, modal 5 pól ID ról) z wyjaśnieniem systemu
+- **Krok 6:** Powiadomienia Global TOP3 (Tak/Nie) — per-guild flaga `globalTop3Notifications`
 - **Krok 7:** Ranking roli (opcjonalne) — przyciski "Dodaj ranking roli" (RoleSelectMenu), "Usuń ranking roli" (StringSelectMenu), "Gotowe / Pomiń"; stan `roleRankingsDone` w RAM; dla istniejącej konfiguracji pre-fill `true`
-- Zielony przycisk **✅ Zaakceptuj konfigurację!** (ButtonStyle.Success) pojawia się gdy wszystkie kroki ukończone
-- Szary przycisk **Anuluj** widoczny od początku — czyści `_configWizard` i zamyka dashboard
+- Zielony przycisk **✅ Zaakceptuj konfigurację!** pojawia się gdy wszystkie kroki ukończone
+- **Ostatni rząd:** `⚙️ Panel Admina` — dostęp do operacji administracyjnych (patrz sekcja Panel Admina)
 - Po zapisaniu: OCR domyślnie zablokowane (`['update', 'test']`), komendy re-rejestrowane dla nowego języka
 - Konfiguracja persystowana w `data/guild_configs.json` przez `GuildConfigService`
 - Stan wizarda trzymany w RAM (`_configWizard` Map, per userId_guildId)
-- Bot po raz pierwszy dodany do serwera (`guildCreate`): automatyczna rejestracja komend + domyślny wpis (unconfigured, OCR zablokowane) + welcome message + powiadomienie na `ENDERSECHO_INVALID_REPORT_CHANNEL_ID` (zielony embed z nazwą i liczbą członków)
-- Bot usunięty z serwera (`guildDelete`): powiadomienie na `ENDERSECHO_INVALID_REPORT_CHANNEL_ID` (czerwony embed z nazwą serwera)
-- Serwer w pełni skonfigurowany (`/configure` → Zaakceptuj): powiadomienie na `ENDERSECHO_INVALID_REPORT_CHANNEL_ID` (niebieski embed z nazwą serwera, adminem, kanałem, językiem, tagiem, rolami TOP, kanałem raportów; oznaczony jako rekonfiguracja jeśli serwer był już skonfigurowany)
-
-**Komenda /ocr-on-off** — per-guild włącz/wyłącz komendy OCR (head admin tylko, dowolny kanał):
-- Parametry: `action` (enable/disable), `target` (update/test/both), `guild` (autocomplete)
-- Autocomplete `guild`: pobiera `getAllConfiguredGuildIds()` z `GuildConfigService`, filtruje po nazwie/ID
-- Stan per-guild w `guild_configs.json` poprzez `OcrBlockService` (`ocrBlockService.block/unblock(guildId, commands[])`)
-- Po odblokowanie → ogłoszenie do `allowedChannelId` serwera
-- Migracja: stary globalny `ocr_blocked.json` → per-guild przy pierwszym starcie
 
 **System raportów odrzuconych screenów** (per-guild + global):
 - Raport w języku serwera źródłowego (`config.getMessages(guildId)`) — klucze `reportTitle`, `reportField*`, `reportReason*`
@@ -181,10 +211,12 @@
 - `getOcrBlocked/setOcrBlocked`: per-guild stan blokady OCR
 - `getAllConfiguredGuilds()`: format kompatybilny z `config.guilds` (id, allowedChannelId, lang, tag, topRoles, globalTop3Notifications)
 
-**Uprawnienia komend** (po nowym routingu):
-- Bez konfiguracji (zawsze): `/configure`, `/info`, `/ocr-on-off`, `/limit`, `/tokens`, `/unblock`
-- Wymaga konfiguracji, dowolny kanał: `/test`, `/remove`
+**Uprawnienia komend:**
+- Bez konfiguracji (zawsze): `/configure` (+ Panel Admina)
+- Wymaga konfiguracji, dowolny kanał: `/test` (Administrator + `ENDERSECHO_BLOCK_OCR_USER_IDS`)
 - Wymaga konfiguracji + bot channel: `/update`, `/ranking`, `/subscribe`
+- Panel Admina (tryb Admin): Administrator Discord → usuń gracza, odblokuj, tokeny
+- Panel Admina (tryb Head Admin): `ENDERSECHO_BLOCK_OCR_USER_IDS` → wszystko + info, OCR toggle, limit
 
 **Struktura danych:**
 ```
@@ -237,9 +269,6 @@ ENDERSECHO_GUILD_2_TOP1_ROLE=role_id
 USE_ENDERSECHO_AI_OCR=false
 ENDERSECHO_GOOGLE_AI_API_KEY=AIzaSy-xxxxxxxxxxxxx
 ENDERSECHO_GOOGLE_AI_MODEL=gemini-2.5-flash-preview-05-20
-
-# Komenda /info (wymagane do działania /info)
-ENDERSECHO_INFO_USER_ID=discord_user_id
 
 # Dedykowany kanał logów EndersEcho (opcjonalne — jeśli ustawiony, logi NIE trafiają do głównego webhooka)
 # Każdy serwer pojawia się z własnym avatarem (ENDERSECHO_GUILD_N_ICON) i nazwą (TAG)

--- a/EndersEcho/config/config.js
+++ b/EndersEcho/config/config.js
@@ -84,7 +84,6 @@ let _guildConfigService = null;
 module.exports = {
     token: process.env.ENDERSECHO_TOKEN,
     clientId: process.env.ENDERSECHO_CLIENT_ID,
-    infoUserId: process.env.ENDERSECHO_INFO_USER_ID || null,
     blockOcrUserIds: (process.env.ENDERSECHO_BLOCK_OCR_USER_IDS || '').split(',').map(id => id.trim()).filter(Boolean),
     logWebhookUrl: process.env.ENDERSECHO_LOG_WEBHOOK_URL || null,
     invalidReportChannelId: process.env.ENDERSECHO_INVALID_REPORT_CHANNEL_ID || null,

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -114,57 +114,9 @@ class InteractionHandler {
                         .setRequired(true)),
 
             new SlashCommandBuilder()
-                .setName('remove')
-                .setDescription('Remove a player from the ranking (admins only)')
-                .setDescriptionLocalizations(pl('Usuń gracza z rankingu (tylko dla adminów)'))
-                .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
-                .addUserOption(option =>
-                    option.setName('user')
-                        .setDescription('User to remove from the ranking')
-                        .setDescriptionLocalizations(pl('Użytkownik do usunięcia z rankingu'))
-                        .setRequired(true)),
-
-            new SlashCommandBuilder()
                 .setName('subscribe')
                 .setDescription('Manage record break notifications for players')
                 .setDescriptionLocalizations(pl('Zarządzaj powiadomieniami o pobiciach rekordów graczy')),
-
-            new SlashCommandBuilder()
-                .setName('info')
-                .setDescription('Send an info message to all servers (selected users only)')
-                .setDescriptionLocalizations(pl('Wyślij wiadomość informacyjną na wszystkie serwery (tylko dla wybranych)'))
-                .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
-
-            new SlashCommandBuilder()
-                .setName('ocr-on-off')
-                .setDescription('Enable / disable /update and/or /test on a specific server (head admin only)')
-                .setDescriptionLocalizations(pl('Włącz / wyłącz /update i/lub /test na wybranym serwerze (tylko head admin)'))
-                .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
-                .addStringOption(option =>
-                    option.setName('action')
-                        .setDescription('Enable or disable the command')
-                        .setDescriptionLocalizations(pl('Włącz lub wyłącz komendę'))
-                        .setRequired(true)
-                        .addChoices(
-                            { name: '🔓 Enable', value: 'enable' },
-                            { name: '🔒 Disable', value: 'disable' }
-                        ))
-                .addStringOption(option =>
-                    option.setName('guild')
-                        .setDescription('Server to apply the change to (autocomplete)')
-                        .setDescriptionLocalizations(pl('Serwer na którym zmienić ustawienie (autocomplete)'))
-                        .setRequired(true)
-                        .setAutocomplete(true))
-                .addStringOption(option =>
-                    option.setName('target')
-                        .setDescription('Which command (default: both)')
-                        .setDescriptionLocalizations(pl('Która komenda (domyślnie: obie)'))
-                        .setRequired(false)
-                        .addChoices(
-                            { name: '/update', value: 'update' },
-                            { name: '/test', value: 'test' },
-                            { name: 'Both / Obie', value: 'both' }
-                        )),
 
             new SlashCommandBuilder()
                 .setName('test')
@@ -176,24 +128,6 @@ class InteractionHandler {
                         .setDescription('Screenshot of the boss result screen')
                         .setDescriptionLocalizations(pl('Screenshot ekranu wyników bossa'))
                         .setRequired(true)),
-
-            new SlashCommandBuilder()
-                .setName('unblock')
-                .setDescription('View blocked users and unblock them (admins only)')
-                .setDescriptionLocalizations(pl('Wyświetla zablokowanych użytkowników i umożliwia ich odblokowanie (tylko dla adminów)'))
-                .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
-
-            new SlashCommandBuilder()
-                .setName('limit')
-                .setDescription('Set daily usage limit for /update and /test per user (selected users only)')
-                .setDescriptionLocalizations(pl('Ustaw dzienny limit użyć /update i /test na użytkownika (tylko dla wybranych)'))
-                .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
-
-            new SlashCommandBuilder()
-                .setName('tokens')
-                .setDescription('Show AI token usage and cost statistics (admins only)')
-                .setDescriptionLocalizations(pl('Wyświetl statystyki zużycia tokenów AI i kosztów (tylko dla adminów)'))
-                .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
 
             new SlashCommandBuilder()
                 .setName('configure')
@@ -272,36 +206,11 @@ class InteractionHandler {
                 await this.handleConfigureCommand(interaction);
                 return;
             }
-            if (interaction.commandName === 'info') {
-                await this.handleInfoCommand(interaction);
-                return;
-            }
-            if (interaction.commandName === 'ocr-on-off') {
-                await this.handleBlockOcrCommand(interaction);
-                return;
-            }
-            if (interaction.commandName === 'limit') {
-                await this.handleLimitCommand(interaction);
-                return;
-            }
-            if (interaction.commandName === 'tokens') {
-                await this.handleTokensCommand(interaction);
-                return;
-            }
-            if (interaction.commandName === 'unblock') {
-                await this.handleUnblockCommand(interaction);
-                return;
-            }
 
             // Komendy admin — dowolny kanał, ale wymagają konfiguracji serwera
             if (interaction.commandName === 'test') {
                 if (!this._checkConfigured(interaction)) return;
                 await this.handleTestCommand(interaction);
-                return;
-            }
-            if (interaction.commandName === 'remove') {
-                if (!this._checkConfigured(interaction)) return;
-                await this.handleRemoveCommand(interaction);
                 return;
             }
             // Pozostałe komendy — wymagają konfiguracji i dozwolonego kanału
@@ -442,6 +351,13 @@ class InteractionHandler {
             rows.push(new ActionRowBuilder().addComponents(cancelBtn));
         }
 
+        rows.push(new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId('cfg_admin_panel')
+                .setLabel(t('⚙️ Panel Admina', '⚙️ Admin Panel'))
+                .setStyle(ButtonStyle.Secondary)
+        ));
+
         const summaryLines = [
             done[1] ? `🌐 ${t('Język:', 'Language:')} ${state.lang === 'pol' ? '🇵🇱 Polish' : '🇬🇧 English'}` : null,
             done[2] ? `📡 ${t('Kanał:', 'Channel:')} <#${state.allowedChannelId}>` : null,
@@ -571,10 +487,10 @@ class InteractionHandler {
                     t(
                         'Wybierz kanał, na którym użytkownicy będą używać komend EndersEcho.\n\n' +
                         '**Dostępne na tym kanale (wszyscy):**\n• `/update` — prześlij wynik\n• `/ranking` — wyświetl ranking\n• `/subscribe` — zarządzaj powiadomieniami\n\n' +
-                        'Komendy adminów (`/remove`, `/unblock`, `/tokens`, `/test`, `/configure`) działają z **dowolnego** kanału.',
+                        'Komendy adminów są dostępne przez **Panel Admina** w `/configure` z dowolnego kanału.',
                         'Choose the channel where users can run EndersEcho commands.\n\n' +
                         '**Available in this channel (all users):**\n• `/update` — submit a score\n• `/ranking` — view rankings\n• `/subscribe` — manage notifications\n\n' +
-                        'Admin commands (`/remove`, `/unblock`, `/tokens`, `/test`, `/configure`) work from **any** channel.'
+                        'Admin commands are available through the **Admin Panel** in `/configure` from any channel.'
                     )
                 );
             const channelSelect = new ChannelSelectMenuBuilder()
@@ -1017,6 +933,304 @@ class InteractionHandler {
             }
             return;
         }
+    }
+
+    // =====================================================================
+    // Panel Admina — dostępny z /configure → przycisk cfg_admin_panel
+    // =====================================================================
+
+    _isHeadAdmin(userId) {
+        return this.config.blockOcrUserIds.includes(userId);
+    }
+
+    _buildAdminPanel(interaction) {
+        const isHeadAdmin = this._isHeadAdmin(interaction.user.id);
+        const embed = new EmbedBuilder()
+            .setColor(isHeadAdmin ? 0xFF6B35 : 0x5865F2)
+            .setTitle('⚙️ Panel Administracyjny')
+            .setDescription(
+                `**Tryb: ${isHeadAdmin ? 'Head Admin' : 'Admin'}**\n\n` +
+                (isHeadAdmin
+                    ? 'Pełny dostęp do wszystkich operacji administracyjnych.'
+                    : 'Dostęp do podstawowych operacji administracyjnych.')
+            );
+
+        const adminRow = new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId('panel_remove').setLabel('🗑️ Usuń gracza').setStyle(ButtonStyle.Danger),
+            new ButtonBuilder().setCustomId('panel_unblock').setLabel('🔓 Odblokuj').setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('panel_tokens').setLabel('📊 Tokeny AI').setStyle(ButtonStyle.Secondary),
+        );
+
+        const backRow = new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId('panel_back_configure').setLabel('◀️ Wróć do konfiguracji').setStyle(ButtonStyle.Secondary),
+        );
+
+        const components = [adminRow];
+        if (isHeadAdmin) {
+            components.push(new ActionRowBuilder().addComponents(
+                new ButtonBuilder().setCustomId('panel_info').setLabel('📢 Wyślij Info').setStyle(ButtonStyle.Primary),
+                new ButtonBuilder().setCustomId('panel_ocr').setLabel('🔄 OCR on/off').setStyle(ButtonStyle.Primary),
+                new ButtonBuilder().setCustomId('panel_limit').setLabel('📏 Limit').setStyle(ButtonStyle.Primary),
+            ));
+        }
+        components.push(backRow);
+
+        return { embed, components };
+    }
+
+    async _handleAdminPanelOpen(interaction) {
+        const { embed, components } = this._buildAdminPanel(interaction);
+        await interaction.update({ embeds: [embed], components });
+    }
+
+    async _handlePanelRemove(interaction) {
+        const guildId = interaction.guildId;
+        try {
+            const players = await this.rankingService.getSortedPlayers(guildId);
+            if (players.length === 0) {
+                await interaction.update({
+                    embeds: [new EmbedBuilder().setColor(0xFF4444).setTitle('🗑️ Usuń gracza').setDescription('Ranking jest pusty — brak graczy do usunięcia.')],
+                    components: [new ActionRowBuilder().addComponents(
+                        new ButtonBuilder().setCustomId('panel_back').setLabel('◀️ Powrót').setStyle(ButtonStyle.Secondary)
+                    )]
+                });
+                return;
+            }
+            const options = players.slice(0, 25).map((p, i) => ({
+                label: `#${i + 1} ${(p.username || p.userId).slice(0, 80)}`,
+                description: `Wynik: ${p.score}`,
+                value: p.userId,
+            }));
+            await interaction.update({
+                embeds: [new EmbedBuilder().setColor(0xFF4444).setTitle('🗑️ Usuń gracza z rankingu').setDescription('Wybierz gracza, którego chcesz usunąć z rankingu tego serwera.')],
+                components: [
+                    new ActionRowBuilder().addComponents(
+                        new StringSelectMenuBuilder().setCustomId('panel_remove_select').setPlaceholder('Wybierz gracza do usunięcia...').addOptions(options)
+                    ),
+                    new ActionRowBuilder().addComponents(
+                        new ButtonBuilder().setCustomId('panel_back').setLabel('◀️ Powrót').setStyle(ButtonStyle.Secondary)
+                    )
+                ]
+            });
+        } catch (err) {
+            logger.error(`Błąd _handlePanelRemove (guildId=${guildId}):`, err);
+            await interaction.update({ content: '❌ Błąd wczytywania rankingu.', embeds: [], components: [] });
+        }
+    }
+
+    async _handlePanelRemoveSelect(interaction) {
+        const targetUserId = interaction.values[0];
+        const guildId = interaction.guildId;
+        const players = await this.rankingService.getSortedPlayers(guildId);
+        const player = players.find(p => p.userId === targetUserId);
+        const displayName = player?.username || targetUserId;
+        await interaction.update({
+            embeds: [new EmbedBuilder().setColor(0xFF4444).setTitle('🗑️ Potwierdzenie usunięcia').setDescription(`Czy na pewno chcesz usunąć **${displayName}** z rankingu?\n\nTej operacji nie można cofnąć.`)],
+            components: [new ActionRowBuilder().addComponents(
+                new ButtonBuilder().setCustomId(`panel_remove_confirm_${targetUserId}`).setLabel('✅ Usuń').setStyle(ButtonStyle.Danger),
+                new ButtonBuilder().setCustomId('panel_back').setLabel('◀️ Anuluj').setStyle(ButtonStyle.Secondary),
+            )]
+        });
+    }
+
+    async _handlePanelRemoveConfirm(interaction, targetUserId) {
+        const guildId = interaction.guildId;
+        await interaction.deferUpdate();
+        try {
+            const wasRemoved = await this.rankingService.removePlayerFromRanking(targetUserId, guildId);
+            if (!wasRemoved) {
+                const { embed, components } = this._buildAdminPanel(interaction);
+                embed.setDescription('⚠️ Gracz nie znajduje się w rankingu.\n\n' + (embed.data.description || ''));
+                await interaction.editReply({ embeds: [embed], components });
+                return;
+            }
+            try {
+                const guildConfig = this.config.getGuildConfig(guildId);
+                const updatedPlayers = await this.rankingService.getSortedPlayers(guildId);
+                await this.roleService.updateTopRoles(interaction.guild, updatedPlayers, guildConfig?.topRoles || null);
+                await this.logService.logMessage('success', `Gracz ${targetUserId} usunięty z rankingu przez panel admina`, interaction);
+            } catch (roleError) {
+                logger.warn(`Błąd aktualizacji ról TOP po usunięciu (panel): ${roleError.message}`);
+            }
+            await interaction.editReply({
+                embeds: [new EmbedBuilder().setColor(0x57F287).setTitle('✅ Gracz usunięty').setDescription(`Gracz <@${targetUserId}> został usunięty z rankingu.`)],
+                components: [new ActionRowBuilder().addComponents(
+                    new ButtonBuilder().setCustomId('panel_back').setLabel('◀️ Powrót do panelu').setStyle(ButtonStyle.Secondary)
+                )]
+            });
+        } catch (err) {
+            logger.error(`Błąd _handlePanelRemoveConfirm (guildId=${guildId}, userId=${targetUserId}):`, err);
+            await interaction.editReply({ content: '❌ Błąd usuwania gracza.', embeds: [], components: [] });
+        }
+    }
+
+    async _handlePanelUnblock(interaction) {
+        const msgs = this.msgs(interaction.guildId);
+        const blocked = this.userBlockService.getBlockedUsers();
+        if (blocked.length === 0) {
+            await interaction.update({
+                embeds: [new EmbedBuilder().setColor(0x57F287).setTitle('🔓 Odblokuj użytkownika').setDescription(msgs.unblockNoBlocked)],
+                components: [new ActionRowBuilder().addComponents(
+                    new ButtonBuilder().setCustomId('panel_back').setLabel('◀️ Powrót').setStyle(ButtonStyle.Secondary)
+                )]
+            });
+            return;
+        }
+        const options = blocked.slice(0, 25).map(entry => {
+            const timeLabel = this.userBlockService.formatTimeRemaining(entry.blockedUntil);
+            return {
+                label: entry.username.slice(0, 100),
+                description: `${entry.guildName} | Pozostało: ${timeLabel}`.slice(0, 100),
+                value: entry.userId
+            };
+        });
+        await interaction.update({
+            embeds: [new EmbedBuilder().setColor(0xFF4444).setTitle(msgs.unblockTitle)
+                .setDescription(blocked.slice(0, 25).map((entry, i) => {
+                    const timeLabel = this.userBlockService.formatTimeRemaining(entry.blockedUntil);
+                    return `${i + 1}. **${entry.username}** — ${entry.guildName} | \`${timeLabel}\``;
+                }).join('\n'))
+                .setFooter({ text: `Łącznie: ${blocked.length} zablokowanych` })
+                .setTimestamp()],
+            components: [
+                new ActionRowBuilder().addComponents(
+                    new StringSelectMenuBuilder().setCustomId('panel_unblock_select').setPlaceholder('Wybierz użytkownika do odblokowania').addOptions(options)
+                ),
+                new ActionRowBuilder().addComponents(
+                    new ButtonBuilder().setCustomId('panel_back').setLabel('◀️ Powrót').setStyle(ButtonStyle.Secondary)
+                )
+            ]
+        });
+    }
+
+    async _handlePanelTokens(interaction) {
+        await interaction.deferUpdate();
+        const month = new Date().toISOString().slice(0, 7);
+        const isSuperUser = this._isHeadAdmin(interaction.user.id);
+        const guildFilter = isSuperUser ? 'all' : interaction.guildId;
+        const reply = await this._buildTokensEmbed(interaction, month, guildFilter, isSuperUser);
+        if (reply.components.length < 5) {
+            reply.components.push(new ActionRowBuilder().addComponents(
+                new ButtonBuilder().setCustomId('panel_back').setLabel('◀️ Powrót do panelu').setStyle(ButtonStyle.Secondary)
+            ));
+        }
+        await interaction.editReply(reply);
+    }
+
+    async _handlePanelOcr(interaction) {
+        const configuredIds = this.guildConfigService?.getAllConfiguredGuildIds() || [];
+        const options = [];
+        for (const guildId of configuredIds) {
+            const guild = interaction.client.guilds.cache.get(guildId);
+            if (!guild) continue;
+            const updateBlocked = this.ocrBlockService.isBlocked(guildId, 'update');
+            const testBlocked = this.ocrBlockService.isBlocked(guildId, 'test');
+            const statusIcon = updateBlocked || testBlocked ? '🔒' : '🔓';
+            options.push({
+                label: `${statusIcon} ${guild.name}`.slice(0, 100),
+                description: `update: ${updateBlocked ? 'wyłączone' : 'włączone'} | test: ${testBlocked ? 'wyłączone' : 'włączone'}`,
+                value: guildId,
+            });
+        }
+        if (options.length === 0) {
+            await interaction.update({
+                embeds: [new EmbedBuilder().setColor(0xFF4444).setTitle('🔄 OCR on/off').setDescription('Brak skonfigurowanych serwerów widocznych w cache bota.')],
+                components: [new ActionRowBuilder().addComponents(
+                    new ButtonBuilder().setCustomId('panel_back').setLabel('◀️ Powrót').setStyle(ButtonStyle.Secondary)
+                )]
+            });
+            return;
+        }
+        await interaction.update({
+            embeds: [new EmbedBuilder().setColor(0xFF6B35).setTitle('🔄 OCR on/off — wybierz serwer').setDescription('Wybierz serwer, na którym chcesz zmienić ustawienia OCR.')],
+            components: [
+                new ActionRowBuilder().addComponents(
+                    new StringSelectMenuBuilder().setCustomId('panel_ocr_guild_select').setPlaceholder('Wybierz serwer...').addOptions(options.slice(0, 25))
+                ),
+                new ActionRowBuilder().addComponents(
+                    new ButtonBuilder().setCustomId('panel_back').setLabel('◀️ Powrót').setStyle(ButtonStyle.Secondary)
+                )
+            ]
+        });
+    }
+
+    async _handlePanelOcrGuildSelect(interaction) {
+        const targetGuildId = interaction.values[0];
+        const guild = interaction.client.guilds.cache.get(targetGuildId);
+        const guildName = guild?.name || targetGuildId;
+        const updateBlocked = this.ocrBlockService.isBlocked(targetGuildId, 'update');
+        const testBlocked = this.ocrBlockService.isBlocked(targetGuildId, 'test');
+        const gid = targetGuildId;
+        await interaction.update({
+            embeds: [new EmbedBuilder().setColor(0xFF6B35)
+                .setTitle(`🔄 OCR on/off — ${guildName}`)
+                .setDescription(
+                    `Stan /update: ${updateBlocked ? '🔒 wyłączone' : '🔓 włączone'}\n` +
+                    `Stan /test: ${testBlocked ? '🔒 wyłączone' : '🔓 włączone'}\n\n` +
+                    'Wybierz akcję:'
+                )],
+            components: [
+                new ActionRowBuilder().addComponents(
+                    new ButtonBuilder().setCustomId(`panel_ocr_en_update_${gid}`).setLabel('🔓 Włącz /update').setStyle(ButtonStyle.Success).setDisabled(!updateBlocked),
+                    new ButtonBuilder().setCustomId(`panel_ocr_en_test_${gid}`).setLabel('🔓 Włącz /test').setStyle(ButtonStyle.Success).setDisabled(!testBlocked),
+                    new ButtonBuilder().setCustomId(`panel_ocr_en_both_${gid}`).setLabel('🔓 Włącz oba').setStyle(ButtonStyle.Success).setDisabled(!updateBlocked && !testBlocked),
+                ),
+                new ActionRowBuilder().addComponents(
+                    new ButtonBuilder().setCustomId(`panel_ocr_dis_update_${gid}`).setLabel('🔒 Wyłącz /update').setStyle(ButtonStyle.Danger).setDisabled(updateBlocked),
+                    new ButtonBuilder().setCustomId(`panel_ocr_dis_test_${gid}`).setLabel('🔒 Wyłącz /test').setStyle(ButtonStyle.Danger).setDisabled(testBlocked),
+                    new ButtonBuilder().setCustomId(`panel_ocr_dis_both_${gid}`).setLabel('🔒 Wyłącz oba').setStyle(ButtonStyle.Danger).setDisabled(updateBlocked && testBlocked),
+                ),
+                new ActionRowBuilder().addComponents(
+                    new ButtonBuilder().setCustomId('panel_back').setLabel('◀️ Powrót').setStyle(ButtonStyle.Secondary)
+                )
+            ]
+        });
+    }
+
+    async _handlePanelOcrAction(interaction, customId) {
+        // panel_ocr_{en|dis}_{update|test|both}_{guildId}
+        const parts = customId.split('_');
+        const action = parts[2];       // 'en' lub 'dis'
+        const target = parts[3];       // 'update', 'test', 'both'
+        const targetGuildId = parts.slice(4).join('_');
+        const targetCommands = target === 'both' ? ['update', 'test'] : [target];
+        const cmdLabel = targetCommands.map(c => `\`/${c}\``).join(', ');
+        const guildConfig = this.config.getGuildConfig(targetGuildId);
+        const serverName = interaction.client.guilds.cache.get(targetGuildId)?.name || targetGuildId;
+        if (!guildConfig) {
+            await interaction.update({
+                embeds: [new EmbedBuilder().setColor(0xFF4444).setTitle('❌ Błąd').setDescription('Serwer nie jest skonfigurowany.')],
+                components: [new ActionRowBuilder().addComponents(
+                    new ButtonBuilder().setCustomId('panel_back').setLabel('◀️ Powrót').setStyle(ButtonStyle.Secondary)
+                )]
+            });
+            return;
+        }
+        await interaction.deferUpdate();
+        if (action === 'en') {
+            await this.ocrBlockService.unblock(targetGuildId, targetCommands);
+            logger.info(`🔓 OCR odblokowany dla ${cmdLabel} na serwerze ${serverName} (panel)`);
+            if (guildConfig.allowedChannelId) {
+                const ch = await interaction.client.channels.fetch(guildConfig.allowedChannelId).catch(() => null);
+                if (ch) {
+                    const guildMsgs = this.config.getMessages(targetGuildId);
+                    await ch.send({ content: formatMessage(guildMsgs.ocrBlockPerGuildDisabled, { commands: cmdLabel, serverName }) }).catch(() => {});
+                }
+            }
+        } else {
+            await this.ocrBlockService.block(targetGuildId, targetCommands);
+            logger.warn(`🔒 OCR zablokowany dla ${cmdLabel} na serwerze ${serverName} (panel)`);
+        }
+        const actionLabel = action === 'en' ? '🔓 Odblokowano' : '🔒 Zablokowano';
+        await interaction.editReply({
+            embeds: [new EmbedBuilder()
+                .setColor(action === 'en' ? 0x57F287 : 0xFF4444)
+                .setTitle(`${actionLabel} OCR`)
+                .setDescription(`${cmdLabel} na serwerze **${serverName}** — ${action === 'en' ? 'włączone' : 'wyłączone'}.`)],
+            components: [new ActionRowBuilder().addComponents(
+                new ButtonBuilder().setCustomId('panel_back').setLabel('◀️ Powrót do panelu').setStyle(ButtonStyle.Secondary)
+            )]
+        });
     }
 
     /**
@@ -1722,6 +1936,81 @@ class InteractionHandler {
                 return;
             }
 
+            // === Przyciski Panelu Admina ===
+            if (customId === 'cfg_admin_panel' || customId === 'panel_back') {
+                await this._handleAdminPanelOpen(interaction);
+                return;
+            }
+            if (customId === 'panel_back_configure') {
+                const key = this._wizardKey(interaction.user.id, interaction.guildId);
+                const state = this._configWizard.get(key);
+                if (!state) {
+                    await interaction.update({ content: '⚠️ Sesja konfiguracji wygasła. Użyj komendy `/configure` ponownie.', embeds: [], components: [] });
+                    return;
+                }
+                const { embed, rows } = this._buildWizardDashboard(state, interaction.guildId);
+                await interaction.update({ embeds: [embed], components: rows });
+                return;
+            }
+            if (customId === 'panel_remove') {
+                await this._handlePanelRemove(interaction);
+                return;
+            }
+            if (customId.startsWith('panel_remove_confirm_')) {
+                const targetUserId = customId.replace('panel_remove_confirm_', '');
+                await this._handlePanelRemoveConfirm(interaction, targetUserId);
+                return;
+            }
+            if (customId === 'panel_unblock') {
+                await this._handlePanelUnblock(interaction);
+                return;
+            }
+            if (customId === 'panel_tokens') {
+                await this._handlePanelTokens(interaction);
+                return;
+            }
+            if (customId === 'panel_info') {
+                if (!this._isHeadAdmin(interaction.user.id)) {
+                    await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+                    return;
+                }
+                const prefill = this._infoSessions.get(interaction.user.id) || {};
+                await interaction.showModal(this._buildInfoModal(prefill));
+                return;
+            }
+            if (customId === 'panel_ocr') {
+                if (!this._isHeadAdmin(interaction.user.id)) {
+                    await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+                    return;
+                }
+                await this._handlePanelOcr(interaction);
+                return;
+            }
+            if (customId.startsWith('panel_ocr_en_') || customId.startsWith('panel_ocr_dis_')) {
+                if (!this._isHeadAdmin(interaction.user.id)) {
+                    await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+                    return;
+                }
+                await this._handlePanelOcrAction(interaction, customId);
+                return;
+            }
+            if (customId === 'panel_limit') {
+                if (!this._isHeadAdmin(interaction.user.id)) {
+                    await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+                    return;
+                }
+                const msgs = this.msgs(interaction.guildId);
+                const currentLimit = this.usageLimitService.getLimit();
+                const modal = new ModalBuilder().setCustomId('limit_modal').setTitle(msgs.limitModalTitle);
+                modal.addComponents(new ActionRowBuilder().addComponents(
+                    new TextInputBuilder().setCustomId('limit_value').setLabel(msgs.limitModalLabel)
+                        .setStyle(TextInputStyle.Short).setPlaceholder(msgs.limitModalPlaceholder)
+                        .setValue(currentLimit !== null ? String(currentLimit) : '').setRequired(false)
+                ));
+                await interaction.showModal(modal);
+                return;
+            }
+
             // === Przyciski wizarda /configure ===
             if (customId.startsWith('cfg_step_') || customId === 'cfg_back' || customId === 'cfg_tag_open' ||
                 customId === 'cfg_lang_pol' || customId === 'cfg_lang_eng' ||
@@ -2127,6 +2416,33 @@ class InteractionHandler {
         try {
             const customId = interaction.customId;
 
+            if (customId === 'panel_remove_select') {
+                await this._handlePanelRemoveSelect(interaction);
+                return;
+            }
+
+            if (customId === 'panel_unblock_select') {
+                const msgs = this.msgs(interaction.guildId);
+                const targetUserId = interaction.values[0];
+                const entry = this.userBlockService.getBlockedUsers().find(e => e.userId === targetUserId);
+                const success = await this.userBlockService.unblockUser(targetUserId);
+                const username = entry?.username || targetUserId;
+                await interaction.update({
+                    embeds: [new EmbedBuilder().setColor(success ? 0x57F287 : 0xFF4444)
+                        .setTitle(success ? '✅ Odblokowano' : '⚠️ Nie znaleziono')
+                        .setDescription(success ? formatMessage(msgs.unblockSuccess, { username }) : msgs.unblockNotFound)],
+                    components: [new ActionRowBuilder().addComponents(
+                        new ButtonBuilder().setCustomId('panel_back').setLabel('◀️ Powrót do panelu').setStyle(ButtonStyle.Secondary)
+                    )]
+                });
+                return;
+            }
+
+            if (customId === 'panel_ocr_guild_select') {
+                await this._handlePanelOcrGuildSelect(interaction);
+                return;
+            }
+
             if (customId === 'ee_unblock_select') {
                 const msgs = this.msgs(interaction.guildId);
                 if (!interaction.member.permissions.has('Administrator')) {
@@ -2520,7 +2836,7 @@ class InteractionHandler {
      * Obsługuje komendę /info — sprawdza userId, pokazuje modal.
      */
     async handleInfoCommand(interaction) {
-        if (!this.config.infoUserId || interaction.user.id !== this.config.infoUserId) {
+        if (!this.config.blockOcrUserIds.includes(interaction.user.id)) {
             const msgs = this.msgs(interaction.guildId);
             await interaction.reply({ content: msgs.noPermission, flags: ['Ephemeral'] });
             return;
@@ -2534,7 +2850,7 @@ class InteractionHandler {
      */
     async _handleInfoModalSubmit(interaction) {
         const msgs = this.msgs(interaction.guildId);
-        if (!this.config.infoUserId || interaction.user.id !== this.config.infoUserId) {
+        if (!this.config.blockOcrUserIds.includes(interaction.user.id)) {
             await interaction.reply({ content: msgs.noPermission, flags: ['Ephemeral'] });
             return;
         }
@@ -3308,6 +3624,11 @@ class InteractionHandler {
 
         if (action === 'm') {
             const reply = await this._buildTokensMonthBreakdown(interaction, month, isSuperUser);
+            if (reply.components.length < 5) {
+                reply.components.push(new ActionRowBuilder().addComponents(
+                    new ButtonBuilder().setCustomId('panel_back').setLabel('◀️ Powrót do panelu').setStyle(ButtonStyle.Secondary)
+                ));
+            }
             await interaction.editReply(reply);
             return;
         }
@@ -3321,6 +3642,11 @@ class InteractionHandler {
         }
 
         const reply = await this._buildTokensEmbed(interaction, targetMonth, effectiveFilter, isSuperUser);
+        if (reply.components.length < 5) {
+            reply.components.push(new ActionRowBuilder().addComponents(
+                new ButtonBuilder().setCustomId('panel_back').setLabel('◀️ Powrót do panelu').setStyle(ButtonStyle.Secondary)
+            ));
+        }
         await interaction.editReply(reply);
     }
 

--- a/Muteusz/config/all_commands.json
+++ b/Muteusz/config/all_commands.json
@@ -575,21 +575,9 @@
       "description": "Bot do rankingu wyników bossów z automatycznym przypisywaniem ról TOP",
       "commands": [
         {
-          "name": "/info",
-          "description": "Wysyła wiadomość informacyjną na wszystkie serwery (tylko dla wybranych użytkowników)",
-          "usage": "/info",
-          "requiredPermission": "administrator"
-        },
-        {
-          "name": "/subscribe",
-          "description": "Zarządza subskrypcjami DM o nowych rekordach graczy",
-          "usage": "/subscribe",
-          "requiredPermission": "public"
-        },
-        {
-          "name": "/ocr-on-off",
-          "description": "Blokuje / odblokowuje komendę /update na wszystkich serwerach",
-          "usage": "/ocr-on-off",
+          "name": "/configure",
+          "description": "Konfiguruje EndersEcho na serwerze. Zawiera Panel Admina z operacjami: usuń gracza, odblokuj, tokeny AI, wyślij info (head admin), OCR on/off (head admin), limit dzienny (head admin).",
+          "usage": "/configure → przyciski kroków 1-7 + ⚙️ Panel Admina",
           "requiredPermission": "administrator"
         },
         {
@@ -599,21 +587,15 @@
           "requiredPermission": "public"
         },
         {
-          "name": "/remove",
-          "description": "Usuwa gracza z rankingu",
-          "usage": "/remove użytkownik:@user",
-          "requiredPermission": "administrator"
+          "name": "/subscribe",
+          "description": "Zarządza subskrypcjami DM o nowych rekordach graczy",
+          "usage": "/subscribe",
+          "requiredPermission": "public"
         },
         {
           "name": "/test",
-          "description": "Testuje analizę screenshota przez AI — porównuje z wzorcem i wyciąga dane (boss + wynik) bez zapisu. Pokazuje ephemeral podgląd czy byłby to nowy rekord.",
+          "description": "Testuje analizę screenshota przez AI — porównuje z wzorcem i wyciąga dane (boss + wynik) bez zapisu. Pokazuje ephemeral podgląd czy byłby to nowy rekord. Tylko dla administratorów z ENDERSECHO_BLOCK_OCR_USER_IDS.",
           "usage": "/test obraz:[screenshot do przetestowania]",
-          "requiredPermission": "administrator"
-        },
-        {
-          "name": "/unblock",
-          "description": "Wyświetla listę zablokowanych użytkowników (posortowaną od najkrótszej kary do permanentnych) i umożliwia ich odblokowanie.",
-          "usage": "/unblock",
           "requiredPermission": "administrator"
         },
         {


### PR DESCRIPTION
## Summary
Refactored the admin command structure by removing standalone slash commands (`/info`, `/ocr-on-off`, `/limit`, `/remove`, `/unblock`, `/tokens`) and consolidating all admin operations into a unified **Admin Panel** accessible through the `/configure` command. This simplifies the command interface while maintaining all functionality through an organized button-based UI.

## Key Changes

### Command Structure
- **Removed slash commands:** `/info`, `/ocr-on-off`, `/limit`, `/remove`, `/unblock`, `/tokens`
- **Retained slash commands:** `/configure`, `/ranking`, `/subscribe`, `/test`, `/update`
- All admin operations now accessible via `/configure` → `⚙️ Panel Admina` button

### Admin Panel Implementation
- Added `_buildAdminPanel()` method that creates a role-based UI:
  - **Admin mode:** Remove player, Unblock user, View AI tokens
  - **Head Admin mode** (users in `ENDERSECHO_BLOCK_OCR_USER_IDS`): All admin features + Send Info, OCR on/off, Daily Limit
- Implemented dedicated handlers for each panel operation:
  - `_handlePanelRemove()` / `_handlePanelRemoveSelect()` / `_handlePanelRemoveConfirm()` — player removal with confirmation
  - `_handlePanelUnblock()` — blocked user management
  - `_handlePanelTokens()` — AI token usage statistics
  - `_handlePanelOcr()` / `_handlePanelOcrGuildSelect()` / `_handlePanelOcrAction()` — per-guild OCR toggle
  - Panel info modal and limit modal handlers

### UI/UX Improvements
- Added `⚙️ Panel Admina` button to `/configure` dashboard (last row)
- Consistent navigation with `◀️ Powrót` (Back) buttons throughout panel
- `◀️ Wróć do konfiguracji` button returns to configure wizard
- Updated help text in channel selection step to reference Admin Panel instead of individual commands

### Permission Model
- Unified permission check: `_isHeadAdmin()` uses `config.blockOcrUserIds`
- Removed separate `ENDERSECHO_INFO_USER_ID` env variable (consolidated into `blockOcrUserIds`)
- Admin operations require Discord Administrator permission; head admin features require `blockOcrUserIds` membership

### CustomID Routing
- Added comprehensive button/select handlers for all panel operations:
  - `cfg_admin_panel` — open panel from configure
  - `panel_*` — all panel-specific operations
  - Proper state management with `_configWizard` for wizard persistence

### Documentation
- Updated `CLAUDE.md` with complete Admin Panel specification
- Updated `all_commands.json` to reflect new command structure
- Removed references to standalone admin commands

## Implementation Details
- Panel state is ephemeral (not persisted) — users navigate via button interactions
- All underlying services (`rankingService`, `userBlockService`, `ocrBlockService`, etc.) remain unchanged
- Backward compatibility maintained for all data persistence (guild configs, user blocks, token usage)
- Head admin check uses existing `blockOcrUserIds` configuration for consistency

https://claude.ai/code/session_01PfrTmSbEqGUP164XtFFTzL