### PR TITLE
Improve /info broadcast reporting with detailed error handling

### DIFF
--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -3792,6 +3792,20 @@ class InteractionHandler {
     }
 
     /**
+     * Mapuje błąd Discord API na czytelny opis po polsku.
+     */
+    _mapSendError(err) {
+        const code = err.code;
+        const msg = err.message || '';
+        if (code === 50001 || msg.includes('Missing Access')) return 'Brak dostępu — bot wyrzucony lub brak uprawnień na kanale';
+        if (code === 10003 || msg.includes('Unknown Channel')) return 'Kanał nie istnieje (skonfiguruj ponownie)';
+        if (code === 50013 || msg.includes('Missing Permissions')) return 'Brak uprawnień do wysyłania wiadomości';
+        if (code === 50035 || msg.includes('Invalid Form Body')) return 'Nieprawidłowy format wiadomości (embed za długi?)';
+        if (code === 10004 || msg.includes('Unknown Guild')) return 'Serwer nie istnieje';
+        return msg || 'Nieznany błąd';
+    }
+
+    /**
      * Obsługuje przycisk "Wyślij" — wysyła embed na kanały wszystkich serwerów.
      */
     async _handleInfoSend(interaction) {
@@ -3803,28 +3817,68 @@ class InteractionHandler {
         }
 
         await interaction.deferUpdate();
-        let sent = 0;
-        let failed = 0;
+
+        const results = [];
 
         for (const guildCfg of this.config.getAllGuilds()) {
+            const guildObj = interaction.client.guilds.cache.get(guildCfg.id);
+            const guildLabel = guildObj?.name || guildCfg.tag || guildCfg.id;
+
+            if (!guildObj) {
+                results.push({ label: guildLabel, id: guildCfg.id, status: 'skipped', reason: 'Bot nie jest na tym serwerze (wyrzucony lub opuścił)' });
+                continue;
+            }
+
             try {
-                const channel = await interaction.client.channels.fetch(guildCfg.allowedChannelId);
-                if (!channel) { failed++; continue; }
+                const channel = await interaction.client.channels.fetch(guildCfg.allowedChannelId).catch(() => null);
+                if (!channel) {
+                    results.push({ label: guildLabel, id: guildCfg.id, status: 'error', reason: 'Nie znaleziono kanału (ID nieaktualne?)' });
+                    continue;
+                }
                 const description = guildCfg.lang === 'pol' ? data.descriptionPol : data.descriptionEng;
                 const embed = this._buildInfoEmbed(data, data.user, description);
                 await channel.send({ embeds: [embed] });
-                sent++;
+                results.push({ label: guildLabel, id: guildCfg.id, status: 'ok' });
             } catch (err) {
                 logger.error(`Błąd wysyłania /info do serwera ${guildCfg.id}: ${err.message}`);
-                failed++;
+                results.push({ label: guildLabel, id: guildCfg.id, status: 'error', reason: this._mapSendError(err) });
             }
         }
 
         this._clearInfoSession(interaction.user.id);
-        const summary = failed > 0
-            ? `✅ Wysłano na **${sent}** serwer(ów). ❌ Błąd na **${failed}** serwer(ach).`
-            : `✅ Wiadomość wysłana na **${sent}** serwer(ów).`;
-        await interaction.editReply({ content: summary, embeds: [], components: [] });
+
+        const sent = results.filter(r => r.status === 'ok').length;
+        const failed = results.filter(r => r.status === 'error').length;
+        const skipped = results.filter(r => r.status === 'skipped').length;
+
+        const color = failed === 0 && skipped === 0 ? 0x00aa00
+            : failed === 0 ? 0xffaa00
+            : sent === 0 ? 0xcc0000
+            : 0xff8800;
+
+        const summaryParts = [];
+        if (sent > 0) summaryParts.push(`✅ Wysłano: **${sent}**`);
+        if (skipped > 0) summaryParts.push(`⏭️ Pominięto: **${skipped}**`);
+        if (failed > 0) summaryParts.push(`❌ Błędy: **${failed}**`);
+
+        const reportEmbed = new EmbedBuilder()
+            .setTitle('📋 Raport wysyłania /info')
+            .setColor(color)
+            .setDescription(summaryParts.join(' · '))
+            .setTimestamp();
+
+        for (const r of results.slice(0, 25)) {
+            const value = r.status === 'ok' ? '✅ Wysłano pomyślnie'
+                : r.status === 'skipped' ? `⏭️ ${r.reason}`
+                : `❌ ${r.reason}`;
+            reportEmbed.addFields({ name: r.label, value, inline: true });
+        }
+
+        if (results.length > 25) {
+            reportEmbed.setFooter({ text: `Pokazano 25 z ${results.length} serwerów` });
+        }
+
+        await interaction.editReply({ content: '', embeds: [reportEmbed], components: [] });
     }
 
     /**


### PR DESCRIPTION
## Summary
Enhanced the `/info` command's broadcast functionality to provide detailed, per-server reporting with specific error messages instead of simple success/failure counts.

## Key Changes
- **Added `_mapSendError()` method**: Maps Discord API error codes to user-friendly Polish error descriptions (missing access, unknown channel, missing permissions, invalid embed format, etc.)
- **Replaced simple counters with detailed results tracking**: Changed from basic `sent`/`failed` counts to a comprehensive results array that tracks status, guild label, and specific failure reasons for each server
- **Enhanced error handling**: Improved channel fetch error handling with `.catch(() => null)` and added detection for when the bot is no longer on a guild
- **Redesigned user feedback**: Replaced plain text summary with an embedded report that includes:
  - Color-coded status (green for all success, orange for skipped servers, red for failures)
  - Per-server status with specific reasons for failures or skips
  - Support for up to 25 servers with a footer note if more exist
  - Separate counts for successful sends, skipped servers, and errors

## Implementation Details
- Results are collected in an array with objects containing: `label` (guild name), `id`, `status` ('ok'/'error'/'skipped'), and optional `reason`
- Guild names are resolved from cache with fallback to config tag or ID
- Skipped servers (bot not on guild) are now explicitly reported rather than silently counted as failures
- The embed uses inline fields for compact display and includes a timestamp

https://claude.ai/code/session_012KJACRk8N158vEeMtxkCqw