### PR TITLE
EndersEcho: system osiągnięć + nowa paginacja rankingu + Ranking Serwerów

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -131,6 +131,18 @@
    - Subskrypcje są trwałe (plik JSON) — przeżywają restart bota
    - Limit: max 25 subskrypcji wyświetlanych naraz w select menu (Discord API limit)
 
+7. **System Osiągnięć** — `achievementService.js` + `config/achievements.js`:
+   - **43 stałe osiągnięcia** w 5 kategoriach + 1 dynamiczny status (`status_top1` — rewokowany gdy wynik usunięty)
+   - **Kategorie:** 🏆 Wyniki (20) · 🔁 Rekordy (10) · 🐉 Bossowie (3) · 🕵️ Eksplorator/ukryte (5) · 💎 Prestiż (5)
+   - **Rarities:** ⬜ Common · 🟩 Uncommon · 🟦 Rare · 🟪 Epic · 🟧 Legendary · 🔴 Mythic
+   - **Odblokowanie:** osiągnięcia score/records/bosses/prestige blokowane przy każdym nowym rekordzie; ukryte (explorer) blokowane natychmiast przy przegladzie rankingu lub subskrypcji
+   - **Powiadomienie:** w embeddzie rekordu pojawia się pole `🎉 Nowe osiągnięcia` TYLKO z osiągnięciami zdobytymi od poprzedniego pobicia rekordu (`lastRecordBeatAt`)
+   - **Persistencja:** `data/achievements_{guildId}.json` — per-serwer; przeżywa restart
+   - **Komenda /achievements:** ephemeral embed z zakładkami: `🏆 Odblokowane` (paginacja po 10) i `📊 Podsumowanie` (per-kategoria + statystyki)
+   - **Tracking:** `trackRankingView(guildId, userId)` — wołane w `handleRankingCommand`; `trackSubscription(guildId, userId)` — wołane w `_handleNotifConfirm` po udanej subskrypcji
+   - **Progress:** `progress.recordCount`, `progress.bossesEncountered[]`, `progress.rankingViews`, `progress.subscriptions`, `progress.lastRecordAt`, `progress.lastRecordBeatAt`
+   - **CustomIDs:** `ach_view_{tab}_{page}` — tab = `unlocked` | `overview`
+
 6. **Panel Admina** — dostępny przez `/manage`:
    - **Usuń gracza z rankingu (admin):** modal wyszukiwania nicku → przefiltrowana lista → potwierdzenie → usunięcie + aktualizacja ról TOP. Head Admin może usunąć gracza z **dowolnego serwera** (cross-server).
    - **Odblokuj gracza (admin):** modal wyszukiwania nicku → przefiltrowana lista → odblokowanie. Persistencja: `data/user_blocks.json`. Jeśli blokada pochodzi od Head Admina (`blockedByHeadAdmin: true`) — zwykły Admin nie może odblokować.
@@ -140,7 +152,7 @@
    - **Ustaw limity (head admin):** modal z 2 polami — cooldown (np. `5m`, `1h`) i limit dzienny (liczba). Persistencja: `data/usage_limits.json`, `data/update_cooldowns.json`
    - **Wyślij Info (head admin):** modal → podgląd PL+ENG → wyślij na wszystkie serwery. `_infoSessions` Map (RAM)
 
-**Komendy slash:** `/configure`, `/manage`, `/ranking`, `/subscribe`, `/test`, `/update`
+**Komendy slash:** `/achievements`, `/configure`, `/manage`, `/ranking`, `/subscribe`, `/test`, `/update`
 
 **Panel Admina** — dostępny przez `/manage`:
 - Dostęp: każdy admin Discord (Administrator)

--- a/EndersEcho/config/achievements.js
+++ b/EndersEcho/config/achievements.js
@@ -1,0 +1,307 @@
+'use strict';
+
+const RARITY = {
+    common:    { pol: 'Zwykłe',      eng: 'Common',    emoji: '⬜', color: 0x95a5a6 },
+    uncommon:  { pol: 'Niepospolite', eng: 'Uncommon', emoji: '🟩', color: 0x2ecc71 },
+    rare:      { pol: 'Rzadkie',     eng: 'Rare',      emoji: '🟦', color: 0x3498db },
+    epic:      { pol: 'Epickie',     eng: 'Epic',      emoji: '🟪', color: 0x9b59b6 },
+    legendary: { pol: 'Legendarne',  eng: 'Legendary', emoji: '🟧', color: 0xe67e22 },
+    mythic:    { pol: 'Mityczne',    eng: 'Mythic',    emoji: '🔴', color: 0xe74c3c },
+};
+
+const CATEGORY_INFO = {
+    score:    { pol: '🏆 Wyniki',      eng: '🏆 Scores'   },
+    records:  { pol: '🔁 Rekordy',     eng: '🔁 Records'  },
+    bosses:   { pol: '🐉 Bossowie',    eng: '🐉 Bosses'   },
+    explorer: { pol: '🕵️ Eksplorator', eng: '🕵️ Explorer' },
+    prestige: { pol: '💎 Prestiż',     eng: '💎 Prestige'  },
+};
+
+// check(progress, context) — progress = user's stored progress object,
+// context = { scoreValue, isNewRecord, prevScoreValue, currentPosition, bossName }
+const ACHIEVEMENTS = [
+    // ===== WYNIKI (SCORES) =====
+    {
+        id: 'score_first', category: 'score', rarity: 'common', hidden: false,
+        namePol: 'Pierwsze Kroki',   nameEng: 'First Steps',
+        descPol: 'Prześlij swój pierwszy wynik', descEng: 'Submit your first score',
+        check: (_p, ctx) => ctx.isNewRecord,
+    },
+    {
+        id: 'score_1k', category: 'score', rarity: 'common', hidden: false,
+        namePol: 'Debiutant',   nameEng: 'Beginner',
+        descPol: 'Osiągnij wynik 1 000', descEng: 'Reach a score of 1,000',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 1_000,
+    },
+    {
+        id: 'score_10k', category: 'score', rarity: 'common', hidden: false,
+        namePol: 'Aspirant',   nameEng: 'Aspirant',
+        descPol: 'Osiągnij wynik 10 000', descEng: 'Reach a score of 10,000',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 10_000,
+    },
+    {
+        id: 'score_100k', category: 'score', rarity: 'common', hidden: false,
+        namePol: 'Zawodnik',   nameEng: 'Contender',
+        descPol: 'Osiągnij wynik 100 000', descEng: 'Reach a score of 100,000',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 100_000,
+    },
+    {
+        id: 'score_1m', category: 'score', rarity: 'uncommon', hidden: false,
+        namePol: 'Milioner',   nameEng: 'Millionaire',
+        descPol: 'Osiągnij wynik 1M', descEng: 'Reach a score of 1M',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 1_000_000,
+    },
+    {
+        id: 'score_10m', category: 'score', rarity: 'uncommon', hidden: false,
+        namePol: 'Magnat',   nameEng: 'Magnate',
+        descPol: 'Osiągnij wynik 10M', descEng: 'Reach a score of 10M',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 10_000_000,
+    },
+    {
+        id: 'score_100m', category: 'score', rarity: 'uncommon', hidden: false,
+        namePol: 'Potentat',   nameEng: 'Potentate',
+        descPol: 'Osiągnij wynik 100M', descEng: 'Reach a score of 100M',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 100_000_000,
+    },
+    {
+        id: 'score_1b', category: 'score', rarity: 'rare', hidden: false,
+        namePol: 'Miliarder',   nameEng: 'Billionaire',
+        descPol: 'Osiągnij wynik 1B', descEng: 'Reach a score of 1B',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 1_000_000_000,
+    },
+    {
+        id: 'score_10b', category: 'score', rarity: 'rare', hidden: false,
+        namePol: 'Gigant',   nameEng: 'Giant',
+        descPol: 'Osiągnij wynik 10B', descEng: 'Reach a score of 10B',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 10_000_000_000,
+    },
+    {
+        id: 'score_100b', category: 'score', rarity: 'rare', hidden: false,
+        namePol: 'Lewiatan',   nameEng: 'Leviathan',
+        descPol: 'Osiągnij wynik 100B', descEng: 'Reach a score of 100B',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 100_000_000_000,
+    },
+    {
+        id: 'score_1t', category: 'score', rarity: 'epic', hidden: false,
+        namePol: 'Tytan',   nameEng: 'Titan',
+        descPol: 'Osiągnij wynik 1T', descEng: 'Reach a score of 1T',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 1_000_000_000_000,
+    },
+    {
+        id: 'score_10t', category: 'score', rarity: 'epic', hidden: false,
+        namePol: 'Behemot',   nameEng: 'Behemoth',
+        descPol: 'Osiągnij wynik 10T', descEng: 'Reach a score of 10T',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 10_000_000_000_000,
+    },
+    {
+        id: 'score_100t', category: 'score', rarity: 'epic', hidden: false,
+        namePol: 'Kolos',   nameEng: 'Colossus',
+        descPol: 'Osiągnij wynik 100T', descEng: 'Reach a score of 100T',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 100_000_000_000_000,
+    },
+    {
+        id: 'score_1q', category: 'score', rarity: 'legendary', hidden: false,
+        namePol: 'Feniks',   nameEng: 'Phoenix',
+        descPol: 'Osiągnij wynik 1Q', descEng: 'Reach a score of 1Q',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 1e15,
+    },
+    {
+        id: 'score_10q', category: 'score', rarity: 'legendary', hidden: false,
+        namePol: 'Smok',   nameEng: 'Dragon',
+        descPol: 'Osiągnij wynik 10Q', descEng: 'Reach a score of 10Q',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 1e16,
+    },
+    {
+        id: 'score_100q', category: 'score', rarity: 'legendary', hidden: false,
+        namePol: 'Półbóg',   nameEng: 'Demigod',
+        descPol: 'Osiągnij wynik 100Q', descEng: 'Reach a score of 100Q',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 1e17,
+    },
+    {
+        id: 'score_1qi', category: 'score', rarity: 'mythic', hidden: false,
+        namePol: 'Nieśmiertelny',   nameEng: 'Immortal',
+        descPol: 'Osiągnij wynik 1Qi', descEng: 'Reach a score of 1Qi',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 1e18,
+    },
+    {
+        id: 'score_10qi', category: 'score', rarity: 'mythic', hidden: false,
+        namePol: 'Transcendent',   nameEng: 'Transcendent',
+        descPol: 'Osiągnij wynik 10Qi', descEng: 'Reach a score of 10Qi',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 1e19,
+    },
+    {
+        id: 'score_1sx', category: 'score', rarity: 'mythic', hidden: false,
+        namePol: 'Bóg Wyników',   nameEng: 'Score God',
+        descPol: 'Osiągnij wynik 1Sx', descEng: 'Reach a score of 1Sx',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 1e21,
+    },
+    {
+        id: 'score_1sp', category: 'score', rarity: 'mythic', hidden: false,
+        namePol: 'Poza Granicami',   nameEng: 'Beyond Limits',
+        descPol: 'Osiągnij wynik w nieznanej jednostce', descEng: 'Reach a score in an unknown unit',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 1e24,
+    },
+
+    // ===== REKORDY (RECORDS) =====
+    {
+        id: 'record_1', category: 'records', rarity: 'common', hidden: false,
+        namePol: 'Przetarłem Szlak',   nameEng: 'Trail Blazer',
+        descPol: 'Pobij swój pierwszy rekord', descEng: 'Beat your first record',
+        check: (p, _ctx) => (p.recordCount || 0) >= 1,
+    },
+    {
+        id: 'record_10', category: 'records', rarity: 'uncommon', hidden: false,
+        namePol: 'Dziesięcioboista',   nameEng: 'Decathlete',
+        descPol: 'Pobij rekord 10 razy', descEng: 'Beat your record 10 times',
+        check: (p, _ctx) => (p.recordCount || 0) >= 10,
+    },
+    {
+        id: 'record_20', category: 'records', rarity: 'uncommon', hidden: false,
+        namePol: 'Weteran',   nameEng: 'Veteran',
+        descPol: 'Pobij rekord 20 razy', descEng: 'Beat your record 20 times',
+        check: (p, _ctx) => (p.recordCount || 0) >= 20,
+    },
+    {
+        id: 'record_50', category: 'records', rarity: 'rare', hidden: false,
+        namePol: 'Nieugięty',   nameEng: 'Relentless',
+        descPol: 'Pobij rekord 50 razy', descEng: 'Beat your record 50 times',
+        check: (p, _ctx) => (p.recordCount || 0) >= 50,
+    },
+    {
+        id: 'record_100', category: 'records', rarity: 'epic', hidden: false,
+        namePol: 'Stuprocentowy',   nameEng: 'Centurion',
+        descPol: 'Pobij rekord 100 razy', descEng: 'Beat your record 100 times',
+        check: (p, _ctx) => (p.recordCount || 0) >= 100,
+    },
+    {
+        id: 'record_200', category: 'records', rarity: 'epic', hidden: false,
+        namePol: 'Dwieście',   nameEng: 'Double Centurion',
+        descPol: 'Pobij rekord 200 razy', descEng: 'Beat your record 200 times',
+        check: (p, _ctx) => (p.recordCount || 0) >= 200,
+    },
+    {
+        id: 'record_500', category: 'records', rarity: 'legendary', hidden: false,
+        namePol: 'Pięćset',   nameEng: 'Five Hundred',
+        descPol: 'Pobij rekord 500 razy', descEng: 'Beat your record 500 times',
+        check: (p, _ctx) => (p.recordCount || 0) >= 500,
+    },
+    {
+        id: 'record_1000', category: 'records', rarity: 'mythic', hidden: false,
+        namePol: 'Tysiącznik',   nameEng: 'Millennial',
+        descPol: 'Pobij rekord 1000 razy', descEng: 'Beat your record 1000 times',
+        check: (p, _ctx) => (p.recordCount || 0) >= 1000,
+    },
+    {
+        id: 'improve_100pct', category: 'records', rarity: 'rare', hidden: false,
+        namePol: 'Podwójny Postęp',   nameEng: 'Double Progress',
+        descPol: 'Podwój swój wynik w jednym podejściu', descEng: 'Double your score in one submission',
+        check: (_p, ctx) => ctx.prevScoreValue > 0 && ctx.scoreValue >= ctx.prevScoreValue * 2,
+    },
+    {
+        id: 'improve_200pct', category: 'records', rarity: 'legendary', hidden: false,
+        namePol: 'Potrójny Postęp',   nameEng: 'Triple Progress',
+        descPol: 'Potróż swój wynik w jednym podejściu', descEng: 'Triple your score in one submission',
+        check: (_p, ctx) => ctx.prevScoreValue > 0 && ctx.scoreValue >= ctx.prevScoreValue * 3,
+    },
+
+    // ===== BOSSOWIE (BOSSES) =====
+    {
+        id: 'boss_first', category: 'bosses', rarity: 'common', hidden: false,
+        namePol: 'Pierwsze Starcie',   nameEng: 'First Encounter',
+        descPol: 'Wyślij wynik z dowolnego bossa', descEng: 'Submit a score from any boss',
+        check: (p, _ctx) => (p.bossesEncountered || []).length >= 1,
+    },
+    {
+        id: 'boss_3', category: 'bosses', rarity: 'uncommon', hidden: false,
+        namePol: 'Łowca',   nameEng: 'Hunter',
+        descPol: 'Wyślij wyniki z 3 różnych bossów', descEng: 'Submit scores from 3 different bosses',
+        check: (p, _ctx) => (p.bossesEncountered || []).length >= 3,
+    },
+    {
+        id: 'boss_hunter', category: 'bosses', rarity: 'rare', hidden: false,
+        namePol: 'Łowca Bossów',   nameEng: 'Boss Hunter',
+        descPol: 'Wyślij wyniki z 5 różnych bossów', descEng: 'Submit scores from 5 different bosses',
+        check: (p, _ctx) => (p.bossesEncountered || []).length >= 5,
+    },
+
+    // ===== EKSPLORATOR (EXPLORER) — ukryte =====
+    {
+        id: 'view_10', category: 'explorer', rarity: 'common', hidden: true,
+        namePol: 'Obserwator',   nameEng: 'Observer',
+        descPol: 'Sprawdź ranking 10 razy', descEng: 'View the ranking 10 times',
+        check: (p, _ctx) => (p.rankingViews || 0) >= 10,
+    },
+    {
+        id: 'view_50', category: 'explorer', rarity: 'uncommon', hidden: true,
+        namePol: 'Analityk',   nameEng: 'Analyst',
+        descPol: 'Sprawdź ranking 50 razy', descEng: 'View the ranking 50 times',
+        check: (p, _ctx) => (p.rankingViews || 0) >= 50,
+    },
+    {
+        id: 'view_200', category: 'explorer', rarity: 'rare', hidden: true,
+        namePol: 'Detektyw',   nameEng: 'Detective',
+        descPol: 'Sprawdź ranking 200 razy', descEng: 'View the ranking 200 times',
+        check: (p, _ctx) => (p.rankingViews || 0) >= 200,
+    },
+    {
+        id: 'sub_first', category: 'explorer', rarity: 'common', hidden: true,
+        namePol: 'Kibol',   nameEng: 'Fan',
+        descPol: 'Aktywuj swoją pierwszą subskrypcję', descEng: 'Activate your first subscription',
+        check: (p, _ctx) => (p.subscriptions || 0) >= 1,
+    },
+    {
+        id: 'sub_5', category: 'explorer', rarity: 'uncommon', hidden: true,
+        namePol: 'Zagorzały Kibic',   nameEng: 'Devoted Fan',
+        descPol: 'Aktywuj 5 subskrypcji', descEng: 'Activate 5 subscriptions',
+        check: (p, _ctx) => (p.subscriptions || 0) >= 5,
+    },
+
+    // ===== PRESTIŻ (PRESTIGE) =====
+    {
+        id: 'rank_top10', category: 'prestige', rarity: 'rare', hidden: false,
+        namePol: 'Elita Serwera',   nameEng: 'Server Elite',
+        descPol: 'Zdobądź miejsce w Top 10 serwera', descEng: 'Reach the Top 10 on the server',
+        check: (_p, ctx) => ctx.currentPosition > 0 && ctx.currentPosition <= 10,
+    },
+    {
+        id: 'rank_top3', category: 'prestige', rarity: 'epic', hidden: false,
+        namePol: 'Podium',   nameEng: 'Podium',
+        descPol: 'Zdobądź miejsce w Top 3 serwera', descEng: 'Reach the Top 3 on the server',
+        check: (_p, ctx) => ctx.currentPosition > 0 && ctx.currentPosition <= 3,
+    },
+    {
+        id: 'rank_top1', category: 'prestige', rarity: 'legendary', hidden: false,
+        namePol: 'Mistrz Serwera',   nameEng: 'Server Champion',
+        descPol: 'Zdobądź miejsce #1 na serwerze', descEng: 'Reach #1 on the server',
+        check: (_p, ctx) => ctx.currentPosition === 1,
+    },
+    {
+        id: 'big_leap', category: 'prestige', rarity: 'uncommon', hidden: false,
+        namePol: 'Wielki Skok',   nameEng: 'Big Leap',
+        descPol: 'Popraw wynik o ponad 50% w jednym podejściu', descEng: 'Improve your score by more than 50% in one submission',
+        check: (_p, ctx) => ctx.prevScoreValue > 0 && ctx.scoreValue >= ctx.prevScoreValue * 1.5,
+    },
+    {
+        id: 'comeback', category: 'prestige', rarity: 'rare', hidden: false,
+        namePol: 'Powrót',   nameEng: 'Comeback',
+        descPol: 'Pobij rekord po przerwie ponad 30 dni', descEng: 'Beat a record after a break of over 30 days',
+        check: (p, _ctx) => {
+            if (!p.lastRecordAt) return false;
+            const daysSince = (Date.now() - new Date(p.lastRecordAt).getTime()) / (1000 * 60 * 60 * 24);
+            return daysSince >= 30;
+        },
+    },
+];
+
+// Dynamiczny status — oddzielny od stałych osiągnięć, może być odebrany
+const DYNAMIC_STATUSES = [
+    {
+        id: 'status_top1',
+        namePol: '👑 Aktualny Lider',
+        nameEng: '👑 Current Leader',
+        descPol: 'Aktualnie zajmuje #1 na serwerze',
+        descEng: 'Currently holds #1 on the server',
+    },
+];
+
+module.exports = { ACHIEVEMENTS, RARITY, CATEGORY_INFO, DYNAMIC_STATUSES };

--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -207,6 +207,16 @@ const pol = {
     // Modal blokady użytkownika
     blockUserModalTitle: 'Zablokuj użytkownika',
     blockUserTimeLabel: 'Czas blokady (np. 1h, 7d, 30m) — puste = permanentnie',
+
+    // /achievements
+    achievementsTitle: '🏆 Twoje Osiągnięcia',
+    achievementsOverviewTitle: '📊 Przegląd Osiągnięć',
+    achievementsEmpty: '❌ Nie masz jeszcze żadnych osiągnięć. Graj i bądź aktywny!',
+    achievementsPage: 'Strona {current} z {total} • {count} odblokowanych z {total_ach}',
+    achievementsUnlockedOf: '{count} z {total} odblokowanych',
+    achievementsBtnUnlocked: '🏆 Odblokowane',
+    achievementsBtnOverview: '📊 Podsumowanie',
+    achievementsNewField: '🎉 Nowe osiągnięcia',
     blockUserTimePlaceholder: 'Zostaw puste dla blokady permanentnej',
 
     // /info
@@ -468,6 +478,16 @@ const eng = {
     // User block modal
     blockUserModalTitle: 'Block user',
     blockUserTimeLabel: 'Block duration (e.g. 1h, 7d, 30m) — empty = permanent',
+
+    // /achievements
+    achievementsTitle: '🏆 Your Achievements',
+    achievementsOverviewTitle: '📊 Achievement Overview',
+    achievementsEmpty: '❌ No achievements yet. Play and stay active!',
+    achievementsPage: 'Page {current} of {total} • {count} unlocked of {total_ach}',
+    achievementsUnlockedOf: '{count} of {total} unlocked',
+    achievementsBtnUnlocked: '🏆 Unlocked',
+    achievementsBtnOverview: '📊 Overview',
+    achievementsNewField: '🎉 New achievements',
     blockUserTimePlaceholder: 'Leave empty for permanent block',
 
     // /info

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -44,7 +44,7 @@ function buildGeminiUsage(aiResult) {
 }
 
 class InteractionHandler {
-    constructor(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService, roleRankingConfigService, usageLimitService, tokenUsageService, botOps, guildConfigService, ocrBlockService, updateCooldownService, testerService) {
+    constructor(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService, roleRankingConfigService, usageLimitService, tokenUsageService, botOps, guildConfigService, ocrBlockService, updateCooldownService, testerService, achievementService) {
         this.config = config;
         this.ocrService = ocrService;
         this.aiOcrService = aiOcrService;
@@ -61,6 +61,7 @@ class InteractionHandler {
         this.ocrBlockService = ocrBlockService;
         this.updateCooldownService = updateCooldownService;
         this.testerService = testerService;
+        this.achievementService = achievementService;
         // Tymczasowe sesje dla /info (userId -> { title, description, icon, image })
         // Każda sesja ma TTL 15 minut — timer usuwający ją automatycznie.
         this._infoSessions = new Map();
@@ -131,6 +132,11 @@ class InteractionHandler {
                         .setDescription('Screenshot of the boss result screen')
                         .setDescriptionLocalizations(pl('Screenshot ekranu wyników bossa'))
                         .setRequired(true)),
+
+            new SlashCommandBuilder()
+                .setName('achievements')
+                .setDescription('View your unlocked achievements')
+                .setDescriptionLocalizations(pl('Sprawdź swoje odblokowane osiągnięcia')),
 
             new SlashCommandBuilder()
                 .setName('configure')
@@ -242,9 +248,10 @@ class InteractionHandler {
             }
 
             switch (interaction.commandName) {
-                case 'ranking':   await this.handleRankingCommand(interaction);        break;
-                case 'update':    await this.handleUpdateCommand(interaction);         break;
-                case 'subscribe': await this.handleNotificationsCommand(interaction);  break;
+                case 'ranking':      await this.handleRankingCommand(interaction);        break;
+                case 'update':       await this.handleUpdateCommand(interaction);         break;
+                case 'subscribe':    await this.handleNotificationsCommand(interaction);  break;
+                case 'achievements': await this.handleAchievementsCommand(interaction);   break;
             }
         } else if (interaction.isButton()) {
             await this.handleButtonInteraction(interaction);
@@ -1786,6 +1793,11 @@ class InteractionHandler {
                 callerStats, roleRows, userPage
             });
 
+            // Śledź przegląd rankingu dla osiągnięć (fire-and-forget)
+            if (this.achievementService) {
+                this.achievementService.trackRankingView(guildId, interaction.user.id).catch(() => {});
+            }
+
         } catch (error) {
             await this.logService.logRankingError(error, 'handleRankingCommand', interaction.guildId);
             if (!interaction.replied && !interaction.deferred) {
@@ -2049,6 +2061,25 @@ class InteractionHandler {
                 await this.logService.logScoreUpdate(userName, bestScore, isNewRecord, guildId);
             }
 
+            // Pozycja po zapisie (potrzebna do osiągnięć i do embeda)
+            let newAchievements = [];
+            let currentPositionForAch = 0;
+            if (isNewRecord && !dryRun && this.achievementService) {
+                try {
+                    const sortedAfter = await this.rankingService.getSortedPlayers(guildId);
+                    currentPositionForAch = sortedAfter.findIndex(p => p.userId === userId) + 1;
+                    const prevScoreValue = currentScore ? this.rankingService.parseScoreValue(currentScore.score) : 0;
+                    const newScoreValue = this.rankingService.parseScoreValue(bestScore);
+                    newAchievements = await this.achievementService.processSubmission(guildId, userId, {
+                        scoreValue: newScoreValue,
+                        bossName,
+                        isNewRecord: true,
+                        prevScoreValue,
+                        currentPosition: currentPositionForAch,
+                    });
+                } catch {}
+            }
+
             if (!isNewRecord) {
                 try {
                     const safeUserName = userName.replace(/[^a-zA-Z0-9]/g, '_');
@@ -2102,6 +2133,10 @@ class InteractionHandler {
 
             const guildConfig = this.config.getGuildConfig(interaction.guildId);
             const rolePositions = await this._computeRolePositions(guildId, userId, interaction.guild, interaction.member?.roles?.cache);
+            const lang = guildConfig?.lang || 'pol';
+            const achievementsFieldValue = this.achievementService
+                ? this.achievementService.buildNewAchievementsFieldValue(newAchievements, lang)
+                : null;
             const publicEmbed = await this.rankingService.createRecordEmbed(
                 userName,
                 bestScore,
@@ -2114,7 +2149,8 @@ class InteractionHandler {
                 interaction.guild,
                 guildConfig?.topRoles || null,
                 currentScore ? currentScore.timestamp : null,
-                rolePositions
+                rolePositions,
+                achievementsFieldValue
             );
 
             // Pobierz subskrybentów i dodaj liczbę obserwujących do embeda
@@ -2535,6 +2571,12 @@ class InteractionHandler {
             // === Przycisk powrotu do wyboru ===
             if (customId === 'ranking_back') {
                 await this._handleRankingBack(interaction);
+                return;
+            }
+
+            // === Przyciski /achievements ===
+            if (customId.startsWith('ach_view_')) {
+                await this._handleAchievementsButton(interaction, customId);
                 return;
             }
 
@@ -3151,6 +3193,46 @@ class InteractionHandler {
     /**
      * Obsługuje komendę /notifications
      */
+    // =====================================================================
+    // /achievements
+    // =====================================================================
+
+    async handleAchievementsCommand(interaction) {
+        if (!this._checkConfigured(interaction)) return;
+        await interaction.deferReply({ flags: ['Ephemeral'] });
+        try {
+            const guildId = interaction.guildId;
+            const userId = interaction.user.id;
+            const lang = this.config.getGuildConfig(guildId)?.lang || 'pol';
+            const { embed, components } = await this.achievementService.buildAchievementsView(
+                guildId, userId, lang, 'unlocked', 0
+            );
+            await interaction.editReply({ embeds: [embed], components });
+        } catch (err) {
+            this.logService._gl(interaction.guildId).error(`Błąd /achievements: ${err.message}`);
+            await interaction.editReply({ content: this.msgs(interaction.guildId).generalError });
+        }
+    }
+
+    async _handleAchievementsButton(interaction, customId) {
+        // customId: ach_view_{tab}_{page}  — np. ach_view_unlocked_0
+        await interaction.deferUpdate();
+        try {
+            const parts = customId.split('_'); // ['ach', 'view', tab, page]
+            const tab = parts[2] || 'unlocked';
+            const page = parseInt(parts[3], 10) || 0;
+            const guildId = interaction.guildId;
+            const userId = interaction.user.id;
+            const lang = this.config.getGuildConfig(guildId)?.lang || 'pol';
+            const { embed, components } = await this.achievementService.buildAchievementsView(
+                guildId, userId, lang, tab, page
+            );
+            await interaction.editReply({ embeds: [embed], components });
+        } catch (err) {
+            this.logService._gl(interaction.guildId).error(`Błąd przycisku osiągnięć: ${err.message}`);
+        }
+    }
+
     async handleNotificationsCommand(interaction) {
         const msgs = this.msgs(interaction.guildId);
         const row = new ActionRowBuilder().addComponents(
@@ -3412,6 +3494,10 @@ class InteractionHandler {
                 components: []
             });
             return;
+        }
+        // Śledź subskrypcję dla osiągnięć (fire-and-forget)
+        if (this.achievementService) {
+            this.achievementService.trackSubscription(interaction.guildId, interaction.user.id).catch(() => {});
         }
         await interaction.editReply({
             content: formatMessage(msgs.notifSuccess, { username: targetUsername, guild: targetGuildName }),

--- a/EndersEcho/index.js
+++ b/EndersEcho/index.js
@@ -24,6 +24,7 @@ const UsageLimitService = require('./services/usageLimitService');
 const { TokenUsageService } = require('./services/tokenUsageService');
 const { UpdateCooldownService } = require('./services/updateCooldownService');
 const InteractionHandler = require('./handlers/interactionHandlers');
+const AchievementService = require('./services/achievementService');
 const { createBotLogger } = require('../utils/consoleLogger');
 const { createLlmAdapter } = require('../utils/llmAdapter');
 const { createAppSync } = require('../utils/appSync');
@@ -83,7 +84,8 @@ const roleRankingConfigService = new RoleRankingConfigService(config);
 const usageLimitService = new UsageLimitService(config);
 const tokenUsageService = new TokenUsageService(config);
 const updateCooldownService = new UpdateCooldownService(config);
-const interactionHandler = new InteractionHandler(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService, roleRankingConfigService, usageLimitService, tokenUsageService, botOps, guildConfigService, ocrBlockService, updateCooldownService, testerService);
+const achievementService = new AchievementService(config);
+const interactionHandler = new InteractionHandler(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService, roleRankingConfigService, usageLimitService, tokenUsageService, botOps, guildConfigService, ocrBlockService, updateCooldownService, testerService, achievementService);
 
 /**
  * Inicjalizuje bota EndersEcho

--- a/EndersEcho/services/achievementService.js
+++ b/EndersEcho/services/achievementService.js
@@ -1,0 +1,307 @@
+'use strict';
+
+const fs = require('fs').promises;
+const path = require('path');
+const { ACHIEVEMENTS, RARITY, CATEGORY_INFO } = require('../config/achievements');
+const { EmbedBuilder, ButtonBuilder, ButtonStyle, ActionRowBuilder } = require('discord.js');
+
+const PER_PAGE = 10;
+
+class AchievementService {
+    constructor(config) {
+        this.config = config;
+        this.dataDir = config.ranking?.dataDir || path.join(__dirname, '../data');
+    }
+
+    _getDataFile(guildId) {
+        return path.join(this.dataDir, `achievements_${guildId}.json`);
+    }
+
+    async loadData(guildId) {
+        try {
+            const raw = await fs.readFile(this._getDataFile(guildId), 'utf8');
+            return JSON.parse(raw);
+        } catch {
+            return {};
+        }
+    }
+
+    async saveData(guildId, data) {
+        await fs.writeFile(this._getDataFile(guildId), JSON.stringify(data, null, 2), 'utf8');
+    }
+
+    _ensureUser(data, userId) {
+        if (!data[userId]) {
+            data[userId] = {
+                unlocked: {},
+                progress: {
+                    recordCount: 0,
+                    bossesEncountered: [],
+                    rankingViews: 0,
+                    subscriptions: 0,
+                    lastRecordAt: null,
+                    lastRecordBeatAt: null,
+                },
+            };
+        }
+        return data[userId];
+    }
+
+    /**
+     * Called after a successful /update (not dryRun).
+     * Returns array of achievement IDs to show in the record embed
+     * (those unlocked since the previous record beat).
+     *
+     * @param {string} guildId
+     * @param {string} userId
+     * @param {{ scoreValue, bossName, isNewRecord, prevScoreValue, currentPosition }} ctx
+     * @returns {Promise<string[]>}
+     */
+    async processSubmission(guildId, userId, ctx) {
+        if (!ctx.isNewRecord) return [];
+
+        try {
+            const data = await this.loadData(guildId);
+            const userData = this._ensureUser(data, userId);
+            const p = userData.progress;
+
+            const prevLastBeat = p.lastRecordBeatAt;
+
+            // Aktualizuj progress przed sprawdzeniem warunków
+            p.recordCount = (p.recordCount || 0) + 1;
+
+            if (ctx.bossName) {
+                const boss = ctx.bossName.trim();
+                if (boss && boss !== 'Nieznany' && boss !== 'Unknown') {
+                    if (!p.bossesEncountered) p.bossesEncountered = [];
+                    const lc = boss.toLowerCase();
+                    if (!p.bossesEncountered.some(b => b.toLowerCase() === lc)) {
+                        p.bossesEncountered.push(boss);
+                    }
+                }
+            }
+
+            const nowIso = new Date().toISOString();
+
+            // Sprawdź i odblokuj osiągnięcia
+            for (const ach of ACHIEVEMENTS) {
+                if (userData.unlocked[ach.id]) continue;
+                try {
+                    if (ach.check(p, ctx)) {
+                        userData.unlocked[ach.id] = { unlockedAt: nowIso };
+                    }
+                } catch {}
+            }
+
+            // Zbierz osiągnięcia do pokazania w embeddzie (odblokowane od ostatniego pobicia rekordu)
+            const toShow = Object.entries(userData.unlocked)
+                .filter(([, info]) => !prevLastBeat || info.unlockedAt >= prevLastBeat)
+                .map(([id]) => id);
+
+            // Zapisz timestamp PO zebraniu listy (żeby prevLastBeat był sprzed obecnego rekordu)
+            p.lastRecordAt = nowIso;
+            p.lastRecordBeatAt = nowIso;
+
+            await this.saveData(guildId, data);
+            return toShow;
+        } catch {
+            return [];
+        }
+    }
+
+    /**
+     * Śledzi przegląd rankingu — może odblokować ukryte osiągnięcia eksploratora.
+     */
+    async trackRankingView(guildId, userId) {
+        try {
+            const data = await this.loadData(guildId);
+            const userData = this._ensureUser(data, userId);
+            const p = userData.progress;
+            p.rankingViews = (p.rankingViews || 0) + 1;
+
+            const nowIso = new Date().toISOString();
+            for (const ach of ACHIEVEMENTS) {
+                if (!ach.hidden || userData.unlocked[ach.id] || ach.category !== 'explorer') continue;
+                try {
+                    if (ach.check(p, {})) userData.unlocked[ach.id] = { unlockedAt: nowIso };
+                } catch {}
+            }
+
+            await this.saveData(guildId, data);
+        } catch {}
+    }
+
+    /**
+     * Śledzi aktywację subskrypcji — może odblokować ukryte osiągnięcia eksploratora.
+     */
+    async trackSubscription(guildId, userId) {
+        try {
+            const data = await this.loadData(guildId);
+            const userData = this._ensureUser(data, userId);
+            const p = userData.progress;
+            p.subscriptions = (p.subscriptions || 0) + 1;
+
+            const nowIso = new Date().toISOString();
+            for (const ach of ACHIEVEMENTS) {
+                if (!ach.hidden || userData.unlocked[ach.id] || ach.category !== 'explorer') continue;
+                try {
+                    if (ach.check(p, {})) userData.unlocked[ach.id] = { unlockedAt: nowIso };
+                } catch {}
+            }
+
+            await this.saveData(guildId, data);
+        } catch {}
+    }
+
+    /**
+     * Tworzy embed i komponenty dla komendy /achievements.
+     * @param {string} guildId
+     * @param {string} userId
+     * @param {string} lang - 'pol' | 'eng'
+     * @param {string} tab  - 'unlocked' | 'overview'
+     * @param {number} page - 0-based
+     * @returns {Promise<{ embed: EmbedBuilder, components: ActionRowBuilder[], totalPages: number, currentPage: number }>}
+     */
+    async buildAchievementsView(guildId, userId, lang, tab, page) {
+        const isPol = lang === 'pol';
+        const t = (pol, eng) => isPol ? pol : eng;
+
+        const data = await this.loadData(guildId);
+        const userData = this._ensureUser(data, userId);
+        const { unlocked, progress } = userData;
+
+        let embed, totalPages, currentPage;
+
+        if (tab === 'overview') {
+            ({ embed, totalPages, currentPage } = this._buildOverviewEmbed(unlocked, progress, t, isPol));
+        } else {
+            ({ embed, totalPages, currentPage } = this._buildUnlockedEmbed(unlocked, t, isPol, page));
+        }
+
+        const components = this._buildComponents(tab, currentPage, totalPages, t);
+        return { embed, components, totalPages, currentPage };
+    }
+
+    _buildUnlockedEmbed(unlocked, t, isPol, page) {
+        const unlockedList = Object.entries(unlocked)
+            .map(([id, info]) => ({ id, unlockedAt: info.unlockedAt }))
+            .sort((a, b) => (b.unlockedAt > a.unlockedAt ? 1 : -1)); // najnowsze pierwsze
+
+        const totalPages = Math.max(1, Math.ceil(unlockedList.length / PER_PAGE));
+        const currentPage = Math.max(0, Math.min(page, totalPages - 1));
+        const pageItems = unlockedList.slice(currentPage * PER_PAGE, (currentPage + 1) * PER_PAGE);
+
+        const embed = new EmbedBuilder()
+            .setColor(0xf1c40f)
+            .setTitle(t('🏆 Twoje Osiągnięcia', '🏆 Your Achievements'))
+            .setFooter({ text: t(
+                `Strona ${currentPage + 1} z ${totalPages} • ${unlockedList.length} odblokowanych z ${ACHIEVEMENTS.length}`,
+                `Page ${currentPage + 1} of ${totalPages} • ${unlockedList.length} unlocked of ${ACHIEVEMENTS.length}`
+            ) });
+
+        if (pageItems.length === 0) {
+            embed.setDescription(t(
+                '❌ Nie masz jeszcze żadnych osiągnięć. Graj i bądź aktywny!',
+                '❌ No achievements yet. Play and stay active!'
+            ));
+        } else {
+            const lines = pageItems.map(({ id, unlockedAt }) => {
+                const ach = ACHIEVEMENTS.find(a => a.id === id);
+                if (!ach) return null;
+                const rarity = RARITY[ach.rarity];
+                const name = isPol ? ach.namePol : ach.nameEng;
+                const desc = isPol ? ach.descPol : ach.descEng;
+                const date = new Date(unlockedAt).toLocaleDateString(isPol ? 'pl-PL' : 'en-GB');
+                const rarityLabel = rarity[isPol ? 'pol' : 'eng'];
+                return `${rarity.emoji} **${name}** *(${rarityLabel})*\n└ ${desc} — ${date}`;
+            }).filter(Boolean);
+            embed.setDescription(lines.join('\n\n'));
+        }
+
+        return { embed, totalPages, currentPage };
+    }
+
+    _buildOverviewEmbed(unlocked, progress, t, isPol) {
+        const unlockedIds = new Set(Object.keys(unlocked));
+
+        const catLines = Object.entries(CATEGORY_INFO).map(([catKey, catLabel]) => {
+            const catAchs = ACHIEVEMENTS.filter(a => a.category === catKey);
+            const catUnlocked = catAchs.filter(a => unlockedIds.has(a.id)).length;
+            const label = isPol ? catLabel.pol : catLabel.eng;
+            return `${label}: **${catUnlocked}/${catAchs.length}**`;
+        });
+
+        const statsLines = [
+            t(`📊 Pobite rekordy: **${progress.recordCount || 0}**`, `📊 Records beaten: **${progress.recordCount || 0}**`),
+            t(`🐉 Unikalne bossy: **${(progress.bossesEncountered || []).length}**`, `🐉 Unique bosses: **${(progress.bossesEncountered || []).length}**`),
+            t(`👁️ Przeglądy rankingu: **${progress.rankingViews || 0}**`, `👁️ Ranking views: **${progress.rankingViews || 0}**`),
+            t(`🔔 Subskrypcje: **${progress.subscriptions || 0}**`, `🔔 Subscriptions: **${progress.subscriptions || 0}**`),
+        ];
+
+        const embed = new EmbedBuilder()
+            .setColor(0x9b59b6)
+            .setTitle(t('📊 Przegląd Osiągnięć', '📊 Achievement Overview'))
+            .addFields(
+                { name: t('Kategorie', 'Categories'), value: catLines.join('\n'), inline: true },
+                { name: t('Statystyki', 'Statistics'), value: statsLines.join('\n'), inline: true },
+            )
+            .setFooter({ text: t(
+                `${unlockedIds.size} z ${ACHIEVEMENTS.length} odblokowanych`,
+                `${unlockedIds.size} of ${ACHIEVEMENTS.length} unlocked`
+            ) });
+
+        return { embed, totalPages: 1, currentPage: 0 };
+    }
+
+    _buildComponents(tab, currentPage, totalPages, t) {
+        const isUnlocked = tab === 'unlocked';
+
+        const row = new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId(`ach_view_unlocked_${currentPage - 1}`)
+                .setLabel('◀')
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(!isUnlocked || currentPage <= 0),
+            new ButtonBuilder()
+                .setCustomId(`ach_view_unlocked_${currentPage + 1}`)
+                .setLabel('▶')
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(!isUnlocked || currentPage >= totalPages - 1),
+            new ButtonBuilder()
+                .setCustomId('ach_view_unlocked_0')
+                .setLabel(t('🏆 Odblokowane', '🏆 Unlocked'))
+                .setStyle(isUnlocked ? ButtonStyle.Primary : ButtonStyle.Secondary)
+                .setDisabled(isUnlocked),
+            new ButtonBuilder()
+                .setCustomId('ach_view_overview_0')
+                .setLabel(t('📊 Podsumowanie', '📊 Overview'))
+                .setStyle(!isUnlocked ? ButtonStyle.Primary : ButtonStyle.Secondary)
+                .setDisabled(!isUnlocked),
+        );
+
+        return [row];
+    }
+
+    /**
+     * Buduje tekst pola "Nowe osiągnięcia" do embeda rekordu.
+     * @param {string[]} achievementIds
+     * @param {string} lang
+     * @returns {string|null}
+     */
+    buildNewAchievementsFieldValue(achievementIds, lang) {
+        if (!achievementIds || achievementIds.length === 0) return null;
+        const isPol = lang === 'pol';
+
+        const lines = achievementIds.map(id => {
+            const ach = ACHIEVEMENTS.find(a => a.id === id);
+            if (!ach) return null;
+            const rarity = RARITY[ach.rarity];
+            const name = isPol ? ach.namePol : ach.nameEng;
+            return `${rarity.emoji} **${name}**`;
+        }).filter(Boolean);
+
+        return lines.length > 0 ? lines.join('\n') : null;
+    }
+}
+
+module.exports = AchievementService;

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -778,7 +778,7 @@ class RankingService {
         return parts.join(' ');
     }
 
-    async createRecordEmbed(userName, bestScore, userAvatarUrl, attachmentName, previousScore = null, userId = null, guildId = null, messages = null, guild = null, guildTopRoles = null, previousTimestamp = null, rolePositions = []) {
+    async createRecordEmbed(userName, bestScore, userAvatarUrl, attachmentName, previousScore = null, userId = null, guildId = null, messages = null, guild = null, guildTopRoles = null, previousTimestamp = null, rolePositions = [], achievementsFieldValue = null) {
         const msgs = messages || this.config.messages;
 
         // Oblicz postęp i poprawę w jednej linii
@@ -887,6 +887,11 @@ class RankingService {
 
         if (authorData) {
             embed.setAuthor(authorData);
+        }
+
+        if (achievementsFieldValue) {
+            const fieldName = msgs.achievementsNewField || '🎉 Nowe osiągnięcia';
+            embed.addFields({ name: fieldName, value: achievementsFieldValue, inline: false });
         }
 
         return embed;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **System osiągnięć** — 43 stałe osiągnięcia w 5 kategoriach + 1 dynamiczny status (`👑 Aktualny Lider`)
- **Nowa paginacja rankingu** — przycisk `🎯 Moja pozycja`, usunięto Pierwsza/Ostatnia, 5 przycisków w rzędzie
- **Ranking Serwerów** — skumulowane wyniki Top 30 graczy per serwer, przełącznik Global ↔ Ranking Serwerów
- **UX** — `/ranking` trafia od razu we własny serwer; brak Globala w widoku wyboru serwerów; ikona bota w globalnym rankingu

## Szczegóły — system osiągnięć

**Nowe pliki:**
- `EndersEcho/config/achievements.js` — definicje 43 osiągnięć (warunki `check(progress, ctx)`, rarity, dwujęzyczne nazwy)
- `EndersEcho/services/achievementService.js` — logika: `processSubmission`, `trackRankingView`, `trackSubscription`, `buildAchievementsView`, `buildNewAchievementsFieldValue`

**Kategorie osiągnięć:**
- 🏆 Wyniki (20): od 1K do 1Sp, rosnąca rarity od Common do Mythic
- 🔁 Rekordy (10): 1/10/20/50/100/200/500/1000 pobić rekordu + podwojenie/potrojenie w jednym podejściu
- 🐉 Bossowie (3): 1 / 3 / 5 unikalnych bossów (Boss Hunter = 5)
- 🕵️ Eksplorator — ukryte (5): przeglądy rankingu (10/50/200) i subskrypcje (1/5)
- 💎 Prestiż (5): Top10/Top3/Top1 serwera, Wielki Skok (+50%), Powrót (>30 dni przerwy)

**Logika powiadomień:** w embeddzie nowego rekordu pojawia się pole `🎉 Nowe osiągnięcia` wyłącznie z osiągnięciami odblokowanymi od poprzedniego pobicia rekordu (w tym ukryte zdobyte przez przeglądanie rankingu).

**Komenda `/achievements`:** ephemeral embed z zakładkami `🏆 Odblokowane` (paginacja po 10) i `📊 Podsumowanie` (per-kategoria + statystyki aktywności). Dwujęzyczna (pol/eng per serwer).

**Persistencja:** `data/achievements_{guildId}.json` — przeżywa restart.

## Test plan

- [ ] `/achievements` — wyświetla embed z zakładkami, paginacja działa, zakładka Podsumowanie pokazuje statystyki
- [ ] `/update` z nowym rekordem — pole `🎉 Nowe osiągnięcia` pojawia się gdy coś odblokowane od ostatniego rekordu
- [ ] Przeglądanie rankingu (`/ranking`) — ukryte osiągnięcia eksploratora naliczają się (widać po `/achievements → Podsumowanie`)
- [ ] `/subscribe` + potwierdzenie — nalicza się subskrypcja w statystykach osiągnięć
- [ ] `/ranking` wchodzi bezpośrednio w ranking własnego serwera
- [ ] Przycisk `🏛️ Ranking Serwerów` w Global — wyświetla skumulowane wyniki serwerów; przycisk `👤 Ranking Indywidualny` przełącza z powrotem
- [ ] Przycisk `🎯 Moja pozycja` — otwiera stronę z pozycją gracza (wyłączony gdy nie ma gracza w rankingu)
- [ ] Przycisk `↩️ Rankingi serwerów` — wraca do wyboru serwerów

https://claude.ai/code/session_01QVMEvHWY4CFq9cDhiWAoXk
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVMEvHWY4CFq9cDhiWAoXk)_