### PR TITLE
Bezpieczeństwo i wydajność: EndersEcho + Stalker Bot

### DIFF
--- a/Stalker/handlers/interactionHandlers.js
+++ b/Stalker/handlers/interactionHandlers.js
@@ -8788,8 +8788,10 @@ async function handlePlayerCompareCommand(interaction, sharedState) {
         addResult(lifePts2, lifePts1); // odwrócone: mniej kar = lepiej
 
         // Wczytaj ostatnie dane bojowe z Gary dla obu graczy (do wyświetlenia w polach i porównania)
-        const _cmpCombat1 = loadCombatHistory(userInfo1.userId);
-        const _cmpCombat2 = loadCombatHistory(userInfo2.userId);
+        const [_cmpCombat1, _cmpCombat2] = await Promise.all([
+            loadCombatHistory(userInfo1.userId),
+            loadCombatHistory(userInfo2.userId),
+        ]);
         const _cmpLast1 = _cmpCombat1.length > 0 ? _cmpCombat1[_cmpCombat1.length - 1] : null;
         const _cmpLast2 = _cmpCombat2.length > 0 ? _cmpCombat2[_cmpCombat2.length - 1] : null;
 
@@ -9678,7 +9680,7 @@ async function handlePlayerStatusCommand(interaction, sharedState) {
         description += `🌍 **Pozycja w strukturach:** ${globalPosition > 0 ? `${globalPosition}/${totalPlayers}` : 'Brak danych'}\n\n`;
 
         // Wczytaj dane bojowe z Gary (RC+<:II_TransmuteCore:1458440558602092647>TC, Atak) - potrzebne do sekcji STATYSTYKI
-        const _statCombatHistory = loadCombatHistory(userId);
+        const _statCombatHistory = await loadCombatHistory(userId);
         const _statLastCombat = _statCombatHistory.length > 0
             ? _statCombatHistory[_statCombatHistory.length - 1]
             : null;
@@ -9942,7 +9944,7 @@ async function handlePlayerStatusCommand(interaction, sharedState) {
             }
 
             // Wykresy RC+<:II_TransmuteCore:1458440558602092647>TC i Atak z historii Gary (lokalna baza Stalkera — zaindeksowana po userId)
-            const combatHistory = loadCombatHistory(userId);
+            const combatHistory = await loadCombatHistory(userId);
             if (combatHistory.length >= 2) {
                 const [rcBuf, atkBuf] = await Promise.all([
                     generateCombatChart(combatHistory, latestNick, 'relicCores', 'RC+TC', '#43B581', v => String(v)),
@@ -10729,7 +10731,7 @@ async function showClanProgress(interaction, selectedClan, sharedState) {
         }
 
         // Wczytaj historię klanu z Gary snapshots (rank, RC+TC, atak)
-        const clanGuildHistory = loadClanGuildHistory(selectedClan, config);
+        const clanGuildHistory = await loadClanGuildHistory(selectedClan, config);
 
         if (clanGuildHistory.length >= 2) {
             try {
@@ -13407,13 +13409,13 @@ async function generateCompareClanRankingChart(rankData1, rankData2, name1, name
  * @param {string} userId - Discord user ID gracza
  * @returns {Array<{weekNumber, year, attack, relicCores}>}
  */
-function loadCombatHistory(userId) {
-    const fs = require('fs');
+async function loadCombatHistory(userId) {
+    const fsAsync = require('fs').promises;
     const path = require('path');
     try {
         const filePath = path.join(__dirname, '../data/player_combat_discord.json');
-        if (!fs.existsSync(filePath)) return [];
-        const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        const raw = await fsAsync.readFile(filePath, 'utf8');
+        const data = JSON.parse(raw);
         const entry = data?.players?.[userId];
         if (entry?.weeks?.length) return entry.weeks.slice(-20);
         return [];
@@ -13428,40 +13430,47 @@ function loadCombatHistory(userId) {
  * @param {Object} config - Konfiguracja z garyGuildIds
  * @returns {Array<{weekNumber, year, rank, relicCores, attack}>}
  */
-function loadClanGuildHistory(clanKey, config) {
-    const fs = require('fs');
+async function loadClanGuildHistory(clanKey, config) {
+    const fsAsync = require('fs').promises;
     const path = require('path');
     try {
         const guildsDir = path.join(__dirname, '../../shared_data/lme_guilds');
-        if (!fs.existsSync(guildsDir)) return [];
 
         const garyGuildId = config.garyGuildIds?.[clanKey];
         if (garyGuildId == null) return [];
 
-        const dirEntries = fs.readdirSync(guildsDir);
+        let dirEntries;
+        try {
+            dirEntries = await fsAsync.readdir(guildsDir);
+        } catch (_) {
+            return [];
+        }
+
         const weekFiles = dirEntries
             .filter(f => f.startsWith('week_') && f.endsWith('.json'))
             .sort();
 
-        const history = [];
-        for (const file of weekFiles) {
-            try {
-                const filePath = path.join(guildsDir, file);
-                const snapshot = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-                const guild = (snapshot.guilds || []).find(g => g.id === garyGuildId);
+        // Wczytaj pliki równolegle
+        const results = await Promise.allSettled(
+            weekFiles.map(file =>
+                fsAsync.readFile(path.join(guildsDir, file), 'utf8')
+                    .then(raw => JSON.parse(raw))
+            )
+        );
 
-                if (guild) {
-                    history.push({
-                        weekNumber: snapshot.weekNumber,
-                        year: snapshot.year,
-                        rank: guild.rank || null,
-                        relicCores: guild.totalRelicCores || 0,
-                        attack: guild.totalPower || 0
-                    });
-                }
-            } catch (_) {
-                // Pomiń uszkodzone pliki
-                continue;
+        const history = [];
+        for (const result of results) {
+            if (result.status !== 'fulfilled') continue;
+            const snapshot = result.value;
+            const guild = (snapshot.guilds || []).find(g => g.id === garyGuildId);
+            if (guild) {
+                history.push({
+                    weekNumber: snapshot.weekNumber,
+                    year: snapshot.year,
+                    rank: guild.rank || null,
+                    relicCores: guild.totalRelicCores || 0,
+                    attack: guild.totalPower || 0
+                });
             }
         }
 

--- a/Stalker/services/garyCombatIngestionService.js
+++ b/Stalker/services/garyCombatIngestionService.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
 const { safeFetchMembers } = require('../../utils/guildMembersThrottle');
 const { isoWeekStartUTC } = require('../../utils/appSync');
@@ -143,12 +143,14 @@ class GaryCombatIngestionService {
     async ingest() {
         try {
             // Agreguj dane ze wszystkich plików weekly (shared_data/lme_weekly/week_YYYY_WW.json)
-            if (!fs.existsSync(WEEKLY_DIR)) {
+            const weeklyDirExists = await fs.access(WEEKLY_DIR).then(() => true).catch(() => false);
+            if (!weeklyDirExists) {
                 this.logger.info('📊 GaryCombatIngestion: brak katalogu shared_data/lme_weekly — uruchom /lme-snapshot w Gary');
                 return { matched: 0, total: 0, unmatchedGary: [], clanMembersWithoutData: [] };
             }
 
-            const weekFiles = fs.readdirSync(WEEKLY_DIR)
+            const allEntries = await fs.readdir(WEEKLY_DIR);
+            const weekFiles = allEntries
                 .filter(f => f.startsWith('week_') && f.endsWith('.json'))
                 .sort(); // week_YYYY_WW — sortowanie leksykograficzne = chronologiczne
 
@@ -157,16 +159,22 @@ class GaryCombatIngestionService {
                 return { matched: 0, total: 0, unmatchedGary: [], clanMembersWithoutData: [] };
             }
 
+            // Wczytaj wszystkie pliki weekly równolegle
+            const weeklyResults = await Promise.allSettled(
+                weekFiles.map(file =>
+                    fs.readFile(path.join(WEEKLY_DIR, file), 'utf8')
+                        .then(raw => ({ file, data: JSON.parse(raw) }))
+                )
+            );
+
             // Zbuduj strukturę garyData agregując wszystkie tygodnie
             const garyData = { players: {} };
-            for (const file of weekFiles) {
-                let weekData;
-                try {
-                    weekData = JSON.parse(fs.readFileSync(path.join(WEEKLY_DIR, file), 'utf8'));
-                } catch (_) {
-                    this.logger.warn(`GaryCombatIngestion: pominięto uszkodzony plik ${file}`);
+            for (const result of weeklyResults) {
+                if (result.status === 'rejected') {
+                    this.logger.warn(`GaryCombatIngestion: pominięto uszkodzony plik (${result.reason?.message})`);
                     continue;
                 }
+                const weekData = result.value.data;
                 if (!weekData?.players || !weekData.weekNumber || !weekData.year) continue;
 
                 for (const [key, player] of Object.entries(weekData.players)) {
@@ -200,13 +208,12 @@ class GaryCombatIngestionService {
 
             // Wczytaj istniejące dane lokalne lub zacznij od zera
             let localData = { players: {}, lastUpdated: '' };
-            if (fs.existsSync(LOCAL_COMBAT_FILE)) {
-                try {
-                    localData = JSON.parse(fs.readFileSync(LOCAL_COMBAT_FILE, 'utf8'));
-                    if (!localData.players) localData.players = {};
-                } catch (_) {
-                    localData = { players: {} };
-                }
+            try {
+                const raw = await fs.readFile(LOCAL_COMBAT_FILE, 'utf8');
+                localData = JSON.parse(raw);
+                if (!localData.players) localData.players = {};
+            } catch (_) {
+                localData = { players: {}, lastUpdated: '' };
             }
 
             const playerNames = Object.keys(garyData.players);
@@ -310,9 +317,8 @@ class GaryCombatIngestionService {
 
             localData.lastUpdated = new Date().toISOString();
 
-            const dir = path.dirname(LOCAL_COMBAT_FILE);
-            if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-            fs.writeFileSync(LOCAL_COMBAT_FILE, JSON.stringify(localData, null, 2), 'utf8');
+            await fs.mkdir(path.dirname(LOCAL_COMBAT_FILE), { recursive: true });
+            await fs.writeFile(LOCAL_COMBAT_FILE, JSON.stringify(localData, null, 2), 'utf8');
 
             // Po zapisie lokalnej bazy, mirroruj wszystkie (gracz × tydzień) do web API.
             // Endpoint jest idempotentny (natural key: discordId+year+weekNumber),

--- a/Stalker/services/phaseService.js
+++ b/Stalker/services/phaseService.js
@@ -3,7 +3,7 @@ const { createBotLogger } = require('../../utils/consoleLogger');
 const { safeFetchMembers } = require('../../utils/guildMembersThrottle');
 const fs = require('fs').promises;
 const path = require('path');
-const https = require('https');
+const { downloadDiscordImage } = require('../utils/helpers');
 
 const logger = createBotLogger('Stalker');
 
@@ -349,28 +349,11 @@ class PhaseService {
      */
     async downloadImage(url, sessionId, index) {
         await this.initTempDir();
-
         const filename = `${sessionId}_${index}_${Date.now()}.png`;
         const filepath = path.join(this.tempDir, filename);
-
-        return new Promise((resolve, reject) => {
-            https.get(url, (response) => {
-                const fileStream = require('fs').createWriteStream(filepath);
-                response.pipe(fileStream);
-
-                fileStream.on('finish', () => {
-                    fileStream.close();
-                    logger.info(`[PHASE1] 💾 Zapisano zdjęcie: ${filename}`);
-                    resolve(filepath);
-                });
-
-                fileStream.on('error', (err) => {
-                    reject(err);
-                });
-            }).on('error', (err) => {
-                reject(err);
-            });
-        });
+        await downloadDiscordImage(url, filepath);
+        logger.info(`[PHASE1] 💾 Zapisano zdjęcie: ${filename}`);
+        return filepath;
     }
 
     /**

--- a/Stalker/services/punishmentService.js
+++ b/Stalker/services/punishmentService.js
@@ -1,7 +1,7 @@
 const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, AttachmentBuilder } = require('discord.js');
 const fs = require('fs').promises;
 const path = require('path');
-const https = require('https');
+const { downloadDiscordImage } = require('../utils/helpers');
 
 const { createBotLogger } = require('../../utils/consoleLogger');
 const { safeFetchMembers } = require('../../utils/guildMembersThrottle');
@@ -623,28 +623,11 @@ class PunishmentService {
      */
     async downloadImage(url, sessionId, index) {
         await this.initTempDir();
-
         const filename = `${sessionId}_${index}_${Date.now()}.png`;
         const filepath = path.join(this.tempDir, filename);
-
-        return new Promise((resolve, reject) => {
-            https.get(url, (response) => {
-                const fileStream = require('fs').createWriteStream(filepath);
-                response.pipe(fileStream);
-
-                fileStream.on('finish', () => {
-                    fileStream.close();
-                    logger.info(`[PUNISH] 💾 Zapisano zdjęcie: ${filename}`);
-                    resolve(filepath);
-                });
-
-                fileStream.on('error', (err) => {
-                    reject(err);
-                });
-            }).on('error', (err) => {
-                reject(err);
-            });
-        });
+        await downloadDiscordImage(url, filepath);
+        logger.info(`[PUNISH] 💾 Zapisano zdjęcie: ${filename}`);
+        return filepath;
     }
 
     /**

--- a/Stalker/services/reminderService.js
+++ b/Stalker/services/reminderService.js
@@ -2,7 +2,7 @@ const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, AttachmentBu
 const messages = require('../config/messages');
 const fs = require('fs').promises;
 const path = require('path');
-const https = require('https');
+const { downloadDiscordImage } = require('../utils/helpers');
 
 const { createBotLogger } = require('../../utils/consoleLogger');
 const { safeFetchMembers } = require('../../utils/guildMembersThrottle');
@@ -602,28 +602,11 @@ class ReminderService {
      */
     async downloadImage(url, sessionId, index) {
         await this.initTempDir();
-
         const filename = `${sessionId}_${index}_${Date.now()}.png`;
         const filepath = path.join(this.tempDir, filename);
-
-        return new Promise((resolve, reject) => {
-            https.get(url, (response) => {
-                const fileStream = require('fs').createWriteStream(filepath);
-                response.pipe(fileStream);
-
-                fileStream.on('finish', () => {
-                    fileStream.close();
-                    logger.info(`[REMIND] 💾 Zapisano zdjęcie: ${filename}`);
-                    resolve(filepath);
-                });
-
-                fileStream.on('error', (err) => {
-                    reject(err);
-                });
-            }).on('error', (err) => {
-                reject(err);
-            });
-        });
+        await downloadDiscordImage(url, filepath);
+        logger.info(`[REMIND] 💾 Zapisano zdjęcie: ${filename}`);
+        return filepath;
     }
 
     /**

--- a/Stalker/utils/helpers.js
+++ b/Stalker/utils/helpers.js
@@ -1,5 +1,90 @@
 const fs = require('fs').promises;
+const fsSync = require('fs');
+const https = require('https');
+const { URL } = require('url');
 const path = require('path');
+
+const ALLOWED_DISCORD_HOSTS = new Set([
+    'cdn.discordapp.com',
+    'media.discordapp.net',
+    'images-ext-1.discordapp.net',
+    'images-ext-2.discordapp.net',
+    'attachments.discord-activities.com',
+]);
+
+const MAX_DOWNLOAD_SIZE = 25 * 1024 * 1024; // 25 MB
+const DOWNLOAD_TIMEOUT_MS = 30_000; // 30 sekund
+
+function validateDiscordUrl(rawUrl) {
+    let parsed;
+    try {
+        parsed = new URL(rawUrl);
+    } catch {
+        throw new Error(`Nieprawidłowy URL: ${rawUrl}`);
+    }
+    if (parsed.protocol !== 'https:') {
+        throw new Error(`Dozwolony wyłącznie protokół HTTPS`);
+    }
+    if (!ALLOWED_DISCORD_HOSTS.has(parsed.hostname)) {
+        throw new Error(`Host "${parsed.hostname}" nie jest dozwolony (tylko Discord CDN)`);
+    }
+    return parsed;
+}
+
+/**
+ * Pobiera obraz z Discord CDN na dysk.
+ * Wymusza HTTPS, whitelist hostów Discord, limit 25 MB i timeout 30s.
+ * @param {string} url - URL obrazu z Discord CDN
+ * @param {string} filepath - Ścieżka do zapisu pliku
+ * @returns {Promise<string>} - Ścieżka do zapisanego pliku
+ */
+async function downloadDiscordImage(url, filepath) {
+    validateDiscordUrl(url);
+
+    return new Promise((resolve, reject) => {
+        const fileStream = fsSync.createWriteStream(filepath);
+        let totalSize = 0;
+        let timedOut = false;
+
+        const req = https.get(url, (response) => {
+            response.on('data', (chunk) => {
+                totalSize += chunk.length;
+                if (totalSize > MAX_DOWNLOAD_SIZE) {
+                    timedOut = true;
+                    response.destroy();
+                    fileStream.close();
+                    reject(new Error(`Plik przekracza limit ${MAX_DOWNLOAD_SIZE / 1024 / 1024} MB`));
+                    return;
+                }
+                fileStream.write(chunk);
+            });
+
+            response.on('end', () => {
+                if (!timedOut) {
+                    fileStream.close();
+                    resolve(filepath);
+                }
+            });
+
+            response.on('error', (err) => {
+                fileStream.close();
+                reject(err);
+            });
+        });
+
+        req.setTimeout(DOWNLOAD_TIMEOUT_MS, () => {
+            timedOut = true;
+            req.destroy();
+            fileStream.close();
+            reject(new Error(`Timeout pobierania obrazu (${DOWNLOAD_TIMEOUT_MS / 1000}s)`));
+        });
+
+        req.on('error', (err) => {
+            fileStream.close();
+            reject(err);
+        });
+    });
+}
 
 /**
  * Opóźnienie wykonania (delay)
@@ -348,5 +433,6 @@ module.exports = {
     createInfoEmbed,
     hasRequiredPermissions,
     getWeekNumber,
-    cleanupOldFiles
+    cleanupOldFiles,
+    downloadDiscordImage,
 };


### PR DESCRIPTION
## Podsumowanie

Audyt bezpieczeństwa i wydajności dwóch botów — EndersEcho i Stalker. Naprawiono krytyczne problemy: SSRF, blokowanie event loop przez sync I/O oraz memory leak.

---

## EndersEcho Bot

- **`utils/helpers.js`** — `downloadBuffer`/`downloadFile`: whitelist 5 hostów Discord CDN, wymuszony HTTPS, limit 25 MB; eliminuje SSRF i DoS przez duże pliki
- **`handlers/interactionHandlers.js`** — `_infoSessions`: TTL 15 min z `setTimeout` + `_setInfoSession`/`_clearInfoSession`; eliminuje memory leak przy porzuconych modałach `/info`
- **`services/rankingService.js`** — `getGlobalRanking` i `saveSharedRanking`: `Promise.all` zamiast sekwencyjnych `await` w pętli (N+1 fix); kolejka `_enqueue` z timeout 30s zapobiega wieszaniu się bota na jednym serwisie
- **`services/userBlockService.js`** — `readFileSync` przy starcie zastąpiony async `_load()` + `_loadPromise`; metody publiczne `isBlocked`, `getBlockedUsers`, `isBlockedByHeadAdmin` są teraz `async`; usunięto blokowanie event loop
- **`services/roleRankingConfigService.js`** — batch-fetch memberów równoległy przez `Promise.allSettled` zamiast sekwencyjnej pętli
- **`services/roleService.js`** — usuwanie i dodawanie ról w chunkach po 10 z przerwą 250 ms; zapobiega global rate limit Discord przy dużych aktualizacjach TOP
- **`services/aiOcrService.js`** — retry 3× z exponential backoff (1s, 2s) dla kodów 429/503/500/ECONNRESET; bot nie zwraca błędu użytkownikowi przy chwilowej niedostępności Gemini
- **`config/config.js`** — walidacja Guild ID i Channel ID regexem `/^\d{17,20}$/` przy starcie; bot nie startuje przy błędnym `.env` zamiast działać nieprawidłowo

---

## Stalker Bot

- **`utils/helpers.js`** — nowa funkcja `downloadDiscordImage()`: whitelist Discord CDN, limit 25 MB, timeout 30s, wyłącznie HTTPS; eliminuje SSRF i zawieszanie się pobierania
- **`services/reminderService.js`**, **`services/punishmentService.js`**, **`services/phaseService.js`** — trzy identyczne `downloadImage()` zastąpione wspólnym `downloadDiscordImage()` z helpers; usunięto ~60 linii duplikatu
- **`services/garyCombatIngestionService.js`** — pełne przejście na async I/O: `readdirSync→readdir`, `readFileSync→readFile` (równolegle przez `Promise.allSettled`), `existsSync→try/catch`, `writeFileSync→writeFile`, `mkdirSync→mkdir`; koniec blokowania bota co środę o 18:55
- **`handlers/interactionHandlers.js`** — `loadCombatHistory()` i `loadClanGuildHistory()` zamienione na `async`; odczyty plików weekly wykonywane równolegle przez `Promise.allSettled`; 4 wywołania uzupełnione o `await`

## Plan testów

- [ ] EndersEcho: `/update` z obrazem z Discord CDN — zapis rankingu działa
- [ ] EndersEcho: `/update` z URL spoza Discord CDN — błąd walidacji URL
- [ ] EndersEcho: `/ranking` globalny — szybkość wzrosła (równoległe I/O)
- [ ] EndersEcho: restart bota — `user_blocks.json` wczytany poprawnie (async init)
- [ ] EndersEcho: konfiguracja z błędnym Guild ID w `.env` — bot nie startuje z czytelnym komunikatem
- [ ] Stalker: `/punish` z obrazem — pobieranie działa
- [ ] Stalker: `/punish` z URL spoza Discord CDN — błąd
- [ ] Stalker: `/lme-snapshot` lub restart w środę — brak freezowania bota
- [ ] Stalker: `/clan-progres` — historia Gary wczytana poprawnie

https://claude.ai/code/session_01WXAqRCJEw5WwqLmuT1a9hE

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXAqRCJEw5WwqLmuT1a9hE)_