### PR TITLE
EndersEcho: /achievements — strony per kategoria + ikona bota w rankingu

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -140,10 +140,10 @@
    - **Reset pełny:** `resetAllAchievements(guildId, userId)` — usuwa cały wpis gracza z pliku (wszystkie kategorie + cały progress); wywoływane ręcznie przez head admina z `/manage` → `🏆 Resetuj osiągnięcia`
    - **Powiadomienie:** w embeddzie rekordu pojawia się pole `🎉 Nowe osiągnięcia` TYLKO z osiągnięciami zdobytymi od poprzedniego pobicia rekordu (`lastRecordBeatAt`)
    - **Persistencja:** `data/achievements_{guildId}.json` — per-serwer; przeżywa restart
-   - **Komenda /achievements:** ephemeral embed z zakładkami: `🏆 Odblokowane` (paginacja po 10) i `📊 Podsumowanie` (per-kategoria + statystyki)
+   - **Komenda /achievements:** ephemeral embed — każda kategoria na osobnej stronie + przycisk podsumowania. Wiersz 1: 5 przycisków kategorii (`🏆 Wyniki`, `🔁 Rekordy`, `🎯 Łowy`, `💎 Prestiż`, `🕵️ Eksplorator`). Wiersz 2: `📊 Podsumowanie`. Tytuł embeda = etykieta kategorii. Odblokowane: `emoji **nazwa** *(rarity)* \n└ opis — data`. Zablokowane nieukryte: `🔒 ~~nazwa~~`. Zablokowane ukryte: `🔒 **???**`. Stopka: `X/Y odblokowanych` (ukryte: `X/? odblokowanych`). Domyślna strona po `/achievements`: kategoria `score`.
    - **Tracking:** `trackRankingView(guildId, userId)` — wołane w `handleRankingCommand`; `trackSubscription(guildId, userId)` — wołane w `_handleNotifConfirm` po udanej subskrypcji
    - **Progress:** `progress.recordCount`, `progress.bossesEncountered[]`, `progress.rankingViews`, `progress.subscriptions`, `progress.lastRecordAt`, `progress.lastRecordBeatAt`
-   - **CustomIDs:** `ach_view_{tab}_{page}` — tab = `unlocked` | `overview`
+   - **CustomIDs:** `ach_cat_{categoryKey}` (score/records/bosses/prestige/explorer) | `ach_overview`
 
 6. **Panel Admina** — dostępny przez `/manage`:
    - **Usuń gracza z rankingu (admin):** modal wyszukiwania nicku → przefiltrowana lista → potwierdzenie → usunięcie + aktualizacja ról TOP + wyczyszczenie wszystkich osiągnięć gracza (`achievementService.clearUserAchievements`). Head Admin może usunąć gracza z **dowolnego serwera** (cross-server).

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -2613,7 +2613,7 @@ class InteractionHandler {
             }
 
             // === Przyciski /achievements ===
-            if (customId.startsWith('ach_view_')) {
+            if (customId.startsWith('ach_cat_') || customId === 'ach_overview') {
                 await this._handleAchievementsButton(interaction, customId);
                 return;
             }
@@ -3275,7 +3275,7 @@ class InteractionHandler {
             const userId = interaction.user.id;
             const lang = this.config.getGuildConfig(guildId)?.lang || 'pol';
             const { embed, components } = await this.achievementService.buildAchievementsView(
-                guildId, userId, lang, 'unlocked', 0
+                guildId, userId, lang, 'cat', 'score'
             );
             await interaction.editReply({ embeds: [embed], components });
         } catch (err) {
@@ -3285,17 +3285,17 @@ class InteractionHandler {
     }
 
     async _handleAchievementsButton(interaction, customId) {
-        // customId: ach_view_{tab}_{page}  — np. ach_view_unlocked_0
+        // customId: ach_cat_{category} | ach_overview
         await interaction.deferUpdate();
         try {
-            const parts = customId.split('_'); // ['ach', 'view', tab, page]
-            const tab = parts[2] || 'unlocked';
-            const page = parseInt(parts[3], 10) || 0;
+            const isOverview = customId === 'ach_overview';
+            const view = isOverview ? 'overview' : 'cat';
+            const category = isOverview ? null : customId.replace('ach_cat_', '');
             const guildId = interaction.guildId;
             const userId = interaction.user.id;
             const lang = this.config.getGuildConfig(guildId)?.lang || 'pol';
             const { embed, components } = await this.achievementService.buildAchievementsView(
-                guildId, userId, lang, tab, page
+                guildId, userId, lang, view, category
             );
             await interaction.editReply({ embeds: [embed], components });
         } catch (err) {

--- a/EndersEcho/services/achievementService.js
+++ b/EndersEcho/services/achievementService.js
@@ -192,11 +192,11 @@ class AchievementService {
      * @param {string} guildId
      * @param {string} userId
      * @param {string} lang - 'pol' | 'eng'
-     * @param {string} tab  - 'unlocked' | 'overview'
-     * @param {number} page - 0-based
-     * @returns {Promise<{ embed: EmbedBuilder, components: ActionRowBuilder[], totalPages: number, currentPage: number }>}
+     * @param {string} view - 'cat' | 'overview'
+     * @param {string|null} category - klucz kategorii (gdy view='cat')
+     * @returns {Promise<{ embed: EmbedBuilder, components: ActionRowBuilder[] }>}
      */
-    async buildAchievementsView(guildId, userId, lang, tab, page) {
+    async buildAchievementsView(guildId, userId, lang, view, category) {
         const isPol = lang === 'pol';
         const t = (pol, eng) => isPol ? pol : eng;
 
@@ -204,55 +204,48 @@ class AchievementService {
         const userData = this._ensureUser(data, userId);
         const { unlocked, progress } = userData;
 
-        let embed, totalPages, currentPage;
-
-        if (tab === 'overview') {
-            ({ embed, totalPages, currentPage } = this._buildOverviewEmbed(unlocked, progress, t, isPol));
+        let embed;
+        if (view === 'overview') {
+            ({ embed } = this._buildOverviewEmbed(unlocked, progress, t, isPol));
         } else {
-            ({ embed, totalPages, currentPage } = this._buildUnlockedEmbed(unlocked, t, isPol, page));
+            const cat = (category && CATEGORY_INFO[category]) ? category : 'score';
+            ({ embed } = this._buildCategoryEmbed(unlocked, cat, t, isPol));
         }
 
-        const components = this._buildComponents(tab, currentPage, totalPages, t);
-        return { embed, components, totalPages, currentPage };
+        const activeKey = view === 'overview' ? 'overview' : ((category && CATEGORY_INFO[category]) ? category : 'score');
+        const components = this._buildComponents(activeKey, isPol, t);
+        return { embed, components };
     }
 
-    _buildUnlockedEmbed(unlocked, t, isPol, page) {
-        const unlockedList = Object.entries(unlocked)
-            .map(([id, info]) => ({ id, unlockedAt: info.unlockedAt }))
-            .sort((a, b) => (b.unlockedAt > a.unlockedAt ? 1 : -1)); // najnowsze pierwsze
+    _buildCategoryEmbed(unlocked, categoryKey, t, isPol) {
+        const catInfo = CATEGORY_INFO[categoryKey];
+        const catAchs = ACHIEVEMENTS.filter(a => a.category === categoryKey);
+        const catLabel = isPol ? catInfo.pol : catInfo.eng;
 
-        const totalPages = Math.max(1, Math.ceil(unlockedList.length / PER_PAGE));
-        const currentPage = Math.max(0, Math.min(page, totalPages - 1));
-        const pageItems = unlockedList.slice(currentPage * PER_PAGE, (currentPage + 1) * PER_PAGE);
+        const lines = catAchs.map(ach => {
+            const isUnlocked = !!unlocked[ach.id];
+            const rarity = RARITY[ach.rarity];
+            const name = isPol ? ach.namePol : ach.nameEng;
+            const desc = isPol ? ach.descPol : ach.descEng;
+            const rarityLabel = rarity[isPol ? 'pol' : 'eng'];
+            if (isUnlocked) {
+                const date = new Date(unlocked[ach.id].unlockedAt).toLocaleDateString(isPol ? 'pl-PL' : 'en-GB');
+                return `${rarity.emoji} **${name}** *(${rarityLabel})*\n└ ${desc} — ${date}`;
+            }
+            if (catInfo.hidden) return `🔒 **???** *(${rarityLabel})*`;
+            return `🔒 ~~${name}~~ *(${rarityLabel})*\n└ ${desc}`;
+        });
+
+        const unlockedCount = catAchs.filter(a => unlocked[a.id]).length;
+        const total = catInfo.hidden ? '?' : catAchs.length;
 
         const embed = new EmbedBuilder()
             .setColor(0xf1c40f)
-            .setTitle(t('🏆 Twoje Osiągnięcia', '🏆 Your Achievements'))
-            .setFooter({ text: t(
-                `Strona ${currentPage + 1} z ${totalPages} • ${unlockedList.length} odblokowanych`,
-                `Page ${currentPage + 1} of ${totalPages} • ${unlockedList.length} unlocked`
-            ) });
+            .setTitle(catLabel)
+            .setDescription(lines.length > 0 ? lines.join('\n\n') : t('Brak osiągnięć w tej kategorii.', 'No achievements in this category.'))
+            .setFooter({ text: t(`${unlockedCount}/${total} odblokowanych`, `${unlockedCount}/${total} unlocked`) });
 
-        if (pageItems.length === 0) {
-            embed.setDescription(t(
-                '❌ Nie masz jeszcze żadnych osiągnięć. Graj i bądź aktywny!',
-                '❌ No achievements yet. Play and stay active!'
-            ));
-        } else {
-            const lines = pageItems.map(({ id, unlockedAt }) => {
-                const ach = ACHIEVEMENTS.find(a => a.id === id);
-                if (!ach) return null;
-                const rarity = RARITY[ach.rarity];
-                const name = isPol ? ach.namePol : ach.nameEng;
-                const desc = isPol ? ach.descPol : ach.descEng;
-                const date = new Date(unlockedAt).toLocaleDateString(isPol ? 'pl-PL' : 'en-GB');
-                const rarityLabel = rarity[isPol ? 'pol' : 'eng'];
-                return `${ach.icon} (${rarity.emoji}) **${name}** *(${rarityLabel})*\n└ ${desc} — ${date}`;
-            }).filter(Boolean);
-            embed.setDescription(lines.join('\n\n'));
-        }
-
-        return { embed, totalPages, currentPage };
+        return { embed };
     }
 
     _buildOverviewEmbed(unlocked, progress, t, isPol) {
@@ -267,7 +260,6 @@ class AchievementService {
             const catAchs = ACHIEVEMENTS.filter(a => a.category === catKey);
             const catUnlocked = catAchs.filter(a => unlockedIds.has(a.id)).length;
             const label = isPol ? catLabel.pol : catLabel.eng;
-            // Ukryte kategorie pokazują liczbę odblokowanych, ale total jako "?"
             const total = catLabel.hidden ? '?' : catAchs.length;
             return `${label}: **${catUnlocked}/${total}**`;
         });
@@ -283,36 +275,38 @@ class AchievementService {
                 `${unlockedIds.size} unlocked`
             ) });
 
-        return { embed, totalPages: 1, currentPage: 0 };
+        return { embed };
     }
 
-    _buildComponents(tab, currentPage, totalPages, t) {
-        const isUnlocked = tab === 'unlocked';
+    _buildComponents(activeKey, isPol, t) {
+        const isOverview = activeKey === 'overview';
 
-        const row = new ActionRowBuilder().addComponents(
-            new ButtonBuilder()
-                .setCustomId(`ach_view_unlocked_${currentPage - 1}`)
-                .setLabel('◀')
-                .setStyle(ButtonStyle.Secondary)
-                .setDisabled(!isUnlocked || currentPage <= 0),
-            new ButtonBuilder()
-                .setCustomId(`ach_view_unlocked_${currentPage + 1}`)
-                .setLabel('▶')
-                .setStyle(ButtonStyle.Secondary)
-                .setDisabled(!isUnlocked || currentPage >= totalPages - 1),
-            new ButtonBuilder()
-                .setCustomId('ach_view_unlocked_0')
-                .setLabel(t('🏆 Odblokowane', '🏆 Unlocked'))
-                .setStyle(isUnlocked ? ButtonStyle.Primary : ButtonStyle.Secondary)
-                .setDisabled(isUnlocked),
-            new ButtonBuilder()
-                .setCustomId('ach_view_overview_0')
-                .setLabel(t('📊 Podsumowanie', '📊 Overview'))
-                .setStyle(!isUnlocked ? ButtonStyle.Primary : ButtonStyle.Secondary)
-                .setDisabled(!isUnlocked),
+        const CATS = [
+            { key: 'score',    pol: '🏆 Wyniki',       eng: '🏆 Scores'    },
+            { key: 'records',  pol: '🔁 Rekordy',      eng: '🔁 Records'   },
+            { key: 'bosses',   pol: '🎯 Łowy',         eng: '🎯 The Hunt'  },
+            { key: 'prestige', pol: '💎 Prestiż',      eng: '💎 Prestige'  },
+            { key: 'explorer', pol: '🕵️ Eksplorator',  eng: '🕵️ Explorer'  },
+        ];
+
+        const catRow = new ActionRowBuilder().addComponents(
+            ...CATS.map(c => new ButtonBuilder()
+                .setCustomId(`ach_cat_${c.key}`)
+                .setLabel(isPol ? c.pol : c.eng)
+                .setStyle(activeKey === c.key ? ButtonStyle.Primary : ButtonStyle.Secondary)
+                .setDisabled(activeKey === c.key)
+            )
         );
 
-        return [row];
+        const overviewRow = new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId('ach_overview')
+                .setLabel(t('📊 Podsumowanie', '📊 Overview'))
+                .setStyle(isOverview ? ButtonStyle.Primary : ButtonStyle.Secondary)
+                .setDisabled(isOverview)
+        );
+
+        return [catRow, overviewRow];
     }
 
     /**


### PR DESCRIPTION
## Zmiany

- **Przeprojektowanie `/achievements`:** każda z 5 kategorii ma własną stronę — przycisk kategorii otwiera dedykowany embed z tytułem = etykieta kategorii
- **Nowy układ przycisków:** wiersz 1 — 5 przycisków kategorii (`🏆 Wyniki`, `🔁 Rekordy`, `🎯 Łowy`, `💎 Prestiż`, `🕵️ Eksplorator`); wiersz 2 — `📊 Podsumowanie`
- **Wyświetlanie osiągnięć per kategoria:** odblokowane z datą, zablokowane nieukryte ze strikethrough, zablokowane ukryte jako `🔒 **???**`
- **Stopka:** `X/Y odblokowanych` (dla ukrytych: `X/? odblokowanych`)
- **Domyślna strona** po `/achievements`: kategoria `score`
- **Ikona bota w rankingu serwerowym:** thumbnail z awatarem bota w embedzie rankingu (zmiany w `rankingService.js` już w main — tutaj tylko logika osiągnięć)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVMEvHWY4CFq9cDhiWAoXk)_