### PR TITLE
Wydarzynier: fix crash strefaCzasowaManager.initialize is not a function

### DIFF
--- a/Wydarzynier/index.js
+++ b/Wydarzynier/index.js
@@ -141,7 +141,6 @@ client.once(Events.ClientReady, async () => {
         await bazarService.initialize(client);
 
         await przypomnieniaMenedzer.initialize();
-        await strefaCzasowaManager.initialize();
         await eventMenedzer.initialize();
 
         tablicaMenedzer = new TablicaMenedzer(client, config, logger, przypomnieniaMenedzer, strefaCzasowaManager, eventMenedzer);


### PR DESCRIPTION
## Podsumowanie

- Usunięto wywołanie `strefaCzasowaManager.initialize()` z `index.js` — metoda została usunięta z serwisu w poprzednim PR (#809) jako pusta, ale jej wywołanie zostało pominięte
- Błąd: `TypeError: strefaCzasowaManager.initialize is not a function` przy starcie bota

## Plan testowania

- [ ] Wydarzynier startuje bez błędu krytycznego

https://claude.ai/code/session_01K7v2f45szESccC6g88mRpq

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7v2f45szESccC6g88mRpq)_