### PR TITLE
Improve fake photo detection in OCR score validation

### DIFF
--- a/EndersEcho/services/aiOcrService.js
+++ b/EndersEcho/services/aiOcrService.js
@@ -275,9 +275,15 @@ Odpowiedz WYŁĄCZNIE w tym formacie (3 linie, nic więcej):
         let total = null;
         if (lines.length >= 3) {
             total = this.normalizeScore(lines[2].replace(/^total[:\s]*/i, '').trim(), log);
+            if (total === null) {
+                return { bossName: null, score: null, confidence: 0, isValidVictory: false, error: 'FAKE_PHOTO' };
+            }
         }
 
         score = this.normalizeScore(score, log);
+        if (score === null) {
+            return { bossName: null, score: null, confidence: 0, isValidVictory: false, error: 'FAKE_PHOTO' };
+        }
         if (score && total) {
             const corrected = this.validateScoreAgainstTotal(score, total, log);
             if (corrected === null) {
@@ -346,7 +352,10 @@ Odpowiedz WYŁĄCZNIE w tym formacie (3 linie, nic więcej):
             }
             if (decimalPart) {
                 const maxDec = integerPart.length === 1 ? 2 : 1;
-                if (decimalPart.length > maxDec) decimalPart = decimalPart.substring(0, maxDec);
+                if (decimalPart.length > maxDec) {
+                    log.warn(`[AI OCR] normalizeScore: "${originalScore}" za dużo miejsc po przecinku (${decimalPart.length} > ${maxDec}) — odrzucam jako podróbkę`);
+                    return null;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
Enhanced the OCR service's fake photo detection by adding stricter validation for score parsing and decimal precision. The changes ensure that malformed or suspicious score data is properly rejected with a `FAKE_PHOTO` error.

## Key Changes
- Added null checks after `normalizeScore()` calls to catch invalid score data and return early with `FAKE_PHOTO` error
- Enhanced decimal precision validation in `normalizeScore()` to reject scores with excessive decimal places (more than 2 for single-digit integers, more than 1 for multi-digit integers)
- Added warning log when a score is rejected due to too many decimal places, indicating potential photo forgery

## Implementation Details
- When either the main score or total score fails to normalize, the function now returns a validation failure response instead of continuing with invalid data
- The decimal validation now returns `null` (indicating invalid score) rather than silently truncating, which triggers the new null checks upstream
- Added descriptive Polish warning message to help identify when scores are rejected for decimal precision violations

https://claude.ai/code/session_01Xgee7fcMGbXRC6ykrnLbRb