### PR TITLE
Refactor ranking system with guild rankings and improved navigation

### DIFF
--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -93,11 +93,11 @@ const pol = {
     ocrDebugOff: '🔇 **Szczegółowe logowanie OCR:** ❌ Wyłączone',
 
     // Przyciski nawigacji
-    buttonFirst: '⏪ Pierwsza',
     buttonPrev: '◀️ Poprzednia',
     buttonNext: 'Następna ▶️',
-    buttonLast: 'Ostatnia ⏩',
-    buttonBack: '↩️ Powrót do wyboru',
+    buttonMyPos: '🎯 Moja pozycja',
+    buttonGlobal: '🌐 Global',
+    buttonBack: '↩️ Wybór serwerów',
 
     // Role TOP
     topRoleUpdated: '🏆 Role TOP zostały zaktualizowane!',
@@ -350,11 +350,11 @@ const eng = {
     ocrDebugOff: '🔇 **Detailed OCR logging:** ❌ Disabled',
 
     // Navigation buttons
-    buttonFirst: '⏪ First',
     buttonPrev: '◀️ Previous',
     buttonNext: 'Next ▶️',
-    buttonLast: 'Last ⏩',
-    buttonBack: '↩️ Back to selection',
+    buttonMyPos: '🎯 My position',
+    buttonGlobal: '🌐 Global',
+    buttonBack: '↩️ Server selection',
 
     // TOP roles
     topRoleUpdated: '🏆 TOP roles have been updated!',

--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -97,7 +97,11 @@ const pol = {
     buttonNext: 'Następna ▶️',
     buttonMyPos: '🎯 Moja pozycja',
     buttonGlobal: '🌐 Global',
+    buttonServerRanking: '🏛️ Ranking Serwerów',
+    buttonIndividualRanking: '👤 Ranking Indywidualny',
     buttonBack: '↩️ Wybór serwerów',
+    guildRankingTitle: '🏛️ Ranking Serwerów',
+    guildRankingFooter: 'Suma wyników top 30 graczy per serwer',
 
     // Role TOP
     topRoleUpdated: '🏆 Role TOP zostały zaktualizowane!',
@@ -354,7 +358,11 @@ const eng = {
     buttonNext: 'Next ▶️',
     buttonMyPos: '🎯 My position',
     buttonGlobal: '🌐 Global',
+    buttonServerRanking: '🏛️ Server Ranking',
+    buttonIndividualRanking: '👤 Individual Ranking',
     buttonBack: '↩️ Server selection',
+    guildRankingTitle: '🏛️ Server Ranking',
+    guildRankingFooter: 'Sum of top 30 players per server',
 
     // TOP roles
     topRoleUpdated: '🏆 TOP roles have been updated!',

--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -99,7 +99,7 @@ const pol = {
     buttonGlobal: '🌐 Global',
     buttonServerRanking: '🏛️ Ranking Serwerów',
     buttonIndividualRanking: '👤 Ranking Indywidualny',
-    buttonBack: '↩️ Wybór serwerów',
+    buttonBack: '↩️ Rankingi serwerów',
     guildRankingTitle: '🏛️ Ranking Serwerów',
     guildRankingFooter: 'Suma wyników top 30 graczy per serwer',
 
@@ -360,7 +360,7 @@ const eng = {
     buttonGlobal: '🌐 Global',
     buttonServerRanking: '🏛️ Server Ranking',
     buttonIndividualRanking: '👤 Individual Ranking',
-    buttonBack: '↩️ Server selection',
+    buttonBack: '↩️ Server rankings',
     guildRankingTitle: '🏛️ Server Ranking',
     guildRankingFooter: 'Sum of top 30 players per server',
 

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -2463,6 +2463,12 @@ class InteractionHandler {
                 return;
             }
 
+            // === Przycisk rankingu serwerów ===
+            if (customId === 'ranking_guild_ranking') {
+                await this._handleGuildRankingSelect(interaction);
+                return;
+            }
+
             // === Przycisk powrotu do wyboru ===
             if (customId === 'ranking_back') {
                 await this._handleRankingBack(interaction);
@@ -2657,27 +2663,37 @@ class InteractionHandler {
             rankingData.currentPage = newPage;
             this.rankingService.updateActiveRanking(interaction.message.id, rankingData);
 
-            const guild = (rankingData.mode === 'server' || rankingData.mode === 'role')
-                ? (interaction.client.guilds.cache.get(rankingData.guildId) || interaction.guild)
-                : null;
+            const btnOptions = {
+                userPage: rankingData.userPage ?? null,
+                mode: rankingData.mode,
+                guildId: rankingData.guildId || null,
+                guildName: rankingData.guildName || null,
+                parentGuildId: rankingData.parentGuildId || null,
+                parentGuildName: rankingData.parentGuildName || null
+            };
 
-            const embed = await this.rankingService.createRankingEmbed(
-                rankingData.players, newPage, rankingData.totalPages, rankingData.userId, guild,
-                {
-                    mode: rankingData.mode,
-                    client: rankingData.mode === 'global' ? interaction.client : null,
-                    messages: msgs,
-                    callerStats: rankingData.callerStats || null
-                }
-            );
+            let embed;
+            if (rankingData.mode === 'guild_ranking') {
+                embed = this.rankingService.createGuildRankingEmbed(
+                    rankingData.guildScores, newPage, rankingData.totalPages, msgs
+                );
+            } else {
+                const guild = (rankingData.mode === 'server' || rankingData.mode === 'role')
+                    ? (interaction.client.guilds.cache.get(rankingData.guildId) || interaction.guild)
+                    : null;
+                embed = await this.rankingService.createRankingEmbed(
+                    rankingData.players, newPage, rankingData.totalPages, rankingData.userId, guild,
+                    {
+                        mode: rankingData.mode,
+                        client: rankingData.mode === 'global' ? interaction.client : null,
+                        messages: msgs,
+                        callerStats: rankingData.callerStats || null
+                    }
+                );
+            }
+
             const buttons = this.rankingService.createRankingButtons(
-                newPage, rankingData.totalPages, false, msgs, rankingData.roleRows || [],
-                {
-                    userPage: rankingData.userPage ?? null,
-                    mode: rankingData.mode,
-                    guildId: rankingData.guildId || rankingData.homeGuildId || null,
-                    guildName: rankingData.guildName || null
-                }
+                newPage, rankingData.totalPages, false, msgs, rankingData.roleRows || [], btnOptions
             );
 
             await interaction.editReply({ embeds: [embed], components: buttons });
@@ -2787,11 +2803,25 @@ class InteractionHandler {
                 ? Math.floor(callerIdx / this.config.ranking.playersPerPage)
                 : null;
 
-            // Nazwa serwera dla przycisku server↔global
+            // Nazwa serwera dla przycisków
             const guildName = guild?.name || null;
-            // homeGuildId — serwer użytkownika (fallback gdy tryb global)
-            const homeGuildId = guildId || interaction.guildId;
-            const homeGuildName = guildName || interaction.guild?.name || null;
+
+            // parentGuildId: serwer do którego wraca button5 w trybie global
+            // Gdy wchodzimy w global — poprzedni stan miał wybrany serwer (mode=server)
+            const prevData = this.rankingService.getActiveRanking(interaction.message.id);
+            let parentGuildId = null;
+            let parentGuildName = null;
+            if (mode === 'global') {
+                // Poprzedni widok był serwerem — zapamiętaj który
+                if (prevData?.mode === 'server' && prevData.guildId) {
+                    parentGuildId = prevData.guildId;
+                    parentGuildName = prevData.guildName || null;
+                } else if (prevData?.mode === 'guild_ranking') {
+                    // Wracamy z guild_ranking do global — zachowaj parentGuildId
+                    parentGuildId = prevData.parentGuildId || null;
+                    parentGuildName = prevData.parentGuildName || null;
+                }
+            }
 
             const embed = await this.rankingService.createRankingEmbed(
                 players, currentPage, totalPages, interaction.user.id, guild,
@@ -2804,12 +2834,7 @@ class InteractionHandler {
             );
             const buttons = this.rankingService.createRankingButtons(
                 currentPage, totalPages, false, rankMsgs, roleRows,
-                {
-                    userPage,
-                    mode,
-                    guildId: mode === 'global' ? homeGuildId : guildId,
-                    guildName: mode === 'global' ? homeGuildName : guildName
-                }
+                { userPage, mode, guildId, guildName, parentGuildId, parentGuildName }
             );
 
             const reply = await interaction.editReply({
@@ -2827,8 +2852,8 @@ class InteractionHandler {
                 mode,
                 guildId,
                 guildName,
-                homeGuildId,
-                homeGuildName,
+                parentGuildId,
+                parentGuildName,
                 callerStats,
                 roleRows,
                 userPage
@@ -2936,6 +2961,63 @@ class InteractionHandler {
 
         } catch (err) {
             logger.error('Błąd w _handleRoleRankingSelect:', err);
+            await interaction.editReply({ content: msgs.rankingError, embeds: [], components: [] });
+        }
+    }
+
+    /**
+     * Obsługuje kliknięcie przycisku "Ranking Serwerów" — tryb guild_ranking.
+     */
+    async _handleGuildRankingSelect(interaction) {
+        await interaction.deferUpdate();
+        const msgs = this.msgs(interaction.guildId);
+
+        // Pobierz poprzedni stan — potrzebny parentGuildId
+        const prevData = this.rankingService.getActiveRanking(interaction.message.id);
+        const parentGuildId = prevData?.parentGuildId || prevData?.guildId || null;
+        const parentGuildName = prevData?.parentGuildName || prevData?.guildName || null;
+
+        try {
+            const guildScores = await this.rankingService.getGuildRanking(interaction.client);
+
+            if (guildScores.length === 0) {
+                await interaction.editReply({ content: msgs.rankingEmpty, embeds: [], components: [] });
+                return;
+            }
+
+            const perPage = this.config.ranking.playersPerPage;
+            const totalPages = Math.max(1, Math.ceil(guildScores.length / perPage));
+
+            const embed = this.rankingService.createGuildRankingEmbed(guildScores, 0, totalPages, msgs);
+            const buttons = this.rankingService.createRankingButtons(0, totalPages, false, msgs, [], {
+                userPage: null,
+                mode: 'guild_ranking',
+                guildId: null,
+                guildName: null,
+                parentGuildId,
+                parentGuildName
+            });
+
+            const reply = await interaction.editReply({ content: null, embeds: [embed], components: buttons });
+            this.rankingService.addActiveRanking(reply.id, {
+                guildScores,
+                players: [],
+                currentPage: 0,
+                totalPages,
+                userId: interaction.user.id,
+                messageId: reply.id,
+                mode: 'guild_ranking',
+                guildId: null,
+                guildName: null,
+                parentGuildId,
+                parentGuildName,
+                callerStats: null,
+                roleRows: [],
+                userPage: null
+            });
+
+        } catch (err) {
+            logger.error('Błąd w _handleGuildRankingSelect:', err);
             await interaction.editReply({ content: msgs.rankingError, embeds: [], components: [] });
         }
     }

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -2649,16 +2649,15 @@ class InteractionHandler {
             let newPage = rankingData.currentPage;
 
             switch (customId) {
-                case 'ranking_first': newPage = 0; break;
-                case 'ranking_prev':  newPage = Math.max(0, rankingData.currentPage - 1); break;
-                case 'ranking_next':  newPage = Math.min(rankingData.totalPages - 1, rankingData.currentPage + 1); break;
-                case 'ranking_last':  newPage = rankingData.totalPages - 1; break;
+                case 'ranking_prev':   newPage = Math.max(0, rankingData.currentPage - 1); break;
+                case 'ranking_next':   newPage = Math.min(rankingData.totalPages - 1, rankingData.currentPage + 1); break;
+                case 'ranking_mypos':  newPage = rankingData.userPage ?? rankingData.currentPage; break;
             }
 
             rankingData.currentPage = newPage;
             this.rankingService.updateActiveRanking(interaction.message.id, rankingData);
 
-            const guild = rankingData.mode === 'server'
+            const guild = (rankingData.mode === 'server' || rankingData.mode === 'role')
                 ? (interaction.client.guilds.cache.get(rankingData.guildId) || interaction.guild)
                 : null;
 
@@ -2671,7 +2670,15 @@ class InteractionHandler {
                     callerStats: rankingData.callerStats || null
                 }
             );
-            const buttons = this.rankingService.createRankingButtons(newPage, rankingData.totalPages, false, msgs, rankingData.roleRows || []);
+            const buttons = this.rankingService.createRankingButtons(
+                newPage, rankingData.totalPages, false, msgs, rankingData.roleRows || [],
+                {
+                    userPage: rankingData.userPage ?? null,
+                    mode: rankingData.mode,
+                    guildId: rankingData.guildId || rankingData.homeGuildId || null,
+                    guildName: rankingData.guildName || null
+                }
+            );
 
             await interaction.editReply({ embeds: [embed], components: buttons });
 
@@ -2774,6 +2781,18 @@ class InteractionHandler {
                 }
             }
 
+            // Strona użytkownika w bieżącym rankingu (dla przycisku "Moja pozycja")
+            const callerIdx = players.findIndex(p => p.userId === interaction.user.id);
+            const userPage = callerIdx !== -1
+                ? Math.floor(callerIdx / this.config.ranking.playersPerPage)
+                : null;
+
+            // Nazwa serwera dla przycisku server↔global
+            const guildName = guild?.name || null;
+            // homeGuildId — serwer użytkownika (fallback gdy tryb global)
+            const homeGuildId = guildId || interaction.guildId;
+            const homeGuildName = guildName || interaction.guild?.name || null;
+
             const embed = await this.rankingService.createRankingEmbed(
                 players, currentPage, totalPages, interaction.user.id, guild,
                 {
@@ -2783,7 +2802,15 @@ class InteractionHandler {
                     callerStats
                 }
             );
-            const buttons = this.rankingService.createRankingButtons(currentPage, totalPages, false, rankMsgs, roleRows);
+            const buttons = this.rankingService.createRankingButtons(
+                currentPage, totalPages, false, rankMsgs, roleRows,
+                {
+                    userPage,
+                    mode,
+                    guildId: mode === 'global' ? homeGuildId : guildId,
+                    guildName: mode === 'global' ? homeGuildName : guildName
+                }
+            );
 
             const reply = await interaction.editReply({
                 content: null,
@@ -2799,8 +2826,12 @@ class InteractionHandler {
                 messageId: reply.id,
                 mode,
                 guildId,
+                guildName,
+                homeGuildId,
+                homeGuildName,
                 callerStats,
-                roleRows
+                roleRows,
+                userPage
             });
 
         } catch (error) {
@@ -2817,44 +2848,7 @@ class InteractionHandler {
         await interaction.deferUpdate();
         const msgs = this.msgs(interaction.guildId);
 
-        const rankingData = this.rankingService.getActiveRanking(interaction.message.id);
-
-        // Powrót z rankingu roli → przywróć ranking serwera
-        if (rankingData?.mode === 'role' && rankingData.parentGuildId) {
-            try {
-                const parentGuildId = rankingData.parentGuildId;
-                const players = await this.rankingService.getSortedPlayers(parentGuildId);
-                const totalPages = Math.ceil(players.length / this.config.ranking.playersPerPage);
-                const guild = interaction.client.guilds.cache.get(parentGuildId) || null;
-
-                let roleRows = [];
-                if (this.roleRankingConfigService) {
-                    const roleRankings = await this.roleRankingConfigService.loadRoleRankings(parentGuildId);
-                    if (roleRankings.length > 0) {
-                        roleRows = this.rankingService.createRoleRankingButtons(roleRankings, parentGuildId);
-                    }
-                }
-
-                const embed = await this.rankingService.createRankingEmbed(
-                    players, 0, totalPages, rankingData.userId, guild,
-                    { mode: 'server', client: null, messages: msgs, callerStats: rankingData.callerStats || null }
-                );
-                const buttons = this.rankingService.createRankingButtons(0, totalPages, false, msgs, roleRows);
-
-                const reply = await interaction.editReply({ content: null, embeds: [embed], components: buttons });
-                this.rankingService.addActiveRanking(reply.id, {
-                    players, currentPage: 0, totalPages,
-                    userId: rankingData.userId, messageId: reply.id,
-                    mode: 'server', guildId: parentGuildId,
-                    callerStats: rankingData.callerStats || null, roleRows
-                });
-                return;
-            } catch (err) {
-                logger.error('Błąd powrotu z rankingu roli:', err);
-            }
-        }
-
-        // Domyślny powrót → wybór serwera/global
+        // Zawsze wróć do wyboru serwerów
         const selectRows = this.rankingService.createServerSelectButtons(interaction.client, msgs);
         await interaction.editReply({
             content: msgs.rankingSelectPrompt,
@@ -2890,22 +2884,36 @@ class InteractionHandler {
             const roleRankings = await this.roleRankingConfigService.loadRoleRankings(guildId);
             const roleCfg = roleRankings.find(r => r.roleId === roleId);
             const roleName = roleCfg?.roleName || roleId;
+            const guildName = guild.name;
+
+            // Przyciski ról — aktywna rola wyłączona
+            const roleRows = roleRankings.length > 0
+                ? this.rankingService.createRoleRankingButtons(roleRankings, guildId, roleId)
+                : [];
 
             const players = await this.rankingService.getSortedPlayersByRole(guildId, roleId, guild, this.roleRankingConfigService);
 
+            // Strona z wynikiem użytkownika w rankingu roli
+            const callerIdx = players.findIndex(p => p.userId === parentUserId);
+            const userPage = callerIdx !== -1
+                ? Math.floor(callerIdx / this.config.ranking.playersPerPage)
+                : null;
+
+            const btnOptions = { userPage, mode: 'role', guildId, guildName };
+
             if (players.length === 0) {
+                const emptyButtons = this.rankingService.createRankingButtons(0, 1, false, msgs, roleRows, btnOptions);
                 await interaction.editReply({
                     content: `📋 Brak graczy z rolą **${roleName}** w rankingu.`,
                     embeds: [],
-                    components: this.rankingService.createRankingButtons(0, 1, false, msgs)
+                    components: emptyButtons
                 });
-                // Zachowaj cache z mode=role żeby Back działał
                 const reply = await interaction.fetchReply();
                 this.rankingService.addActiveRanking(reply.id, {
                     players: [], currentPage: 0, totalPages: 1,
                     userId: parentUserId, messageId: reply.id,
                     mode: 'role', guildId, parentGuildId: guildId, roleId,
-                    callerStats: parentCallerStats, roleRows: []
+                    guildName, callerStats: parentCallerStats, roleRows, userPage: null
                 });
                 return;
             }
@@ -2916,14 +2924,14 @@ class InteractionHandler {
                 players, 0, totalPages, parentUserId, guild,
                 { mode: 'server', client: null, messages: msgs, callerStats: parentCallerStats, titleOverride: `🎖️ Ranking roli: ${roleName}` }
             );
-            const buttons = this.rankingService.createRankingButtons(0, totalPages, false, msgs);
+            const buttons = this.rankingService.createRankingButtons(0, totalPages, false, msgs, roleRows, btnOptions);
 
             const reply = await interaction.editReply({ content: null, embeds: [embed], components: buttons });
             this.rankingService.addActiveRanking(reply.id, {
                 players, currentPage: 0, totalPages,
                 userId: parentUserId, messageId: reply.id,
                 mode: 'role', guildId, parentGuildId: guildId, roleId,
-                callerStats: parentCallerStats, roleRows: []
+                guildName, callerStats: parentCallerStats, roleRows, userPage
             });
 
         } catch (err) {

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -1706,7 +1706,7 @@ class InteractionHandler {
     }
 
     /**
-     * Obsługuje komendę /ranking — pokazuje ephemeral z przyciskami wyboru serwera/global
+     * Obsługuje komendę /ranking — pokazuje ephemeral z rankingiem własnego serwera.
      * @param {CommandInteraction} interaction
      */
     async handleRankingCommand(interaction) {
@@ -1715,16 +1715,79 @@ class InteractionHandler {
         try {
             await interaction.deferReply({ flags: ['Ephemeral'] });
 
-            const selectRows = this.rankingService.createServerSelectButtons(interaction.client, msgs);
+            const guildId = interaction.guildId;
+            const guild = interaction.guild;
+            const players = await this.rankingService.getSortedPlayers(guildId);
 
-            await interaction.editReply({
-                content: msgs.rankingSelectPrompt,
-                components: selectRows
+            if (players.length === 0) {
+                await interaction.editReply({ content: msgs.rankingEmpty });
+                return;
+            }
+
+            const totalPages = Math.ceil(players.length / this.config.ranking.playersPerPage);
+
+            // Statystyki wywołującego
+            let callerStats = null;
+            try {
+                const callerUserId = interaction.user.id;
+                const globalRanking = await this.rankingService.getGlobalRanking(new Set(interaction.client.guilds.cache.keys()));
+                const globalIdx = globalRanking.findIndex(p => p.userId === callerUserId);
+                const serverIdx = players.findIndex(p => p.userId === callerUserId);
+                callerStats = {
+                    score: globalIdx !== -1 ? globalRanking[globalIdx].score : null,
+                    serverPosition: serverIdx !== -1 ? serverIdx + 1 : null,
+                    globalPosition: globalIdx !== -1 ? globalIdx + 1 : null,
+                    rolePositions: []
+                };
+                if (this.roleRankingConfigService) {
+                    const roleRankings = await this.roleRankingConfigService.loadRoleRankings(guildId);
+                    const memberRoles = interaction.member?.roles?.cache;
+                    if (roleRankings.length > 0 && memberRoles) {
+                        for (const rr of roleRankings) {
+                            if (!memberRoles.has(rr.roleId)) continue;
+                            const rolePlayers = await this.rankingService.getSortedPlayersByRole(guildId, rr.roleId, guild, this.roleRankingConfigService);
+                            const roleIdx = rolePlayers.findIndex(p => p.userId === callerUserId);
+                            if (roleIdx !== -1) callerStats.rolePositions.push({ roleName: rr.roleName, position: roleIdx + 1 });
+                        }
+                    }
+                }
+            } catch (statsErr) {
+                logger.error('Błąd pobierania statystyk wywołującego:', statsErr);
+            }
+
+            // Przyciski ról
+            let roleRows = [];
+            if (this.roleRankingConfigService) {
+                try {
+                    const roleRankings = await this.roleRankingConfigService.loadRoleRankings(guildId);
+                    if (roleRankings.length > 0) roleRows = this.rankingService.createRoleRankingButtons(roleRankings, guildId);
+                } catch (roleErr) {
+                    logger.warn('Błąd ładowania rankingów ról:', roleErr);
+                }
+            }
+
+            const callerIdx = players.findIndex(p => p.userId === interaction.user.id);
+            const userPage = callerIdx !== -1 ? Math.floor(callerIdx / this.config.ranking.playersPerPage) : null;
+
+            const embed = await this.rankingService.createRankingEmbed(
+                players, 0, totalPages, interaction.user.id, guild,
+                { mode: 'server', client: null, messages: msgs, callerStats }
+            );
+            const buttons = this.rankingService.createRankingButtons(0, totalPages, false, msgs, roleRows, {
+                userPage, mode: 'server', guildId, guildName: guild?.name || null
+            });
+
+            const reply = await interaction.editReply({ embeds: [embed], components: buttons });
+            this.rankingService.addActiveRanking(reply.id, {
+                players, currentPage: 0, totalPages,
+                userId: interaction.user.id, messageId: reply.id,
+                mode: 'server', guildId, guildName: guild?.name || null,
+                parentGuildId: null, parentGuildName: null,
+                callerStats, roleRows, userPage
             });
 
         } catch (error) {
             await this.logService.logRankingError(error, 'handleRankingCommand', interaction.guildId);
-
             if (!interaction.replied && !interaction.deferred) {
                 await interaction.reply({ content: msgs.rankingError, flags: ['Ephemeral'] });
             } else if (interaction.deferred) {

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -121,6 +121,66 @@ class RankingService {
     }
 
     /**
+     * Oblicza ranking serwerów — suma wyników top 30 graczy per serwer.
+     * @param {import('discord.js').Client} client
+     * @returns {Promise<Array<{guildId,guildName,totalScoreValue,totalScore,playerCount,topScore,topScoreValue}>>}
+     */
+    async getGuildRanking(client) {
+        const configuredGuilds = this.config.getAllGuilds();
+        const results = [];
+
+        await Promise.all(configuredGuilds.map(async (guildCfg) => {
+            const guild = client?.guilds?.cache?.get(guildCfg.id);
+            const guildName = guild?.name || guildCfg.tag || guildCfg.id;
+            const players = await this.getSortedPlayers(guildCfg.id);
+            if (players.length === 0) return;
+
+            const top30 = players.slice(0, 30);
+            const totalScoreValue = top30.reduce((sum, p) => sum + (p.scoreValue || 0), 0);
+
+            results.push({
+                guildId: guildCfg.id,
+                guildName,
+                totalScoreValue,
+                totalScore: this.formatScore(totalScoreValue),
+                playerCount: top30.length,
+                topScore: players[0]?.score || '0',
+                topScoreValue: players[0]?.scoreValue || 0
+            });
+        }));
+
+        return results.sort((a, b) => b.totalScoreValue - a.totalScoreValue);
+    }
+
+    /**
+     * Tworzy embed z rankingiem serwerów.
+     * @param {Array} guildScores
+     * @param {number} page
+     * @param {number} totalPages
+     * @param {object} messages
+     * @returns {EmbedBuilder}
+     */
+    createGuildRankingEmbed(guildScores, page, totalPages, messages) {
+        const msgs = messages || this.config.messages;
+        const perPage = this.config.ranking.playersPerPage;
+        const start = page * perPage;
+        const pageItems = guildScores.slice(start, start + perPage);
+
+        const MEDALS = ['🥇', '🥈', '🥉'];
+        const lines = pageItems.map((gs, idx) => {
+            const rank = start + idx + 1;
+            const medal = MEDALS[rank - 1] || `**#${rank}**`;
+            return `${medal} **${gs.guildName}** — ${gs.totalScore}\n┗ ${gs.playerCount} graczy • najlepszy: ${gs.topScore}`;
+        });
+
+        return new EmbedBuilder()
+            .setTitle(msgs.guildRankingTitle || '🏛️ Ranking Serwerów')
+            .setDescription(lines.join('\n\n') || (msgs.rankingEmpty || 'Brak danych'))
+            .setColor(0x9b59b6)
+            .setFooter({ text: `${msgs.guildRankingFooter || 'Suma top 30 graczy per serwer'} • ${page + 1}/${totalPages}` });
+    }
+
+    /**
      * Eksportuje globalny ranking do shared_data/endersecho_ranking.json.
      * @param {{ syncToApi?: boolean }} [options] — syncToApi=false pomija push
      *   do Web API (używane przy starcie bota, żeby nie spamować API rankingiem,
@@ -434,33 +494,70 @@ class RankingService {
      * @param {ActionRowBuilder[]} roleRows
      * @param {object} options
      * @param {number|null} options.userPage - strona z wynikiem wywołującego (null = brak)
-     * @param {'server'|'global'|'role'} options.mode
-     * @param {string|null} options.guildId - ID serwera kontekstowego (dla przycisku server/global)
-     * @param {string|null} options.guildName - nazwa serwera (dla etykiety przycisku)
+     * @param {'server'|'global'|'guild_ranking'|'role'} options.mode
+     * @param {string|null} options.guildId - ID serwera kontekstowego
+     * @param {string|null} options.guildName - nazwa serwera
+     * @param {string|null} options.parentGuildId - ID serwera do którego wraca button5 (w trybie global/guild_ranking)
+     * @param {string|null} options.parentGuildName - nazwa serwera do przycisku Powrót
      */
     createRankingButtons(page, totalPages, disabled = false, messages = null, roleRows = [], options = {}) {
         const msgs = messages || this.config.messages;
-        const { userPage = null, mode = 'server', guildId = null, guildName = null } = options;
+        const { userPage = null, mode = 'server', guildId = null, guildName = null, parentGuildId = null, parentGuildName = null } = options;
 
-        // Przycisk 4: serwer ↔ global
-        let serverGlobalBtn;
+        // Przycisk 4: przełącznik trybu
+        let switchBtn;
         if (mode === 'server') {
-            // Oglądamy serwer → przycisk skrót do globalnego
-            serverGlobalBtn = new ButtonBuilder()
+            switchBtn = new ButtonBuilder()
                 .setCustomId('ranking_select_global')
-                .setLabel(msgs.buttonGlobal)
+                .setLabel(msgs.buttonGlobal || '🌐 Global')
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(disabled);
+        } else if (mode === 'global') {
+            switchBtn = new ButtonBuilder()
+                .setCustomId('ranking_guild_ranking')
+                .setLabel(msgs.buttonServerRanking || '🏛️ Ranking Serwerów')
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(disabled);
+        } else if (mode === 'guild_ranking') {
+            switchBtn = new ButtonBuilder()
+                .setCustomId('ranking_select_global')
+                .setLabel(msgs.buttonIndividualRanking || '👤 Ranking Indywidualny')
                 .setStyle(ButtonStyle.Secondary)
                 .setDisabled(disabled);
         } else {
-            // Oglądamy global lub rolę → przycisk wraca do serwera
-            const label = guildName ? guildName.substring(0, 80) : (msgs.buttonGlobal || '🌐');
+            // role — przycisk do serwera
+            const label = guildName ? guildName.substring(0, 80) : '🏠';
             const serverId = guildId || '';
-            serverGlobalBtn = new ButtonBuilder()
+            switchBtn = new ButtonBuilder()
                 .setCustomId(`ranking_select_server_${serverId}`)
                 .setLabel(label)
                 .setStyle(ButtonStyle.Secondary)
                 .setDisabled(disabled || !serverId);
         }
+
+        // Przycisk 5: powrót
+        // W global/guild_ranking — wraca do serwera który był wcześniej wybrany
+        // W server/role — wraca do wyboru serwerów
+        let backBtn;
+        if ((mode === 'global' || mode === 'guild_ranking') && parentGuildId) {
+            const backLabel = parentGuildName
+                ? `↩️ ${parentGuildName.substring(0, 70)}`
+                : (msgs.buttonBack || '↩️ Powrót');
+            backBtn = new ButtonBuilder()
+                .setCustomId(`ranking_select_server_${parentGuildId}`)
+                .setLabel(backLabel)
+                .setStyle(ButtonStyle.Danger)
+                .setDisabled(disabled);
+        } else {
+            backBtn = new ButtonBuilder()
+                .setCustomId('ranking_back')
+                .setLabel(msgs.buttonBack || '↩️ Wybór serwerów')
+                .setStyle(ButtonStyle.Danger)
+                .setDisabled(disabled);
+        }
+
+        // "Moja pozycja" nieaktywna w guild_ranking (ranking serwerów, nie indywidualny)
+        const myPosDisabled = disabled || userPage === null || mode === 'guild_ranking';
 
         const navRow = new ActionRowBuilder();
         navRow.addComponents(
@@ -474,7 +571,7 @@ class RankingService {
                 .setCustomId('ranking_mypos')
                 .setLabel(msgs.buttonMyPos)
                 .setStyle(ButtonStyle.Primary)
-                .setDisabled(disabled || userPage === null),
+                .setDisabled(myPosDisabled),
 
             new ButtonBuilder()
                 .setCustomId('ranking_next')
@@ -482,13 +579,8 @@ class RankingService {
                 .setStyle(ButtonStyle.Secondary)
                 .setDisabled(disabled || page >= totalPages - 1),
 
-            serverGlobalBtn,
-
-            new ButtonBuilder()
-                .setCustomId('ranking_back')
-                .setLabel(msgs.buttonBack)
-                .setStyle(ButtonStyle.Danger)
-                .setDisabled(disabled)
+            switchBtn,
+            backBtn
         );
 
         return [navRow, ...roleRows];

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -426,17 +426,44 @@ class RankingService {
      * @param {Object|null} messages - opcjonalny zestaw komunikatów
      * @returns {ActionRowBuilder}
      */
-    createRankingButtons(page, totalPages, disabled = false, messages = null, roleRows = []) {
+    /**
+     * @param {number} page
+     * @param {number} totalPages
+     * @param {boolean} disabled
+     * @param {object|null} messages
+     * @param {ActionRowBuilder[]} roleRows
+     * @param {object} options
+     * @param {number|null} options.userPage - strona z wynikiem wywołującego (null = brak)
+     * @param {'server'|'global'|'role'} options.mode
+     * @param {string|null} options.guildId - ID serwera kontekstowego (dla przycisku server/global)
+     * @param {string|null} options.guildName - nazwa serwera (dla etykiety przycisku)
+     */
+    createRankingButtons(page, totalPages, disabled = false, messages = null, roleRows = [], options = {}) {
         const msgs = messages || this.config.messages;
+        const { userPage = null, mode = 'server', guildId = null, guildName = null } = options;
+
+        // Przycisk 4: serwer ↔ global
+        let serverGlobalBtn;
+        if (mode === 'server') {
+            // Oglądamy serwer → przycisk skrót do globalnego
+            serverGlobalBtn = new ButtonBuilder()
+                .setCustomId('ranking_select_global')
+                .setLabel(msgs.buttonGlobal)
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(disabled);
+        } else {
+            // Oglądamy global lub rolę → przycisk wraca do serwera
+            const label = guildName ? guildName.substring(0, 80) : (msgs.buttonGlobal || '🌐');
+            const serverId = guildId || '';
+            serverGlobalBtn = new ButtonBuilder()
+                .setCustomId(`ranking_select_server_${serverId}`)
+                .setLabel(label)
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(disabled || !serverId);
+        }
 
         const navRow = new ActionRowBuilder();
         navRow.addComponents(
-            new ButtonBuilder()
-                .setCustomId('ranking_first')
-                .setLabel(msgs.buttonFirst)
-                .setStyle(ButtonStyle.Secondary)
-                .setDisabled(disabled || page === 0),
-
             new ButtonBuilder()
                 .setCustomId('ranking_prev')
                 .setLabel(msgs.buttonPrev)
@@ -444,16 +471,18 @@ class RankingService {
                 .setDisabled(disabled || page === 0),
 
             new ButtonBuilder()
+                .setCustomId('ranking_mypos')
+                .setLabel(msgs.buttonMyPos)
+                .setStyle(ButtonStyle.Primary)
+                .setDisabled(disabled || userPage === null),
+
+            new ButtonBuilder()
                 .setCustomId('ranking_next')
                 .setLabel(msgs.buttonNext)
                 .setStyle(ButtonStyle.Secondary)
                 .setDisabled(disabled || page >= totalPages - 1),
 
-            new ButtonBuilder()
-                .setCustomId('ranking_last')
-                .setLabel(msgs.buttonLast)
-                .setStyle(ButtonStyle.Secondary)
-                .setDisabled(disabled || page >= totalPages - 1),
+            serverGlobalBtn,
 
             new ButtonBuilder()
                 .setCustomId('ranking_back')
@@ -470,19 +499,22 @@ class RankingService {
      * Maks. 10 ról = 2 wiersze po 5.
      * @param {Array} roleRankings - lista { roleId, roleName }
      * @param {string} guildId
+     * @param {string|null} activeRoleId - ID aktualnie wyświetlanej roli (przycisk wyłączony)
      * @returns {ActionRowBuilder[]}
      */
-    createRoleRankingButtons(roleRankings, guildId) {
+    createRoleRankingButtons(roleRankings, guildId, activeRoleId = null) {
         const rows = [];
         for (let i = 0; i < roleRankings.length; i += 5) {
             const row = new ActionRowBuilder();
             const chunk = roleRankings.slice(i, i + 5);
             for (const rr of chunk) {
+                const isActive = rr.roleId === activeRoleId;
                 row.addComponents(
                     new ButtonBuilder()
                         .setCustomId(`ranking_role_${guildId}_${rr.roleId}`)
                         .setLabel(rr.roleName.substring(0, 80))
-                        .setStyle(ButtonStyle.Primary)
+                        .setStyle(isActive ? ButtonStyle.Secondary : ButtonStyle.Primary)
+                        .setDisabled(isActive)
                 );
             }
             rows.push(row);

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -653,13 +653,6 @@ class RankingService {
             );
         }
 
-        buttons.push(
-            new ButtonBuilder()
-                .setCustomId('ranking_select_global')
-                .setLabel(msgs.globalButtonLabel)
-                .setStyle(ButtonStyle.Success)
-        );
-
         const rows = [];
         for (let i = 0; i < buttons.length; i += 5) {
             const row = new ActionRowBuilder();


### PR DESCRIPTION
## Summary
This PR significantly refactors the ranking command system to provide a more intuitive navigation flow and introduces a new guild-level ranking feature. The changes simplify the ranking UI by replacing first/last page buttons with a "My Position" button and restructure how users navigate between different ranking modes (server, global, guild, and role rankings).

## Key Changes

### Ranking Command Handler (`handleRankingCommand`)
- Changed `/ranking` command to display server ranking directly instead of showing a server selection prompt
- Added caller statistics calculation (server position, global position, and role positions)
- Integrated role ranking buttons directly into the initial response
- Implemented pagination with "My Position" button to jump to user's rank

### New Guild Ranking Feature
- Added `_handleGuildRankingSelect()` method to display rankings aggregated across all configured servers
- Guild ranking calculates total score from top 30 players per server
- Added `getGuildRanking()` service method to compute guild scores
- Added `createGuildRankingEmbed()` to format guild ranking display

### Navigation Button Redesign
- Replaced `ranking_first` and `ranking_last` buttons with `ranking_mypos` (jump to user's position)
- Restructured button layout: Previous | My Position | Next | Mode Switch | Back
- Mode switch button changes based on context:
  - Server → Global
  - Global → Guild Ranking
  - Guild Ranking → Individual Ranking
  - Role → Server (with guild name label)
- Back button now intelligently returns to previous context (server selection or parent guild)

### State Management Improvements
- Enhanced `rankingData` object to track:
  - `userPage`: page containing user's ranking position
  - `guildName`: server name for button labels
  - `parentGuildId` / `parentGuildName`: for navigation between modes
  - `mode`: current ranking mode ('server', 'global', 'guild_ranking', 'role')
- Added support for `guild_ranking` mode in embed and button creation

### Role Ranking Enhancements
- Active role button is now visually disabled (Secondary style) when viewing that role's ranking
- Role ranking buttons passed through navigation system with proper context
- Improved role ranking button creation with `activeRoleId` parameter

### Button Navigation Updates
- `createRankingButtons()` now accepts options object with mode, guild info, and user page
- Pagination logic updated to handle `ranking_mypos` button
- Removed hardcoded "Back to selection" behavior in favor of context-aware navigation

### Message Configuration
- Updated button labels: removed "First"/"Last", added "My Position", "Global", "Server Ranking", "Individual Ranking"
- Added guild ranking title and footer messages
- Updated Polish and English translations

## Notable Implementation Details
- Guild ranking sums top 30 players per server to prevent single-server dominance
- User position calculation is cached in `rankingData.userPage` to avoid recalculation on navigation
- Parent guild tracking enables seamless navigation between global and server-specific rankings
- Role ranking maintains parent guild context for proper back navigation

https://claude.ai/code/session_01QVMEvHWY4CFq9cDhiWAoXk