### PR TITLE
EndersEcho: ikona bota w rankingu serwerów, poprawki osiągnięć

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -136,6 +136,7 @@
    - **Kategorie:** 🏆 Wyniki (20) · 🔁 Rekordy (10) · 🐉 Bossowie (3) · 🕵️ Eksplorator/ukryte (5) · 💎 Prestiż (5)
    - **Rarities:** ⬜ Common · 🟩 Uncommon · 🟦 Rare · 🟪 Epic · 🟧 Legendary · 🔴 Mythic
    - **Odblokowanie:** osiągnięcia score/records/bosses/prestige blokowane przy każdym nowym rekordzie; ukryte (explorer) blokowane natychmiast przy przegladzie rankingu lub subskrypcji
+   - **Kasowanie:** `clearUserAchievements(guildId, userId)` — usuwa cały wpis gracza z pliku; wywoływane automatycznie przy usunięciu gracza z rankingu (panel admina + komenda `/remove`)
    - **Powiadomienie:** w embeddzie rekordu pojawia się pole `🎉 Nowe osiągnięcia` TYLKO z osiągnięciami zdobytymi od poprzedniego pobicia rekordu (`lastRecordBeatAt`)
    - **Persistencja:** `data/achievements_{guildId}.json` — per-serwer; przeżywa restart
    - **Komenda /achievements:** ephemeral embed z zakładkami: `🏆 Odblokowane` (paginacja po 10) i `📊 Podsumowanie` (per-kategoria + statystyki)
@@ -144,7 +145,7 @@
    - **CustomIDs:** `ach_view_{tab}_{page}` — tab = `unlocked` | `overview`
 
 6. **Panel Admina** — dostępny przez `/manage`:
-   - **Usuń gracza z rankingu (admin):** modal wyszukiwania nicku → przefiltrowana lista → potwierdzenie → usunięcie + aktualizacja ról TOP. Head Admin może usunąć gracza z **dowolnego serwera** (cross-server).
+   - **Usuń gracza z rankingu (admin):** modal wyszukiwania nicku → przefiltrowana lista → potwierdzenie → usunięcie + aktualizacja ról TOP + wyczyszczenie wszystkich osiągnięć gracza (`achievementService.clearUserAchievements`). Head Admin może usunąć gracza z **dowolnego serwera** (cross-server).
    - **Odblokuj gracza (admin):** modal wyszukiwania nicku → przefiltrowana lista → odblokowanie. Persistencja: `data/user_blocks.json`. Jeśli blokada pochodzi od Head Admina (`blockedByHeadAdmin: true`) — zwykły Admin nie może odblokować.
    - **Zablokuj gracza (head admin):** modal wyszukiwania nicku cross-server → lista graczy → potwierdzenie → modal czasu blokady. Blokada zapisywana z flagą `blockedByHeadAdmin: true`.
    - **Zużycie tokenów (admin/head admin):** embed ze statystykami AI per serwer. Admin = swój serwer, Head Admin = wszystkie + breakdown

--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -136,7 +136,7 @@
    - **Kategorie:** 🏆 Wyniki (20) · 🔁 Rekordy (10) · 🐉 Bossowie (3) · 🕵️ Eksplorator/ukryte (5) · 💎 Prestiż (5)
    - **Rarities:** ⬜ Common · 🟩 Uncommon · 🟦 Rare · 🟪 Epic · 🟧 Legendary · 🔴 Mythic
    - **Odblokowanie:** osiągnięcia score/records/bosses/prestige blokowane przy każdym nowym rekordzie; ukryte (explorer) blokowane natychmiast przy przegladzie rankingu lub subskrypcji
-   - **Kasowanie:** `clearUserAchievements(guildId, userId)` — usuwa cały wpis gracza z pliku; wywoływane automatycznie przy usunięciu gracza z rankingu (panel admina + komenda `/remove`)
+   - **Kasowanie:** `clearUserAchievements(guildId, userId)` — usuwa osiągnięcia kategorii `score` i `records` oraz resetuje `recordCount`/`lastRecordAt`/`lastRecordBeatAt`; pozostałe kategorie (bosses, explorer, prestige) zostają; wywoływane automatycznie przy usunięciu gracza z rankingu (panel admina + komenda `/remove`)
    - **Powiadomienie:** w embeddzie rekordu pojawia się pole `🎉 Nowe osiągnięcia` TYLKO z osiągnięciami zdobytymi od poprzedniego pobicia rekordu (`lastRecordBeatAt`)
    - **Persistencja:** `data/achievements_{guildId}.json` — per-serwer; przeżywa restart
    - **Komenda /achievements:** ephemeral embed z zakładkami: `🏆 Odblokowane` (paginacja po 10) i `📊 Podsumowanie` (per-kategoria + statystyki)

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -1229,6 +1229,9 @@ class InteractionHandler {
                 if (targetGuild) {
                     await this.roleService.updateTopRoles(targetGuild, updatedPlayers, guildConfig?.topRoles || null);
                 }
+                if (this.achievementService) {
+                    await this.achievementService.clearUserAchievements(targetGuildId, targetUserId);
+                }
                 await this.logService.logMessage('success', `Gracz ${targetUserId} usunięty z rankingu (serwer ${targetGuildId}) przez panel admina`, interaction);
             } catch (roleError) {
                 logger.warn(`Błąd aktualizacji ról TOP po usunięciu (panel): ${roleError.message}`);
@@ -2390,6 +2393,9 @@ class InteractionHandler {
                 const guildConfig = this.config.getGuildConfig(guildId);
                 const updatedPlayers = await this.rankingService.getSortedPlayers(guildId);
                 await this.roleService.updateTopRoles(interaction.guild, updatedPlayers, guildConfig?.topRoles || null);
+                if (this.achievementService) {
+                    await this.achievementService.clearUserAchievements(guildId, targetUser.id);
+                }
                 await this.logService.logMessage('success', `Gracz ${targetUser.tag} został usunięty z rankingu i zaktualizowano role TOP`, interaction);
             } catch (roleError) {
                 await this.logService.logMessage('error', `Błąd aktualizacji ról TOP po usunięciu gracza: ${roleError.message}`, interaction);

--- a/EndersEcho/services/achievementService.js
+++ b/EndersEcho/services/achievementService.js
@@ -110,7 +110,19 @@ class AchievementService {
     }
 
     /**
-     * Śledzi przegląd rankingu — może odblokować ukryte osiągnięcia eksploratora.
+     * Usuwa wszystkie osiągnięcia i postęp gracza na danym serwerze.
+     * Wywoływane przy usunięciu gracza z rankingu przez admina.
+     */
+    async clearUserAchievements(guildId, userId) {
+        try {
+            const data = await this.loadData(guildId);
+            if (!data[userId]) return;
+            delete data[userId];
+            await this.saveData(guildId, data);
+        } catch {}
+    }
+
+    /**
      */
     async trackRankingView(guildId, userId) {
         try {

--- a/EndersEcho/services/achievementService.js
+++ b/EndersEcho/services/achievementService.js
@@ -110,14 +110,23 @@ class AchievementService {
     }
 
     /**
-     * Usuwa wszystkie osiągnięcia i postęp gracza na danym serwerze.
-     * Wywoływane przy usunięciu gracza z rankingu przez admina.
+     * Usuwa osiągnięcia powiązane z wynikiem i pobijaniem rekordów (kategorie 'score' i 'records')
+     * oraz resetuje powiązane pola progress. Wywoływane przy usunięciu gracza z rankingu przez admina.
      */
     async clearUserAchievements(guildId, userId) {
         try {
             const data = await this.loadData(guildId);
             if (!data[userId]) return;
-            delete data[userId];
+            const userData = data[userId];
+            const scoreAndRecordIds = new Set(
+                ACHIEVEMENTS.filter(a => a.category === 'score' || a.category === 'records').map(a => a.id)
+            );
+            for (const id of scoreAndRecordIds) {
+                delete userData.unlocked[id];
+            }
+            userData.progress.recordCount = 0;
+            userData.progress.lastRecordAt = null;
+            userData.progress.lastRecordBeatAt = null;
             await this.saveData(guildId, data);
         } catch {}
     }


### PR DESCRIPTION
## Zmiany

- **Ikona bota w embedzie rankingu serwerów** — thumbnail z awatarem bota w `🏛️ Ranking Serwerów` (obie ścieżki: pierwsze otwarcie + paginacja)
- **Poprawka ponownego wyświetlania osiągnięć** — zmiana `>=` na `>` w filtrze `toShow`, co zapobiegało pokazywaniu osiągnięć z poprzedniego rekordu przy każdym kolejnym pobiciu
- **Kasowanie osiągnięć przy usunięciu gracza z rankingu** — usuwane są tylko kategorie `score` i `records` + reset `recordCount`/`lastRecordAt`/`lastRecordBeatAt`; pozostałe kategorie (bosses, explorer, prestige) zostają; działa zarówno przez panel admina jak i komendę `/remove`

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQwKnCm9WVPtZnqqc9YDkN)_