### PR TITLE
Translate compare-template prompt to English and bump to v4

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -55,9 +55,10 @@
        - **KROK 3:** Wyciąga nazwę bossa, wynik (Best) i Total (500 tokenów)
      - **Walidacja score vs Total:** Jeśli odczytany Best > Total → automatyczna korekta
      - Zalety: 100% pewność walidacji, fallback na tradycyjny OCR
-   - **Komenda /update (wszyscy, wymaga AI OCR):** Używa `analyzeTestImage()` — weryfikacja wzorcem + ekstrakcja:
-     - **KROK 1:** Porównanie z wzorcem `files/Wzór.jpg` — jeden request z dwoma obrazami (10 tokenów)
-     - **KROK 2:** Ekstrakcja danych (boss + score) — bez sprawdzania Victory i autentyczności (500 tokenów)
+   - **Komenda /update (wszyscy, wymaga AI OCR):** Używa `analyzeTestImage()` — weryfikacja wzorcem + autentyczność + ekstrakcja:
+     - **KROK 1:** Porównanie z wzorcem `files/Wzór.jpg` — jeden request z dwoma obrazami (~10 tokenów)
+     - **KROK 2:** Weryfikacja autentyczności — ten sam prompt co w regularnym flow (`_checkAuthentic`), wykrywa AI-generated i edytowane screeny (~20 tokenów). Wynik: OK → dalej, NOK → `FAKE_PHOTO`
+     - **KROK 3:** Ekstrakcja danych (boss + score) — (~500 tokenów)
      - Gdy screen niepodobny do wzorca → embed `testNotSimilarTitle/Description` (brak zapisu)
      - Po udanej weryfikacji: pełny flow — zapis do rankingu, aktualizacja ról TOP, powiadomienia Global Top 3, powiadomienia DM
      - Wymaga `USE_ENDERSECHO_AI_OCR=true`; gdy AI wyłączone → ephemeral `testAiOcrRequired`
@@ -394,7 +395,7 @@ Wspólny wzorzec opisany w głównym [CLAUDE.md § 7](../CLAUDE.md). Tutaj tylko
 
 - **`/test` jako dry-run `/update`.** Oba handlery delegują do `_runUpdateFlow`; różnice wyłącznie w `dryRun` (ephemeral output, brak zapisu/ról/powiadomień), `commandName` (→ `hints.command`, logi, klucz blokady OCR) i uprawnieniach wejściowych (`/test` wymaga wpisu w `ENDERSECHO_BLOCK_OCR_USER_IDS`). Ten sam prompt wzorca (`compare-template`), ten sam `analyzeTestImage()`, ten sam Operations Gateway, ten sam `tokenUsageService` i `usageLimitService`. Padnięcie Gemini w obu komendach = błąd dla usera (brak fallbacku na Tesseract).
 - **`usageLimitService`** — lokalny dzienny limit per user (`data/usage_limits.json`), działa równolegle do quota w API.
-- **`PROMPT_VERSIONS`** w [services/aiOcrService.js:15-24](services/aiOcrService.js#L15-L24) — 6 wpisów: `victory-check-eng`, `victory-check-jpn`, `authenticity-check`, `extract-data-eng`, `extract-data-jpn`, `compare-template`. Po zmianie treści promptu bump wersji (`'v1'` → `'v2'`) — stare trace zostają w Langfuse do porównania.
+- **`PROMPT_VERSIONS`** w [services/aiOcrService.js:15-24](services/aiOcrService.js#L15-L24) — 6 wpisów: `victory-check-eng` (v1), `victory-check-jpn` (v1), `authenticity-check` (**v2** — przepisany prompt z 3 obszarami: cyfry score, artefakty AI-generation, artefakty edycji), `extract-data-eng` (v1), `extract-data-jpn` (v1), `compare-template` (v3). Po zmianie treści promptu bump wersji — stare trace zostają w Langfuse do porównania.
 - **Model Gemini** dla wszystkich promptów ten sam: z `ENDERSECHO_GOOGLE_AI_MODEL` (default: `gemini-2.5-flash-preview-05-20`).
 
 ### A/B testing

--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -55,10 +55,9 @@
        - **KROK 3:** Wyciąga nazwę bossa, wynik (Best) i Total (500 tokenów)
      - **Walidacja score vs Total:** Jeśli odczytany Best > Total → automatyczna korekta
      - Zalety: 100% pewność walidacji, fallback na tradycyjny OCR
-   - **Komenda /update (wszyscy, wymaga AI OCR):** Używa `analyzeTestImage()` — weryfikacja wzorcem + autentyczność + ekstrakcja:
-     - **KROK 1:** Porównanie z wzorcem `files/Wzór.jpg` — jeden request z dwoma obrazami (~10 tokenów)
-     - **KROK 2:** Weryfikacja autentyczności — ten sam prompt co w regularnym flow (`_checkAuthentic`), wykrywa AI-generated i edytowane screeny (~20 tokenów). Wynik: OK → dalej, NOK → `FAKE_PHOTO`
-     - **KROK 3:** Ekstrakcja danych (boss + score) — (~500 tokenów)
+   - **Komenda /update (wszyscy, wymaga AI OCR):** Używa `analyzeTestImage()` — weryfikacja wzorcem + ekstrakcja:
+     - **KROK 1:** Porównanie z wzorcem `files/Wzór.jpg` — jeden request z dwoma obrazami (10 tokenów)
+     - **KROK 2:** Ekstrakcja danych (boss + score) — bez sprawdzania Victory i autentyczności (500 tokenów)
      - Gdy screen niepodobny do wzorca → embed `testNotSimilarTitle/Description` (brak zapisu)
      - Po udanej weryfikacji: pełny flow — zapis do rankingu, aktualizacja ról TOP, powiadomienia Global Top 3, powiadomienia DM
      - Wymaga `USE_ENDERSECHO_AI_OCR=true`; gdy AI wyłączone → ephemeral `testAiOcrRequired`
@@ -395,7 +394,7 @@ Wspólny wzorzec opisany w głównym [CLAUDE.md § 7](../CLAUDE.md). Tutaj tylko
 
 - **`/test` jako dry-run `/update`.** Oba handlery delegują do `_runUpdateFlow`; różnice wyłącznie w `dryRun` (ephemeral output, brak zapisu/ról/powiadomień), `commandName` (→ `hints.command`, logi, klucz blokady OCR) i uprawnieniach wejściowych (`/test` wymaga wpisu w `ENDERSECHO_BLOCK_OCR_USER_IDS`). Ten sam prompt wzorca (`compare-template`), ten sam `analyzeTestImage()`, ten sam Operations Gateway, ten sam `tokenUsageService` i `usageLimitService`. Padnięcie Gemini w obu komendach = błąd dla usera (brak fallbacku na Tesseract).
 - **`usageLimitService`** — lokalny dzienny limit per user (`data/usage_limits.json`), działa równolegle do quota w API.
-- **`PROMPT_VERSIONS`** w [services/aiOcrService.js:15-24](services/aiOcrService.js#L15-L24) — 6 wpisów: `victory-check-eng` (v1), `victory-check-jpn` (v1), `authenticity-check` (**v2** — przepisany prompt z 3 obszarami: cyfry score, artefakty AI-generation, artefakty edycji), `extract-data-eng` (v1), `extract-data-jpn` (v1), `compare-template` (v3). Po zmianie treści promptu bump wersji — stare trace zostają w Langfuse do porównania.
+- **`PROMPT_VERSIONS`** w [services/aiOcrService.js:15-24](services/aiOcrService.js#L15-L24) — 6 wpisów: `victory-check-eng` (v1), `victory-check-jpn` (v1), `authenticity-check` (v1), `extract-data-eng` (v1), `extract-data-jpn` (v1), `compare-template` (**v4** — prompt przetłumaczony na angielski). Po zmianie treści promptu bump wersji — stare trace zostają w Langfuse do porównania.
 - **Model Gemini** dla wszystkich promptów ten sam: z `ENDERSECHO_GOOGLE_AI_MODEL` (default: `gemini-2.5-flash-preview-05-20`).
 
 ### A/B testing

--- a/EndersEcho/services/aiOcrService.js
+++ b/EndersEcho/services/aiOcrService.js
@@ -19,7 +19,7 @@ const SAFETY_SETTINGS_OFF = [
 const PROMPT_VERSIONS = {
     'victory-check-eng':  'v1',
     'victory-check-jpn':  'v1',
-    'authenticity-check': 'v1',
+    'authenticity-check': 'v2',
     'extract-data-eng':   'v1',
     'extract-data-jpn':   'v1',
     'compare-template':   'v3',
@@ -169,36 +169,54 @@ class AIOCRService {
     }
 
     async _checkAuthentic(base64Image, mediaType, telemetryMeta) {
-        const prompt = `Przeprowadź ABSOLUTNIE DOKŁADNĄ weryfikację zdjęcia ze SZCZEGÓLNYM naciskiem na:
-DOKŁADNĄ ANALIZĘ LICZB
-Sprawdzenie KAŻDEGO piksela w cyfrach
-Analiza spójności czcionkiWE WSZYSTKICH ZNAKACH
-SZCZEGÓLNA UWAGA na cyfry po przecinku
-Porównanie WSZYSTKICH znaków z oficjalnym interfejsem gry
-KLUCZOWE KRYTERIA WERYFIKACJI
-Czy KAŻDY piksel jest 100% zgodny z oryginalnym interfejsem
-Czy liczby wyglądają IDEALNIE symetrycznie
-Czy po przecinku nie ma JAKICHKOLWIEK oznak edycji
-METODOLOGIA SPRAWDZENIA
-Porównaj KAŻDY element z wzorcem oryginalnego interfejsu
-Zwróć uwagę na NAJMNIEJSZE rozbieżności
-Sprawdź KAŻDĄ literę i cyfrę pod kątem zgodności
-Sprawdz czy dostało coś dopisane odręcznie.
-INSTRUKCJA WYKONANIA:
-Jeśli zauważysz JAKĄKOLWIEK ingerencję - napisz tylko jednym słowem "NOK".
-Jeśli ABSOLUTNIE WSZYSTKO jest oryginalne - napisz tylko jednym słowem "OK"`;
+        const prompt = `Determine if this image is a REAL mobile game screenshot or a FAKE (AI-generated or photo-edited).
+
+A genuine mobile game screenshot has these properties:
+— Pixel-perfect, razor-sharp text with clean edges everywhere — no blur, no glow, no softness
+— UI elements (buttons, borders, icons) are geometrically exact: perfectly straight lines, precise symmetry
+— Flat, engine-rendered colors and gradients — NOT painterly, photographic or hand-drawn
+— All text and numbers rendered in a single uniform style throughout the entire screen
+
+EXAMINE THESE THREE AREAS:
+
+[AREA 1 — SCORE NUMBERS: "Best" and "Total" values]
+This is where cheaters make edits. Check each digit individually:
+• Do ALL digits in "Best" have the exact same font weight, sharpness and pixel density?
+• Do ALL digits in "Total" look identical in rendering quality to the "Best" digits?
+• Does ANY single digit appear subtly brighter, softer, blurrier or a different shade than the digits next to it?
+• Does the unit suffix (K / M / B / T / Q / Qi / Sx) match the exact rendering style of the digits?
+• Is there any halo, glow or shadow artifact around any individual digit that is not present around others?
+
+[AREA 2 — AI GENERATION SIGNALS]
+These artifacts appear in images created by Midjourney, DALL-E, Stable Diffusion, Gemini Image etc.:
+• Text or numbers with soft/glowing/blurred edges (real UI text is always hard-edged)
+• UI background that looks photographic, painted, or has organic texture instead of flat game graphics
+• Buttons, banners or borders with slightly curved or irregular edges instead of perfect geometry
+• "Noise", "grain" or texture visible around text or at UI element edges
+• Any element that looks "illustrated" or "artistic" rather than rendered by a game engine
+
+[AREA 3 — PHOTO EDITING SIGNALS]
+These artifacts appear in screenshots edited with Photoshop, GIMP, etc.:
+• Any region of the image that is noticeably sharper or blurrier than surrounding areas
+• A digit or group of digits where the JPEG compression block pattern differs from adjacent digits
+• Color fringing or a subtle "halo" effect around specific numbers suggesting they were pasted in
+• Inconsistent pixel density between the score area and other text on the screen
+
+RESPOND WITH EXACTLY ONE OF (no other words, no explanation):
+OK
+NOK: <reason in Polish, max 5 words>`;
 
         const res = await this._generateContent([
             { inlineData: { data: base64Image, mimeType: mediaType } },
             { text: prompt }
-        ], 10, {
+        ], 20, {
             ...telemetryMeta,
             step: 'authenticity-check',
             promptName: 'authenticity-check',
             promptVersion: PROMPT_VERSIONS['authenticity-check'],
         });
 
-        return { isAuthentic: !res.text.trim().toUpperCase().includes('NOK'), usage: res };
+        return { isAuthentic: !res.text.trim().toUpperCase().startsWith('NOK'), usage: res };
     }
 
     async _extractData(base64Image, mediaType, lang, telemetryMeta) {
@@ -425,6 +443,17 @@ Odpowiedz WYŁĄCZNIE w tym formacie (3 linie, nic więcej):
             if (!isSimilar) {
                 return { bossName: null, score: null, confidence: 0, isValidVictory: false, error: 'NOT_SIMILAR', rejectionReason, tokenUsage };
             }
+
+            const { isAuthentic, usage: u2 } = await this._checkAuthentic(uploadedBase64, mediaType, telemetryMeta);
+            tokenUsage.promptTokens  += u2.promptTokens;
+            tokenUsage.outputTokens  += u2.outputTokens;
+            tokenUsage.thoughtTokens += u2.thoughtTokens;
+
+            if (!isAuthentic) {
+                log.warn(`[AI Test] Autentyczność: ✗ → FAKE_PHOTO`);
+                return { bossName: null, score: null, confidence: 0, isValidVictory: false, error: 'FAKE_PHOTO', tokenUsage };
+            }
+            log.info(`[AI Test] Autentyczność: ✓`);
 
             const extractRes = await this._extractData(uploadedBase64, mediaType, 'eng', telemetryMeta);
             tokenUsage.promptTokens  += extractRes.promptTokens;

--- a/EndersEcho/services/aiOcrService.js
+++ b/EndersEcho/services/aiOcrService.js
@@ -19,10 +19,10 @@ const SAFETY_SETTINGS_OFF = [
 const PROMPT_VERSIONS = {
     'victory-check-eng':  'v1',
     'victory-check-jpn':  'v1',
-    'authenticity-check': 'v2',
+    'authenticity-check': 'v1',
     'extract-data-eng':   'v1',
     'extract-data-jpn':   'v1',
-    'compare-template':   'v3',
+    'compare-template':   'v4',
 };
 const sharp = require('sharp');
 const { createBotLogger } = require('../../utils/consoleLogger');
@@ -169,54 +169,36 @@ class AIOCRService {
     }
 
     async _checkAuthentic(base64Image, mediaType, telemetryMeta) {
-        const prompt = `Determine if this image is a REAL mobile game screenshot or a FAKE (AI-generated or photo-edited).
-
-A genuine mobile game screenshot has these properties:
-— Pixel-perfect, razor-sharp text with clean edges everywhere — no blur, no glow, no softness
-— UI elements (buttons, borders, icons) are geometrically exact: perfectly straight lines, precise symmetry
-— Flat, engine-rendered colors and gradients — NOT painterly, photographic or hand-drawn
-— All text and numbers rendered in a single uniform style throughout the entire screen
-
-EXAMINE THESE THREE AREAS:
-
-[AREA 1 — SCORE NUMBERS: "Best" and "Total" values]
-This is where cheaters make edits. Check each digit individually:
-• Do ALL digits in "Best" have the exact same font weight, sharpness and pixel density?
-• Do ALL digits in "Total" look identical in rendering quality to the "Best" digits?
-• Does ANY single digit appear subtly brighter, softer, blurrier or a different shade than the digits next to it?
-• Does the unit suffix (K / M / B / T / Q / Qi / Sx) match the exact rendering style of the digits?
-• Is there any halo, glow or shadow artifact around any individual digit that is not present around others?
-
-[AREA 2 — AI GENERATION SIGNALS]
-These artifacts appear in images created by Midjourney, DALL-E, Stable Diffusion, Gemini Image etc.:
-• Text or numbers with soft/glowing/blurred edges (real UI text is always hard-edged)
-• UI background that looks photographic, painted, or has organic texture instead of flat game graphics
-• Buttons, banners or borders with slightly curved or irregular edges instead of perfect geometry
-• "Noise", "grain" or texture visible around text or at UI element edges
-• Any element that looks "illustrated" or "artistic" rather than rendered by a game engine
-
-[AREA 3 — PHOTO EDITING SIGNALS]
-These artifacts appear in screenshots edited with Photoshop, GIMP, etc.:
-• Any region of the image that is noticeably sharper or blurrier than surrounding areas
-• A digit or group of digits where the JPEG compression block pattern differs from adjacent digits
-• Color fringing or a subtle "halo" effect around specific numbers suggesting they were pasted in
-• Inconsistent pixel density between the score area and other text on the screen
-
-RESPOND WITH EXACTLY ONE OF (no other words, no explanation):
-OK
-NOK: <reason in Polish, max 5 words>`;
+        const prompt = `Przeprowadź ABSOLUTNIE DOKŁADNĄ weryfikację zdjęcia ze SZCZEGÓLNYM naciskiem na:
+DOKŁADNĄ ANALIZĘ LICZB
+Sprawdzenie KAŻDEGO piksela w cyfrach
+Analiza spójności czcionkiWE WSZYSTKICH ZNAKACH
+SZCZEGÓLNA UWAGA na cyfry po przecinku
+Porównanie WSZYSTKICH znaków z oficjalnym interfejsem gry
+KLUCZOWE KRYTERIA WERYFIKACJI
+Czy KAŻDY piksel jest 100% zgodny z oryginalnym interfejsem
+Czy liczby wyglądają IDEALNIE symetrycznie
+Czy po przecinku nie ma JAKICHKOLWIEK oznak edycji
+METODOLOGIA SPRAWDZENIA
+Porównaj KAŻDY element z wzorcem oryginalnego interfejsu
+Zwróć uwagę na NAJMNIEJSZE rozbieżności
+Sprawdź KAŻDĄ literę i cyfrę pod kątem zgodności
+Sprawdz czy dostało coś dopisane odręcznie.
+INSTRUKCJA WYKONANIA:
+Jeśli zauważysz JAKĄKOLWIEK ingerencję - napisz tylko jednym słowem "NOK".
+Jeśli ABSOLUTNIE WSZYSTKO jest oryginalne - napisz tylko jednym słowem "OK"`;
 
         const res = await this._generateContent([
             { inlineData: { data: base64Image, mimeType: mediaType } },
             { text: prompt }
-        ], 20, {
+        ], 10, {
             ...telemetryMeta,
             step: 'authenticity-check',
             promptName: 'authenticity-check',
             promptVersion: PROMPT_VERSIONS['authenticity-check'],
         });
 
-        return { isAuthentic: !res.text.trim().toUpperCase().startsWith('NOK'), usage: res };
+        return { isAuthentic: !res.text.trim().toUpperCase().includes('NOK'), usage: res };
     }
 
     async _extractData(base64Image, mediaType, lang, telemetryMeta) {
@@ -444,17 +426,6 @@ Odpowiedz WYŁĄCZNIE w tym formacie (3 linie, nic więcej):
                 return { bossName: null, score: null, confidence: 0, isValidVictory: false, error: 'NOT_SIMILAR', rejectionReason, tokenUsage };
             }
 
-            const { isAuthentic, usage: u2 } = await this._checkAuthentic(uploadedBase64, mediaType, telemetryMeta);
-            tokenUsage.promptTokens  += u2.promptTokens;
-            tokenUsage.outputTokens  += u2.outputTokens;
-            tokenUsage.thoughtTokens += u2.thoughtTokens;
-
-            if (!isAuthentic) {
-                log.warn(`[AI Test] Autentyczność: ✗ → FAKE_PHOTO`);
-                return { bossName: null, score: null, confidence: 0, isValidVictory: false, error: 'FAKE_PHOTO', tokenUsage };
-            }
-            log.info(`[AI Test] Autentyczność: ✓`);
-
             const extractRes = await this._extractData(uploadedBase64, mediaType, 'eng', telemetryMeta);
             tokenUsage.promptTokens  += extractRes.promptTokens;
             tokenUsage.outputTokens  += extractRes.outputTokens;
@@ -484,35 +455,33 @@ Odpowiedz WYŁĄCZNIE w tym formacie (3 linie, nic więcej):
                 'NOK: Panel posiada ikonę zamknięcia (X)',
                 'NOK: Brak żółtego przycisku pod panelem',
               ];
-        const prompt = `Masz wzorzec ekranu referencyjnego. Sprawdź czy drugie zdjęcie
-pasuje DO TEGO WZORCA.
+        const prompt = `You have a reference screen. Check whether the second image matches THIS REFERENCE.
 
-KROK 0 — Przed porównaniem: Odczytaj wszystkie napisy na zdjęciu, czy to w kolorze białym, szarym, zielonym. Przetłumacz mentalnie je wszystkie na obydwu
-zdjęciach na język angielski. Dopiero na przetłumaczonej wersji wykonaj poniższe
-sprawdzenie.
+STEP 0 — Before comparing: Read all text visible in both images (white, gray, green labels).
+Mentally translate everything to English. Then perform the check below on the translated version.
 
-WZORZEC (pierwsze zdjęcie) ma DOKŁADNIE:
+THE REFERENCE (first image) has EXACTLY:
 
-  - pełnoekranowe tło z gameplayem
-  - centralny panel BEZ ikony X ani przycisku zamknięcia
-  - kolorowy baner na górze panelu (zaokrąglony, podobny do wstęgi)
-  - pod banerem: nazwa własna Bossa
-  - w centrum panelu: JEDNA duża ikona z liczbą
-  - poniżej: dwie linie statystyk (Best / Total)
-  - pod liniami statystyk: szary tekst z wynikiem Bossa
-  - na dole panelu: rząd różnych małych szarych ikon
-  - pod panelem: jeden żółty przycisk
+  - full-screen gameplay background
+  - a central panel with NO close (X) icon or close button
+  - a colored banner at the top of the panel (rounded, ribbon-like)
+  - below the banner: the Boss's proper name
+  - in the center of the panel: ONE large icon with a number
+  - below that: two stat lines (Best / Total)
+  - below the stat lines: gray text showing the Boss result
+  - at the bottom of the panel: a row of various small gray icons
+  - below the panel: one yellow button
 
-Format odpowiedzi:
+Response format:
 
-  - Jeśli drugie zdjęcie pasuje do wzorca ORAZ szary tekst z wynikiem Bossa jest
-    identyczny na obu zdjęciach → odpowiedz TYLKO: OK
-  - Jeśli cokolwiek się różni strukturalnie LUB szary tekst z wynikiem Bossa
-    jest różny → odpowiedz TYLKO: NOK: <short reason in ${reasonLang}, max 5 words>
+  - If the second image matches the reference AND the gray Boss result text is
+    identical on both images → respond ONLY: OK
+  - If anything differs structurally OR the gray Boss result text is different
+    → respond ONLY: NOK: <short reason in ${reasonLang}, max 5 words>
 
-Przykłady prawidłowych odpowiedzi: OK ${exampleReasons.join('\n')}
+Valid response examples: OK ${exampleReasons.join('\n')}
 
-**ZASADA BEZWZGLĘDNA: Odpowiedz TYLKO w formacie OK lub NOK: <powód>. Zero innych słów.**`;
+**ABSOLUTE RULE: Respond ONLY in the format OK or NOK: <reason>. Zero other words.**`;
 
         const res = await this._generateContent([
             { inlineData: { data: wzorBase64, mimeType: mediaType } },


### PR DESCRIPTION
## Summary
Translated the `compare-template` prompt from Polish to English and incremented its version from v3 to v4 in the prompt versioning system. This improves consistency across the codebase and ensures proper tracking in Langfuse for A/B testing.

## Key Changes
- **Prompt translation**: Converted the entire `compare-template` prompt from Polish to English, including:
  - Instructions and step descriptions
  - Reference template specifications
  - Response format guidelines
  - Examples and absolute rules
  
- **Version bump**: Updated `PROMPT_VERSIONS['compare-template']` from `'v3'` to `'v4'` to track this significant prompt change

- **Documentation update**: Updated CLAUDE.md to reflect that `compare-template` now uses v4 and note that the prompt was translated to English

## Implementation Details
The prompt maintains the same logical structure and validation rules while being fully translated to English. This change:
- Aligns with the multilingual nature of the application (which already handles both English and Japanese prompts)
- Ensures consistent prompt versioning for Langfuse tracing and comparison
- Preserves all validation logic for Boss screen template matching (checking for panel structure, stat lines, gray result text, etc.)

https://claude.ai/code/session_01DRgs2BmTtyw5DrpJDm1nxn