### PR TITLE
Skip past triggers when calculating next scheduled time

### DIFF
--- a/Wydarzynier/services/eventMenedzer.js
+++ b/Wydarzynier/services/eventMenedzer.js
@@ -256,9 +256,16 @@ class EventMenedzer {
         let nextTrigger;
         let newTriggerCount = (event.triggerCount || 0) + 1;
 
+        const now = new Date();
+
         if (event.interval === 'msc') {
             const originalDay = event.monthlyDay || getWarsawComponents(lastTrigger).day;
-            nextTrigger = addOneMonthWarsaw(lastTrigger, originalDay).toISOString();
+            let next = addOneMonthWarsaw(lastTrigger, originalDay);
+            while (next <= now) {
+                next = addOneMonthWarsaw(next, originalDay);
+                newTriggerCount++;
+            }
+            nextTrigger = next.toISOString();
         } else {
             let nextIntervalMs;
             // Specjalny wzorzec "ee": 3d x8, potem 4d, powtórz
@@ -272,7 +279,12 @@ class EventMenedzer {
             } else {
                 nextIntervalMs = event.intervalMs;
             }
-            nextTrigger = new Date(lastTrigger.getTime() + nextIntervalMs).toISOString();
+            let next = new Date(lastTrigger.getTime() + nextIntervalMs);
+            while (next <= now) {
+                next = new Date(next.getTime() + nextIntervalMs);
+                newTriggerCount++;
+            }
+            nextTrigger = next.toISOString();
         }
 
         return await this.updateEvent(id, {

--- a/Wydarzynier/services/przypomnieniaMenedzer.js
+++ b/Wydarzynier/services/przypomnieniaMenedzer.js
@@ -431,10 +431,17 @@ class PrzypomnieniaMenedzer {
         let nextTrigger;
         let newTriggerCount = (scheduled.triggerCount || 0) + 1;
 
+        const now = new Date();
+
         // Miesięczny (ten sam dzień miesiąca, ta sama godzina w Warsaw)
         if (scheduled.interval === 'msc') {
             const originalDay = scheduled.monthlyDay || getWarsawComponents(lastTrigger).day;
-            nextTrigger = addOneMonthWarsaw(lastTrigger, originalDay).toISOString();
+            let next = addOneMonthWarsaw(lastTrigger, originalDay);
+            while (next <= now) {
+                next = addOneMonthWarsaw(next, originalDay);
+                newTriggerCount++;
+            }
+            nextTrigger = next.toISOString();
         } else {
             let nextIntervalMs;
             // Specjalny wzorzec "ee": 3d x8, potem 4d, powtórz
@@ -448,7 +455,12 @@ class PrzypomnieniaMenedzer {
             } else {
                 nextIntervalMs = scheduled.intervalMs;
             }
-            nextTrigger = new Date(lastTrigger.getTime() + nextIntervalMs).toISOString();
+            let next = new Date(lastTrigger.getTime() + nextIntervalMs);
+            while (next <= now) {
+                next = new Date(next.getTime() + nextIntervalMs);
+                newTriggerCount++;
+            }
+            nextTrigger = next.toISOString();
         }
 
         return await this.updateScheduled(id, {


### PR DESCRIPTION
## Summary
Fixed a bug where events and reminders scheduled in the past would not properly advance to the next future trigger time. Previously, if the last trigger time was in the past, the next calculated trigger would also be in the past, causing scheduling issues.

## Key Changes
- **eventMenedzer.js**: Added logic to skip past trigger times by looping until the next calculated trigger is in the future for both monthly (`msc`) and interval-based scheduling
- **przypomnieniaMenedzer.js**: Applied the same fix to the reminder scheduling logic to ensure consistency across both services
- Both changes increment `newTriggerCount` appropriately to account for skipped triggers

## Implementation Details
- Captures the current time (`now`) at the start of trigger calculation
- For monthly intervals: Loops `addOneMonthWarsaw()` until the result is after the current time
- For interval-based scheduling: Loops by adding `nextIntervalMs` until the result is after the current time
- Ensures `newTriggerCount` accurately reflects all skipped triggers, maintaining proper trigger history

https://claude.ai/code/session_01VEgD9axw5u3KsdKKZQ5Ykk