### PR TITLE
Szkolenia / Wydarzynier / Rekruter: przegląd kodu, poprawki błędów i refaktoring

### DIFF
--- a/Rekruter/CLAUDE.md
+++ b/Rekruter/CLAUDE.md
@@ -46,10 +46,10 @@
 **Env:** TOKEN, kanały (RECRUITMENT, CLAN0-2, MAIN_CLAN, WELCOME), role (CLAN0-2, MAIN_CLAN, VERIFIED, NOT_POLISH), USE_AI_OCR (opcjonalne), ANTHROPIC_API_KEY (opcjonalne), ROBOT (opcjonalne, lista user ID rozdzielona przecinkami)
 
 **Przekazywanie wiadomości (Robot2):**
-- Użytkownicy z ID w `ROBOT2` mogą pisać priv do bota, a wiadomości są przekazywane 1:1 na kanał `1486848827997818900`
+- Użytkownicy z ID w `ROBOT` mogą pisać priv do bota, a wiadomości są przekazywane 1:1 na kanał z env `ROBOT2_FORWARD_CHANNEL`
 - Obsługuje tekst i załączniki
 - Wymaga partial `Channel`
-- **Ping roli:** Jeśli wiadomość DM zaczyna się od `@`, zostanie wysłana z pingiem do roli `1486506395057524887`
+- **Ping roli:** Jeśli wiadomość DM zaczyna się od `@`, zostanie wysłana z pingiem do roli z env `ROBOT2_MENTION_ROLE`
 
 ---
 
@@ -80,6 +80,13 @@ MAIN_CLAN_ROLE=role_id
 USE_AI_OCR=false
 ANTHROPIC_API_KEY=sk-ant-api03-xxxxxxxxxxxxx
 ANTHROPIC_MODEL=claude-3-haiku-20240307
+
+# Opcjonalne - z fallbackiem do wartości produkcyjnych
+REKRUTER_MAIN_CHANNEL=channel_id          # Kanał główny (notyfikacje dołączeń/boostów)
+REKRUTER_BOOST_BONUS_CHANNEL=channel_id   # Kanał bonusowy dla boosterów
+ROBOT2_FORWARD_CHANNEL=channel_id         # Kanał forward dla Robot2
+ROBOT2_MENTION_ROLE=role_id               # Rola do pingu (@) dla Robot2
+ROBOT2_ACTIVATION_CHANNEL=channel_id      # Kanał z przyciskiem aktywacji Robot2
 ```
 
 ## Najlepsze Praktyki

--- a/Rekruter/config/config.js
+++ b/Rekruter/config/config.js
@@ -46,8 +46,9 @@ module.exports = {
 
     // Przekazywanie wiadomości z priv na kanał (robot2)
     robot2Users: localEnv.ROBOT ? localEnv.ROBOT.split(',').map(id => id.trim()) : [],
-    notificationForwardChannel: '1486848827997818900',
-    mentionRoleId: '1486506395057524887',
+    notificationForwardChannel: process.env.ROBOT2_FORWARD_CHANNEL || '1486848827997818900',
+    mentionRoleId: process.env.ROBOT2_MENTION_ROLE || '1486506395057524887',
+    robot2ActivationChannel: process.env.ROBOT2_ACTIVATION_CHANNEL || '1486510519119773818',
 
     channels: {
         recruitment: process.env.RECRUITMENT_CHANNEL,
@@ -55,7 +56,9 @@ module.exports = {
         clan1: process.env.CLAN1_CHANNEL,
         clan2: process.env.CLAN2_CHANNEL,
         mainClan: process.env.MAIN_CLAN_CHANNEL,
-        welcome: process.env.WELCOME_CHANNEL
+        welcome: process.env.WELCOME_CHANNEL,
+        main: process.env.REKRUTER_MAIN_CHANNEL || '1170323972173340744',
+        boost: process.env.REKRUTER_BOOST_BONUS_CHANNEL || '1384597663378440363'
     },
     roles: {
         notPolish: process.env.NOT_POLISH_ROLE,
@@ -75,7 +78,7 @@ module.exports = {
         recruit2: process.env.RECRUIT_2_ROLE,
         recruitMain: process.env.RECRUIT_MAIN_ROLE
     },
-    
+
     // Konfiguracja monitorowania użytkowników bez ról
     roleMonitoring: {
         enabled: true,
@@ -84,17 +87,17 @@ module.exports = {
         dataFile: './Rekruter/data/user_monitoring.json',
         waitingRoomChannel: process.env.WAITING_ROOM_CHANNEL || 'poczekalnia'
     },
-    
+
     // Konfiguracja powiadomień o wejściach/wyjściach
     memberNotifications: {
         enabled: true,
-        channelId: '1170323972173340744',
+        channelId: process.env.REKRUTER_MAIN_CHANNEL || '1170323972173340744',
         emojis: {
             join: '<:PepeBizensik:1278014731113857037>',
             leave: '<:PepeRIP:1267576534252916849>'
         }
     },
-    
+
     // Konfiguracja OCR
     ocr: {
         tempDir: path.join(__dirname, '../temp'),
@@ -117,6 +120,6 @@ module.exports = {
             logPreprocessing: true
         }
     },
-    
+
     messages
 };

--- a/Rekruter/handlers/interactionHandlers.js
+++ b/Rekruter/handlers/interactionHandlers.js
@@ -327,7 +327,7 @@ async function handleNickChangeModal(interaction) {
         // Zmień nick użytkownikowi który wypełnił formularz
         await member.setNickname(newNickname);
 
-        logger.info(`[NICK] ✅ ${interaction.user.tag} zmienił swój nick z "${oldNick}" na "${newNickname}"`);
+        logger.info(`[NICK] ✅ ${interaction.user.username} zmienił swój nick z "${oldNick}" na "${newNickname}"`);
 
         await interaction.editReply({
             content: `✅ **Sukces!** Twój nick został zmieniony!\n\n` +
@@ -336,7 +336,7 @@ async function handleNickChangeModal(interaction) {
         });
 
     } catch (error) {
-        logger.error(`[NICK] ❌ Błąd podczas zmiany nicku dla ${interaction.user.tag}:`, error);
+        logger.error(`[NICK] ❌ Błąd podczas zmiany nicku dla ${interaction.user.username}:`, error);
 
         await interaction.editReply({
             content: '❌ **Ups!** Nie udało się zmienić nicku.\n\n' +
@@ -382,7 +382,7 @@ async function handleOcrDebugCommand(interaction, config) {
     
     const { createBotLogger } = require('../../utils/consoleLogger');
     const logger = createBotLogger('Rekruter');
-    logger.info(`${emoji} Szczegółowe logowanie OCR zostało ${enabled ? 'włączone' : 'wyłączone'} przez ${interaction.user.tag}`);
+    logger.info(`${emoji} Szczegółowe logowanie OCR zostało ${enabled ? 'włączone' : 'wyłączone'} przez ${interaction.user.username}`);
     
     await interaction.reply({
         content: `${emoji} **Szczegółowe logowanie OCR:** ${statusText}`,

--- a/Rekruter/index.js
+++ b/Rekruter/index.js
@@ -1,4 +1,4 @@
-const { Client, GatewayIntentBits, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags, Partials, ChannelType } = require('discord.js');
+const { Client, GatewayIntentBits, ActionRowBuilder, ButtonBuilder, ButtonStyle, MessageFlags, Partials, ChannelType, Events } = require('discord.js');
 const fs = require('fs').promises;
 const path = require('path');
 
@@ -39,9 +39,7 @@ const nicknameRequests = new Map();
 const userEphemeralReplies = new Map();
 const pendingQualifications = new Map();
 const userImages = new Map();
-const pendingOtherPurposeFinish = new Map(); // Nowa mapa dla ścieżki "inne cele"
-
-const MONITORED_CHANNEL_ID = config.channels.recruitment;
+const pendingOtherPurposeFinish = new Map();
 
 const sharedState = {
     userStates,
@@ -75,7 +73,7 @@ async function saveRelay2(dmMessageId, channelId, messageId) {
 async function updateActivationMessage(client, robotUsers, botLabel, customIdPrefix, msgFile) {
     if (robotUsers.length === 0) return;
     try {
-        const activationChannel = await client.channels.fetch('1486510519119773818');
+        const activationChannel = await client.channels.fetch(config.robot2ActivationChannel);
         const guild = activationChannel.guild;
 
         const buttons = [];
@@ -113,9 +111,7 @@ async function updateActivationMessage(client, robotUsers, botLabel, customIdPre
                         b.customId === buttons[i].data.custom_id &&
                         b.label === buttons[i].data.label
                     );
-                if (same) {
-                    return;
-                }
+                if (same) return;
                 await existing.edit({ content, components: [row] });
                 logger.info('[ROBOT2] Zaktualizowano wiadomość aktywacji');
                 return;
@@ -133,93 +129,87 @@ async function updateActivationMessage(client, robotUsers, botLabel, customIdPre
     }
 }
 
-client.once('ready', async () => {
-  try {
-    logger.success('✅ Rekruter gotowy - rekrutacja z OCR, boost tracking');
-
-    // Rejestracja komend slash
-    await registerSlashCommands(client, config);
-    
-    // Inicjalizacja serwisów
-    await notificationPreferencesService.load();
-    await roleMonitoringService.initialize(client);
-    memberNotificationService.initialize(client);
-    await memberCacheService.initialize(client);
-    await clanRoleChangeService.initialize(client);
-    await initializeOCR(config);
-    
-    // Inicjalizacja folderu temp
+client.once(Events.ClientReady, async () => {
     try {
-        await fs.mkdir(path.join(__dirname, 'temp'), { recursive: true });
-    } catch (error) {
-    }
-    
-    // Czyszczenie starych wiadomości i wysyłanie nowej
-    const channel = client.channels.cache.get(MONITORED_CHANNEL_ID);
-    if (channel) {
-        
-        try {
-            const messages = await channel.messages.fetch({ limit: 50 });
-            const botMessages = messages.filter(msg =>
-                msg.author.id === client.user.id &&
-                msg.content === config.messages.initialQuestion &&
-                msg.components.length > 0
-            );
-            
-            logger.info(`[BOT] Znaleziono ${botMessages.size} starych wiadomości bota do usunięcia`);
-            
-            for (const [messageId, message] of botMessages) {
-                try {
-                    await message.delete();
-                } catch (deleteError) {
-                    logger.warn(`[BOT] Nie udało się usunąć wiadomości ${messageId}`);
-                }
-            }
-        } catch (error) {
-            logger.error(`[BOT] ❌ Błąd podczas czyszczenia kanału:`, error);
-        }
-        
-        const row = new ActionRowBuilder()
-            .addComponents(
-                new ButtonBuilder()
-                    .setCustomId('not_polish')
-                    .setLabel('Nie, nie jestem Polakiem')
-                    .setStyle(ButtonStyle.Primary)
-                    .setEmoji('<:PepeNie:1185134768464076831>'),
-                new ButtonBuilder()
-                    .setCustomId('yes_polish')
-                    .setLabel('Oczywiście, że tak!')
-                    .setStyle(ButtonStyle.Primary)
-                    .setEmoji('<:peepoxYes:461067799427547136>')
-            );
-        
-        await channel.send({
-            content: config.messages.initialQuestion,
-            components: [row]
-        });
-        
-        logger.info(`[BOT] ✅ Wysłano wiadomość rekrutacyjną`);
-    } else {
-        logger.error(`[BOT] ❌ Nie znaleziono kanału rekrutacji`);
-    }
+        logger.success('✅ Rekruter gotowy - rekrutacja z OCR, boost tracking');
 
-    await updateActivationMessage(
-        client, config.robot2Users, 'Rekruter', 'robot_activate_rekruter_',
-        path.join(__dirname, 'data', 'robot_activation_msg.json')
-    );
-  } catch (error) {
-    logger.error('❌ Błąd krytyczny podczas inicjalizacji Rekruter:', error);
-  }
+        await registerSlashCommands(client, config);
+
+        await notificationPreferencesService.load();
+        await roleMonitoringService.initialize(client);
+        memberNotificationService.initialize(client);
+        await memberCacheService.initialize(client);
+        await clanRoleChangeService.initialize(client);
+        await initializeOCR(config);
+
+        try {
+            await fs.mkdir(path.join(__dirname, 'temp'), { recursive: true });
+        } catch {}
+
+        const channel = client.channels.cache.get(config.channels.recruitment);
+        if (channel) {
+            try {
+                const messages = await channel.messages.fetch({ limit: 50 });
+                const botMessages = messages.filter(msg =>
+                    msg.author.id === client.user.id &&
+                    msg.content === config.messages.initialQuestion &&
+                    msg.components.length > 0
+                );
+
+                logger.info(`[BOT] Znaleziono ${botMessages.size} starych wiadomości bota do usunięcia`);
+
+                for (const [messageId, message] of botMessages) {
+                    try {
+                        await message.delete();
+                    } catch {
+                        logger.warn(`[BOT] Nie udało się usunąć wiadomości ${messageId}`);
+                    }
+                }
+            } catch (error) {
+                logger.error(`[BOT] ❌ Błąd podczas czyszczenia kanału:`, error);
+            }
+
+            const row = new ActionRowBuilder()
+                .addComponents(
+                    new ButtonBuilder()
+                        .setCustomId('not_polish')
+                        .setLabel('Nie, nie jestem Polakiem')
+                        .setStyle(ButtonStyle.Primary)
+                        .setEmoji('<:PepeNie:1185134768464076831>'),
+                    new ButtonBuilder()
+                        .setCustomId('yes_polish')
+                        .setLabel('Oczywiście, że tak!')
+                        .setStyle(ButtonStyle.Primary)
+                        .setEmoji('<:peepoxYes:461067799427547136>')
+                );
+
+            await channel.send({
+                content: config.messages.initialQuestion,
+                components: [row]
+            });
+
+            logger.info(`[BOT] ✅ Wysłano wiadomość rekrutacyjną`);
+        } else {
+            logger.error(`[BOT] ❌ Nie znaleziono kanału rekrutacji`);
+        }
+
+        await updateActivationMessage(
+            client, config.robot2Users, 'Rekruter', 'robot_activate_rekruter_',
+            path.join(__dirname, 'data', 'robot_activation_msg.json')
+        );
+    } catch (error) {
+        logger.error('❌ Błąd krytyczny podczas inicjalizacji Rekruter:', error);
+    }
 });
 
-client.on('interactionCreate', async interaction => {
+client.on(Events.InteractionCreate, async interaction => {
     if (interaction.isButton() && interaction.customId.startsWith('robot_activate_rekruter_')) {
         const userId = interaction.customId.replace('robot_activate_rekruter_', '');
         try {
             const user = await client.users.fetch(userId);
             await user.send('System przekazywania wiadomości aktywny!');
-            await interaction.reply({ content: `✅ Aktywowano system dla **${user.displayName || user.tag}**`, ephemeral: true });
-            logger.info(`[ROBOT2] Aktywowano system dla ${user.tag}`);
+            await interaction.reply({ content: `✅ Aktywowano system dla **${user.displayName || user.username}**`, ephemeral: true });
+            logger.info(`[ROBOT2] Aktywowano system dla ${user.username}`);
         } catch (error) {
             await interaction.reply({ content: `❌ Błąd aktywacji: ${error.message}`, ephemeral: true });
             logger.error(`[ROBOT2] Błąd aktywacji: ${error.message}`);
@@ -229,28 +219,7 @@ client.on('interactionCreate', async interaction => {
     try {
         await handleInteraction(interaction, sharedState, config, client);
     } catch (error) {
-        logger.error('❌ Błąd podczas obsługi interakcji');
-        logger.error(`❌ Error name: ${error?.name}`);
-        logger.error(`❌ Error message: ${error?.message}`);
-        logger.error(`❌ Error code: ${error?.code}`);
-        logger.error(`❌ HTTP status: ${error?.status}`);
-        logger.error(`❌ Stack trace: ${error?.stack}`);
-
-        // Próbuj serializować error z bezpieczną metodą
-        try {
-            const errorDetails = {
-                name: error?.name,
-                message: error?.message,
-                code: error?.code,
-                status: error?.status,
-                method: error?.method,
-                url: error?.url
-            };
-            logger.error(`❌ Error details: ${JSON.stringify(errorDetails, null, 2)}`);
-        } catch (serializeError) {
-            logger.error(`❌ Nie można serializować błędu: ${serializeError.message}`);
-        }
-
+        logger.error('❌ Błąd podczas obsługi interakcji:', error);
         try {
             if (!interaction.replied && !interaction.deferred) {
                 await interaction.reply({
@@ -263,19 +232,16 @@ client.on('interactionCreate', async interaction => {
                 });
             }
         } catch (replyError) {
-            logger.error('❌ Nie można odpowiedzieć na interakcję (prawdopodobnie timeout)');
-            logger.error(`❌ Reply error message: ${replyError?.message}`);
-            logger.error(`❌ Reply error code: ${replyError?.code}`);
+            logger.error('❌ Nie można odpowiedzieć na interakcję:', replyError.message);
         }
     }
 });
 
-client.on('messageCreate', async message => {
+client.on(Events.MessageCreate, async message => {
     if (message.channel.type === ChannelType.DM && !message.author.bot) {
         if (config.robot2Users.length > 0 && config.robot2Users.includes(message.author.id)) {
             if (message.partial) await message.fetch();
 
-            // Odpowiedź na przekazaną wiadomość → odpowiedz w oryginalnym kanale
             if (message.reference?.messageId) {
                 const relay = await loadRelay2();
                 const original = relay[message.reference.messageId];
@@ -296,21 +262,19 @@ client.on('messageCreate', async message => {
                 }
             }
 
-            // Zwykły DM → przekaż na kanał
             try {
                 const forwardChannel = await client.channels.fetch(config.notificationForwardChannel);
                 if (forwardChannel) {
                     const attachmentUrls = [...message.attachments.values()].map(a => a.url);
                     const payload = {};
                     let msgContent = message.content || '';
-                    // Jeśli wiadomość zaczyna się od "@" i skonfigurowano rolę → dodaj ping do roli
                     if (msgContent.startsWith('@') && config.mentionRoleId) {
                         msgContent = `<@&${config.mentionRoleId}> ${msgContent.slice(1).trimStart()}`;
                     }
                     if (msgContent) payload.content = msgContent;
                     if (attachmentUrls.length > 0) payload.files = attachmentUrls;
                     if (payload.content || payload.files) await forwardChannel.send(payload);
-                    logger.info(`[ROBOT2] Przekazano wiadomość od ${message.author.tag} na kanał`);
+                    logger.info(`[ROBOT2] Przekazano wiadomość od ${message.author.username} na kanał`);
                 }
             } catch (error) {
                 logger.error(`[ROBOT2] Błąd przekazywania wiadomości: ${error.message}`);
@@ -319,7 +283,6 @@ client.on('messageCreate', async message => {
         }
     }
 
-    // Ping bota w kanale → przekaż do DM robot userów (tylko z kanału notificationForwardChannel, ignoruj @everyone/@here)
     if (!message.author.bot && message.guild && config.robot2Users.length > 0 && message.channelId === config.notificationForwardChannel && message.mentions.has(client.user) && !message.mentions.everyone) {
         for (const userId of config.robot2Users) {
             try {
@@ -331,65 +294,48 @@ client.on('messageCreate', async message => {
                 if (attachmentUrls.length > 0) payload.files = attachmentUrls;
                 const dmMsg = await user.send(payload);
                 await saveRelay2(dmMsg.id, message.channelId, message.id);
-                logger.info(`[ROBOT2] Przekazano ping od ${message.author.tag} do ${user.tag}`);
+                logger.info(`[ROBOT2] Przekazano ping od ${message.author.username} do ${user.username}`);
             } catch (err) {
                 logger.error(`[ROBOT2] Błąd przekazywania pinga do ${userId}: ${err.message}`);
             }
         }
     }
 
-    await handleMessage(message, sharedState, config, client, MONITORED_CHANNEL_ID);
+    await handleMessage(message, sharedState, config, client, config.channels.recruitment);
 });
 
-// Obsługa dołączenia nowego członka
-client.on('guildMemberAdd', async member => {
+client.on(Events.GuildMemberAdd, async member => {
     await memberNotificationService.handleMemberJoin(member);
 });
 
-// Obsługa opuszczenia serwera przez członka
-client.on('guildMemberRemove', async member => {
+client.on(Events.GuildMemberRemove, async member => {
     await memberNotificationService.handleMemberLeave(member);
 });
 
-// Obsługa boost events i zmian ról klanowych
-client.on('guildMemberUpdate', async (oldMember, newMember) => {
+client.on(Events.GuildMemberUpdate, async (oldMember, newMember) => {
     try {
-        // Obsługa zmian ról klanowych
         await clanRoleChangeService.handleRoleChange(oldMember, newMember);
 
-        // NOWY SYSTEM: Użyj MemberCacheService do prawidłowego wykrywania zmian boost
         const cacheResult = await memberCacheService.handleMemberUpdate(oldMember, newMember);
 
         if (cacheResult.changed) {
             if (cacheResult.changeType === 'gained') {
-                // Nowy boost!
-                logger.info(`[BOOST] 🎉 Nowy boost od ${newMember.user.tag} (${newMember.id})`);
+                logger.info(`[BOOST] 🎉 Nowy boost od ${newMember.user.username} (${newMember.id})`);
                 await handleNewBoost(cacheResult.member);
             } else if (cacheResult.changeType === 'lost') {
-                // Utrata boosta!
-                logger.info(`[BOOST] 💔 Utrata boost od ${newMember.user.tag} (${newMember.id})`);
+                logger.info(`[BOOST] 💔 Utrata boost od ${newMember.user.username} (${newMember.id})`);
                 await handleLostBoost(cacheResult.member);
             }
         }
     } catch (error) {
-        logger.error(`[BOOST] ❌ Błąd podczas obsługi boost event dla ${newMember?.user?.tag || 'nieznany'}:`, error);
-        logger.error(`[BOOST] ❌ Stack trace:`, error.stack);
+        logger.error(`[BOOST] ❌ Błąd podczas obsługi boost event dla ${newMember?.user?.username || 'nieznany'}:`, error);
     }
 });
 
-/**
- * Obsługuje nowy boost od członka
- * @param {GuildMember} member - Członek który zboostował
- */
 async function handleNewBoost(member) {
-    logger.info(`[BOOST] 🎉 Nowy boost od ${member.user.tag}`);
-    
     try {
-        const guild = member.guild;
-        const memberCount = guild.memberCount;
-        
-        
-        // 10 sentencji boost
+        const memberCount = member.guild.memberCount;
+
         const boostMessages = [
             `🧟‍♂️ Boost zebrany! ${member} jak prawdziwy strateg wybiera najlepsze wzmocnienia - dzięki Tobie serwer ma teraz legendarną moc! ${memberCount}+ członków podziwia Twoją hojność!`,
             `💎 To lepsze niż 100k gemów! ${member} dropnął nam najrzadszy boost w całej historii serwera! Twoja szczodrość podnosi nas na wyższy poziom!`,
@@ -402,76 +348,33 @@ async function handleNewBoost(member) {
             `⭐ ${member} ma oko do najlepszych wyborów! Twój boost dowodzi, że jesteś prawdziwym liderem z wielkim sercem dla społeczności!`,
             `🔋 ${member} to nasz główny bohater! Twój boost napędza cały serwer i pokazuje, że jesteś jednym z najcenniejszych członków tej społeczności!`
         ];
-        
-        // Wybierz losową sentencję
-        const randomIndex = Math.floor(Math.random() * boostMessages.length);
-        const randomMessage = boostMessages[randomIndex];
-        
-        // Wyślij na kanał główny
-        const mainChannelId = '1170323972173340744';
-        
+
+        const randomMessage = boostMessages[Math.floor(Math.random() * boostMessages.length)];
+
         try {
-            const mainChannel = client.channels.cache.get(mainChannelId);
-            if (!mainChannel) {
-                logger.error(`[BOOST] ❌ Nie znaleziono kanału głównego (${mainChannelId}) w cache`);
-                
-                // Spróbuj pobrać kanał z API
-                const fetchedMainChannel = await client.channels.fetch(mainChannelId);
-                if (fetchedMainChannel) {
-                    await fetchedMainChannel.send(randomMessage);
-                } else {
-                    logger.error(`[BOOST] ❌ Nie udało się pobrać kanału głównego z API`);
-                }
-            } else {
-                await mainChannel.send(randomMessage);
-            }
-        } catch (mainChannelError) {
-            logger.error(`[BOOST] ❌ Błąd wysyłania na kanał główny:`, mainChannelError);
-            logger.error(`[BOOST] ❌ Stack trace (main channel):`, mainChannelError.stack);
+            const mainChannel = client.channels.cache.get(config.channels.main) || await client.channels.fetch(config.channels.main);
+            await mainChannel.send(randomMessage);
+        } catch (error) {
+            logger.error(`[BOOST] ❌ Błąd wysyłania na kanał główny:`, error);
         }
-        
-        // Wyślij na kanał bonusowy
-        const bonusChannelId = '1384597663378440363';
-        
+
         try {
-            const bonusChannel = client.channels.cache.get(bonusChannelId);
+            const bonusChannel = client.channels.cache.get(config.channels.boost) || await client.channels.fetch(config.channels.boost);
             const bonusMessage = `${member} bardzo nam miło, że wspierasz nasz serwer. Chcemy się Tobie odwdzięczyć dlatego przygotowaliśmy kilka bonusów, które umilą Ci tu pobyt. Zapoznaj się z nimi tutaj: https://discord.com/channels/1170323970692743240/1283802643789250673/1283803231008456724\n\nW sprawie indywidualnej roli kontaktuj się tutaj z właścicielem serwera. <:PepeOK:1185134659286347886>`;
-            
-            if (!bonusChannel) {
-                logger.error(`[BOOST] ❌ Nie znaleziono kanału bonusowego (${bonusChannelId}) w cache`);
-                
-                // Spróbuj pobrać kanał z API
-                const fetchedBonusChannel = await client.channels.fetch(bonusChannelId);
-                if (fetchedBonusChannel) {
-                    await fetchedBonusChannel.send(bonusMessage);
-                } else {
-                    logger.error(`[BOOST] ❌ Nie udało się pobrać kanału bonusowego z API`);
-                }
-            } else {
-                await bonusChannel.send(bonusMessage);
-            }
-        } catch (bonusChannelError) {
-            logger.error(`[BOOST] ❌ Błąd wysyłania na kanał bonusowy:`, bonusChannelError);
-            logger.error(`[BOOST] ❌ Stack trace (bonus channel):`, bonusChannelError.stack);
+            await bonusChannel.send(bonusMessage);
+        } catch (error) {
+            logger.error(`[BOOST] ❌ Błąd wysyłania na kanał bonusowy:`, error);
         }
-        
-        logger.info(`[BOOST] ✅ Wysłano wiadomości boost dla ${member.user.tag}`);
-        
+
+        logger.info(`[BOOST] ✅ Wysłano wiadomości boost dla ${member.user.username}`);
+
     } catch (error) {
-        logger.error(`[BOOST] ❌ Ogólny błąd podczas obsługi nowego boost dla ${member.user.tag}:`, error);
-        logger.error(`[BOOST] ❌ Stack trace (general):`, error.stack);
+        logger.error(`[BOOST] ❌ Błąd podczas obsługi nowego boost dla ${member.user.username}:`, error);
     }
 }
 
-/**
- * Obsługuje utratę boosta przez członka
- * @param {GuildMember} member - Członek który stracił boost
- */
 async function handleLostBoost(member) {
-    logger.info(`[BOOST] 💔 Utrata boost od ${member.user.tag}`);
-    
     try {
-        // 10 smutnych sentencji dla utraty boosta
         const lostBoostMessages = [
             `💔 Game over... ${member} zakończył swoją misję wsparcia serwera. Dziękujemy za każdy dzień Twojego boosta - zniknął jak ostatnia amunicja w magazynie, ale Twoja hojność pozostanie w pamięci!`,
             `😢 Połączenie utracone! ${member} opuścił nasze szeregi boosterów. Dziękujemy za cały czas wspierania - jak gdy skończy się energia w grze, musimy poczekać na Twój powrót!`,
@@ -484,54 +387,27 @@ async function handleLostBoost(member) {
             `⏰ Czas minął! ${member} przestał boostować nasz serwer. Dziękujemy za każdą minutę Twojego wsparcia - jak gdy kończy się timer w grze, wszystko wraca do punktu wyjścia, ale pamięć trwa!`,
             `💀 Bohater upadł! ${member} nie jest już naszym boosterem. Dziękujemy za cały okres bycia jednym z najcenniejszych członków - czy kiedyś powrócisz do gry? Zawsze będziesz mile widziany!`
         ];
-        
-        // Wybierz losową smutną sentencję
-        const randomIndex = Math.floor(Math.random() * lostBoostMessages.length);
-        const randomMessage = lostBoostMessages[randomIndex];
-        
-        // Wyślij na kanał główny (ten sam co dla nowych boostów)
-        const mainChannelId = '1170323972173340744';
-        
+
+        const randomMessage = lostBoostMessages[Math.floor(Math.random() * lostBoostMessages.length)];
+
         try {
-            const mainChannel = client.channels.cache.get(mainChannelId);
-            if (!mainChannel) {
-                const fetchedMainChannel = await client.channels.fetch(mainChannelId);
-                if (fetchedMainChannel) {
-                    await fetchedMainChannel.send(randomMessage);
-                } else {
-                    logger.error(`[BOOST] ❌ Nie udało się pobrać kanału głównego`);
-                }
-            } else {
-                await mainChannel.send(randomMessage);
-            }
-        } catch (mainChannelError) {
-            logger.error(`[BOOST] ❌ Błąd wysyłania smutnej wiadomości na kanał główny:`, mainChannelError);
-            logger.error(`[BOOST] ❌ Stack trace (lost boost main channel):`, mainChannelError.stack);
+            const mainChannel = client.channels.cache.get(config.channels.main) || await client.channels.fetch(config.channels.main);
+            await mainChannel.send(randomMessage);
+        } catch (error) {
+            logger.error(`[BOOST] ❌ Błąd wysyłania smutnej wiadomości na kanał główny:`, error);
         }
-        
-        logger.info(`[BOOST] ✅ Wysłano wiadomość o utracie boost dla ${member.user.tag}`);
-        
+
+        logger.info(`[BOOST] ✅ Wysłano wiadomość o utracie boost dla ${member.user.username}`);
+
     } catch (error) {
-        logger.error(`[BOOST] ❌ Ogólny błąd podczas obsługi utraty boost dla ${member.user.tag}:`, error);
-        logger.error(`[BOOST] ❌ Stack trace (lost boost general):`, error.stack);
+        logger.error(`[BOOST] ❌ Błąd podczas obsługi utraty boost dla ${member.user.username}:`, error);
     }
 }
 
-process.on('SIGINT', async () => {
-    logger.info('Zamykanie bota Rekruter...');
-    
-    await memberCacheService.cleanup();
-    
-    client.destroy();
-    process.exit(0);
-});
-
-process.on('SIGTERM', async () => {
-    logger.info('Otrzymano sygnał SIGTERM, zamykam bota Rekruter...');
-    
+async function shutdown(signal) {
+    logger.info(`Otrzymano ${signal} - zamykanie bota Rekruter...`);
     try {
         await memberCacheService.cleanup();
-        
         client.destroy();
         logger.info('Bot Rekruter został pomyślnie zamknięty');
         process.exit(0);
@@ -539,6 +415,25 @@ process.on('SIGTERM', async () => {
         logger.error(`Błąd podczas zamykania bota Rekruter: ${error.message}`);
         process.exit(1);
     }
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+
+process.on('unhandledRejection', error => {
+    logger.error(`Nieobsłużone odrzucenie Promise: ${error.message}`);
 });
 
-client.login(config.token);
+process.on('uncaughtException', error => {
+    logger.error(`Nieobsłużony wyjątek: ${error.message}`);
+    process.exit(1);
+});
+
+module.exports = {
+    client,
+    start: () => client.login(config.token),
+    stop: async () => {
+        await memberCacheService.cleanup();
+        return client.destroy();
+    }
+};

--- a/Rekruter/services/clanRoleChangeService.js
+++ b/Rekruter/services/clanRoleChangeService.js
@@ -107,7 +107,7 @@ class ClanRoleChangeService {
 
             // Sprawdź czy użytkownik wyłączył swoje powiadomienia
             if (this.notificationPreferencesService && this.notificationPreferencesService.isOptedOut(userId)) {
-                logger.info(`[CLAN_ROLE] Użytkownik ${freshMember.user.tag} wyłączył powiadomienia - pomijam`);
+                logger.info(`[CLAN_ROLE] Użytkownik ${freshMember.user.username} wyłączył powiadomienia - pomijam`);
                 return;
             }
 
@@ -148,7 +148,7 @@ class ClanRoleChangeService {
 
             // Sprawdź czy użytkownik, któremu zmienia się rola, jest administratorem
             if (this.isUserAdmin(freshMember)) {
-                logger.info(`[CLAN_ROLE] Użytkownik ${freshMember.user.tag} jest administratorem - pomijam powiadomienie o zmianie klanu`);
+                logger.info(`[CLAN_ROLE] Użytkownik ${freshMember.user.username} jest administratorem - pomijam powiadomienie o zmianie klanu`);
                 return;
             }
 
@@ -254,7 +254,7 @@ class ClanRoleChangeService {
                 files: [attachment]
             });
 
-            logger.info(`[CLAN_ROLE] ${member.user.tag} awansował na ${roleName}`);
+            logger.info(`[CLAN_ROLE] ${member.user.username} awansował na ${roleName}`);
         } catch (error) {
             logger.error(`[CLAN_ROLE] ❌ Błąd wysyłania powiadomienia:`, error);
         }
@@ -313,7 +313,7 @@ class ClanRoleChangeService {
                 '0': 'PolskiSquad⁰'
             };
 
-            logger.info(`[CLAN_ROLE] ${member.user.tag} ${changeTypeText[changeType]} ${clanFullName[clanName]}`);
+            logger.info(`[CLAN_ROLE] ${member.user.username} ${changeTypeText[changeType]} ${clanFullName[clanName]}`);
         } catch (error) {
             logger.error(`[CLAN_ROLE] ❌ Błąd wysyłania powiadomienia:`, error);
         }

--- a/Rekruter/services/memberCacheService.js
+++ b/Rekruter/services/memberCacheService.js
@@ -602,7 +602,7 @@ class MemberCacheService {
 
             // Loguj tylko faktyczne zmiany boost
             if (changes.changed) {
-                this.logger.info(`[BOOST] ${newMember.user.tag} - był booster: ${changes.wasBooster}, jest booster: ${changes.isBooster}${canNotify ? '' : ' (cooldown powiadomienia)'}`);
+                this.logger.info(`[BOOST] ${newMember.user.username} - był booster: ${changes.wasBooster}, jest booster: ${changes.isBooster}${canNotify ? '' : ' (cooldown powiadomienia)'}`);
             }
 
             return {

--- a/Rekruter/services/memberNotificationService.js
+++ b/Rekruter/services/memberNotificationService.js
@@ -36,7 +36,7 @@ class MemberNotificationService {
             const joinMessage = `${member} jest w drodze na serwer ${this.config.memberNotifications.emojis.join}`;
             
             await channel.send(joinMessage);
-            logger.info(`📥 Powiadomienie o dołączeniu: ${member.user.tag}`);
+            logger.info(`📥 Powiadomienie o dołączeniu: ${member.user.username}`);
         } catch (error) {
             logger.error(`❌ Błąd wysyłania powiadomienia o dołączeniu: ${error.message}`);
         }
@@ -71,7 +71,7 @@ class MemberNotificationService {
             }
 
             await channel.send(leaveMessage);
-            logger.info(`📤 Powiadomienie o opuszczeniu: ${member.user.tag}${nickname ? ` (nick: ${nickname})` : ''}`);
+            logger.info(`📤 Powiadomienie o opuszczeniu: ${member.user.username}${nickname ? ` (nick: ${nickname})` : ''}`);
         } catch (error) {
             logger.error(`❌ Błąd wysyłania powiadomienia o opuszczeniu: ${error.message}`);
         }

--- a/Rekruter/services/roleMonitoringService.js
+++ b/Rekruter/services/roleMonitoringService.js
@@ -129,7 +129,7 @@ class RoleMonitoringService {
                     // Usuń z monitorowania jeśli ma role
                     if (this.monitoringData[userId]) {
                         delete this.monitoringData[userId];
-                        logger.info(`Usunięto ${member.user.tag} z monitorowania - otrzymał role`);
+                        logger.info(`Usunięto ${member.user.username} z monitorowania - otrzymał role`);
                     }
                 }
             }
@@ -156,7 +156,7 @@ class RoleMonitoringService {
                 warned24h: false,
                 guildId: guild.id
             };
-            logger.info(`Rozpoczęto monitorowanie ${member.user.tag} - bez ról od ${new Date(now).toISOString()}`);
+            logger.info(`Rozpoczęto monitorowanie ${member.user.username} - bez ról od ${new Date(now).toISOString()}`);
             return;
         }
 
@@ -167,7 +167,7 @@ class RoleMonitoringService {
         if (timeSinceJoin >= warning24h && !userData.warned24h) {
             await this.send24hWarning(member);
             userData.warned24h = true;
-            logger.info(`Wysłano ostrzeżenie 24h do ${member.user.tag}`);
+            logger.info(`Wysłano ostrzeżenie 24h do ${member.user.username}`);
         }
     }
 
@@ -193,9 +193,9 @@ Pozdrawiamy,
 Bot Rekruter`;
 
             await member.send(warningMessage);
-            logger.info(`✅ Wysłano ostrzeżenie 24h do ${member.user.tag}`);
+            logger.info(`✅ Wysłano ostrzeżenie 24h do ${member.user.username}`);
         } catch (error) {
-            logger.error(`❌ Nie można wysłać wiadomości do ${member.user.tag}: ${error.message}`);
+            logger.error(`❌ Nie można wysłać wiadomości do ${member.user.username}: ${error.message}`);
         }
     }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Podsumowanie

Przegląd kodu trzech botów — **Szkolenia**, **Wydarzynier**, **Rekruter** — z usunięciem dead code, naprawą błędów i standaryzacją wzorców.

## Szkolenia

- **Bugfix:** `setTimeout` z async callbackiem → `await delay()` (cichy brak `await` powodował brak czekania na usunięcie wiadomości)
- **Bugfix:** `registerSlashCommands` nie czyści już wszystkich globalnych komend przy każdym restarcie
- **Refaktoring:** usunięto 5 nieużywanych funkcji z `utils/helpers.js` (`formatTime`, `getTimeElapsed`, `hasAnyRole`, `getUserName`, `getThreadOwner`)
- **Refaktoring:** `checkThreads` miał zduplikowany identyczny blok kodu w obu gałęziach if/else — scalono
- **Refaktoring:** ręczne `* 24 * 60 * 60 * 1000` → `daysToMilliseconds()` z helpersów
- **Cleanup:** usunięto nieużywany import `SlashCommandBuilder`, dead template `threadExists` z messages
- **Config:** hardkodowane ID kanału AI Chat → `process.env.SZKOLENIA_AI_CHAT_CHANNEL_ID`
- **Dokumentacja:** naprawiono błędną wartość cooldownu Perplexity w CLAUDE.md (było "5 min / 60 min", jest "1440 min / 24h")

## Wydarzynier

- **Bugfix:** `setTimeout` z async callbackiem → `await delay()` (ostrzeżenie lobby nie czekało poprawnie)
- **Bugfix:** inline `require('discord.js')` wewnątrz handlerów → importy na górze pliku
- **Refaktoring:** usunięto puste setter-funkcje (`setHarmonogram`, `setTablicaMenedzer`, `setListaEventowMenedzer`) — bezpośrednie przypisanie do `sharedState`
- **Refaktoring:** usunięto martwą funkcję `handleMessageCreate` (nigdy nie wywoływana)
- **Refaktoring:** `isAllowedChannel(a, b)` → bezpośrednie `a !== b` (pełna funkcja dla jednej linii)
- **Refaktoring:** wyodrębniono `shutdown(signal)` — SIGINT i SIGTERM używają tej samej logiki
- **Deprecation:** `.tag` → `.username` (×12 miejsc)
- **Config:** hardkodowane ID kanałów/ról → zmienne env z fallbackiem
- **Dokumentacja:** CLAUDE.md zaktualizowany o nowe opcjonalne zmienne env

## Rekruter

- **Bugfix:** brak `module.exports` — launcher nie mógł wywołać `stop()` → dodano `{ client, start, stop }`
- **Refaktoring:** string event names → `Events.*` enum (standard Discord.js v14)
- **Refaktoring:** wyodrębniono `shutdown(signal)` dla SIGINT/SIGTERM
- **Refaktoring:** dodano handlery `unhandledRejection` / `uncaughtException`
- **Refaktoring:** zduplikowane log-linie w `handleNewBoost`/`handleLostBoost` usunięte
- **Refaktoring:** `cache.get() || fetch()` zamiast tylko `cache.get()` przy pobieraniu kanałów boostów
- **Deprecation:** `.tag` → `.username` (×6 miejsc w 5 plikach)
- **Config:** hardkodowane ID → zmienne env z fallbackiem
- **Dokumentacja:** CLAUDE.md zaktualizowany

## Nowe zmienne środowiskowe (wszystkie opcjonalne, mają fallback do wartości produkcyjnych)

**`Szkolenia/.env`**
```env
SZKOLENIA_AI_CHAT_CHANNEL_ID=1207041051831832586
```

**`Wydarzynier/.env`**
```env
WYDARZYNIER_PARTY_CHANNEL=1201206524165496994
WYDARZYNIER_PARTY_NOTIFICATIONS_ROLE=1272573347946954833
ROBOT3_FORWARD_CHANNEL=1486848827997818900
ROBOT3_MENTION_ROLE=1486506395057524887
ROBOT3_ACTIVATION_CHANNEL=1486510519119773818
```

**`Rekruter/.env`**
```env
REKRUTER_MAIN_CHANNEL=1170323972173340744
REKRUTER_BOOST_BONUS_CHANNEL=1384597663378440363
ROBOT2_FORWARD_CHANNEL=1486848827997818900
ROBOT2_MENTION_ROLE=1486506395057524887
ROBOT2_ACTIVATION_CHANNEL=1486510519119773818
```

## Plan testowania

- [ ] Szkolenia startuje bez błędów, komendy slash się rejestrują
- [ ] Wydarzynier: timer ostrzeżenia lobby działa (wiadomość znika po 10s)
- [ ] Rekruter startuje, launcher może go zatrzymać (`stop()`)
- [ ] Żaden z botów nie wyświetla `undefined` zamiast nicku użytkownika (`.username`)

https://claude.ai/code/session_01K7v2f45szESccC6g88mRpq
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7v2f45szESccC6g88mRpq)_