### PR TITLE
EndersEcho: przebudowa nawigacji rankingu + Ranking Serwerów

### DIFF
--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -473,6 +473,9 @@ class RankingService {
         if (!isGlobal && guild) {
             const iconUrl = guild.iconURL({ size: 128 });
             if (iconUrl) embed.setThumbnail(iconUrl);
+        } else if (isGlobal && client) {
+            const botIconUrl = client.user?.displayAvatarURL({ size: 128 });
+            if (botIconUrl) embed.setThumbnail(botIconUrl);
         }
 
         return embed;


### PR DESCRIPTION
## Summary

- `/ranking` otwiera bezpośrednio ranking własnego serwera (bez ekranu wyboru)
- Przebudowano pasek nawigacji paginacji: usunięto przyciski Pierwsza/Ostatnia, dodano **🎯 Moja pozycja** (skacze do strony z wynikiem użytkownika; wyłączony gdy nie ma go w rankingu) i przełącznik **server ↔ global ↔ Ranking Serwerów**
- Dodano **Ranking Serwerów** — skumulowane wyniki top 30 graczy per serwer, posortowane malejąco
- W rankingu globalnym przycisk 4 to `🏛️ Ranking Serwerów`, w Rankingu Serwerów przycisk 4 to `👤 Ranking Indywidualny`
- Przycisk powrotu w trybie global/guild_ranking wraca do wcześniej wybranego serwera (nie do ekranu wyboru)
- Przycisk powrotu przemianowany na `↩️ Rankingi serwerów`
- Ekran wyboru serwerów (dostępny przez powrót) nie zawiera już przycisku Global
- W rankingu roli: pozostałe przyciski ról nadal widoczne, aktywna rola wyłączona (szara)
- Ikona bota jako thumbnail w embedzie globalnego rankingu

## Test plan

- [ ] `/ranking` → otwiera ranking własnego serwera bezpośrednio
- [ ] Przycisk `🌐 Global` → ranking globalny z ikoną bota jako thumbnail
- [ ] W globalnym: przycisk `🏛️ Ranking Serwerów` → embed z listą serwerów i skumulowanymi wynikami
- [ ] W Rankingu Serwerów: przycisk `👤 Ranking Indywidualny` → powrót do globalnego
- [ ] W globalnym/Rankingu Serwerów: przycisk powrotu → wraca do poprzednio wybranego serwera
- [ ] `🎯 Moja pozycja` → skacze do odpowiedniej strony (wyłączony gdy nie ma gracza w rankingu)
- [ ] Ranking roli: aktywna rola wyłączona, pozostałe klikalne
- [ ] `↩️ Rankingi serwerów` → ekran wyboru serwerów (bez przycisku Global)

https://claude.ai/code/session_01QVMEvHWY4CFq9cDhiWAoXk

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVMEvHWY4CFq9cDhiWAoXk)_