### PR TITLE
EndersEcho: system weryfikacji społeczności

### DIFF
--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -2997,6 +2997,7 @@ class InteractionHandler {
                 customId === 'cfg_roles_open' || customId === 'cfg_roles_skip' ||
                 customId === 'cfg_notif_yes' || customId === 'cfg_notif_no' ||
                 customId === 'cfg_role_ranking_add' || customId === 'cfg_role_ranking_remove' || customId === 'cfg_role_ranking_skip' ||
+                customId === 'cfg_cv_enable' || customId === 'cfg_cv_disable' || customId === 'cfg_cv_threshold' ||
                 customId === 'cfg_accept' || customId === 'cfg_cancel') {
                 const nick = interaction.member?.displayName || interaction.user.displayName || interaction.user.username;
                 this.logService._gl(interaction.guildId).info(`[${nick}] /configure → ${this._describeCfgButton(customId)}`);


### PR DESCRIPTION
## Podsumowanie

- Dodano system weryfikacji społeczności — gracze z rankingu mogą zgłaszać podejrzane wyniki przyciskiem **⚠️ Zgłoś** pod nowym rekordem
- Po osiągnięciu progu zgłoszeń użytkownik jest blokowany na 24h, a raport trafia na per-guild i globalny kanał odrzuconych z przyciskami akcji dla admina
- Krok 8 w wizardzie `/configure` do konfiguracji funkcji per-serwer (próg 1–25, kanał zgłoszeń, włącz/wyłącz)
- Po akcji admina przycisk „Zgłoś" na oryginalnym rekordzie zmienia się na zablokowany z etykietą akcji (zielony = zatwierdzone, czerwony = usunięte/zablokowane)
- Pełne wsparcie dwujęzyczne (pol/eng) — etykieta przycisku na oryginalnym rekordzie zawsze w języku serwera źródłowego

## Nowe pliki

- `EndersEcho/services/communityVerificationService.js` — zarządzanie sesjami głosowań, persistencja w `data/community_votes.json`

## Zmienione pliki

- `EndersEcho/handlers/interactionHandlers.js` — routing CV, krok 8 wizarda, flow głosowania i akcji admina
- `EndersEcho/services/guildConfigService.js` — `getCommunityVerification` / `setCommunityVerification`
- `EndersEcho/services/rankingService.js` — `getUserRecord`, `revertUserRecord`
- `EndersEcho/services/achievementService.js` — `revertSubmissionAchievements`
- `EndersEcho/config/messages.js` — klucze `cv*` w sekcjach pol i eng
- `EndersEcho/index.js` — inicjalizacja `CommunityVerificationService`
- `EndersEcho/CLAUDE.md` — dokumentacja nowego systemu

## Plan testów

- [ ] `/configure` krok 8 — włącz CV, ustaw próg i kanał
- [ ] Przycisk „Ustaw próg" otwiera modal (nie pokazuje błędu rankingu)
- [ ] Po nowym rekordzie pojawia się przycisk `⚠️ Zgłoś`
- [ ] Autor rekordu nie może głosować na własny wynik
- [ ] Gracz spoza rankingu nie może głosować
- [ ] Po osiągnięciu progu — blokada 24h + raport na kanale
- [ ] Admin: Zatwierdź → odblokowanie + zielony przycisk na rekordzie
- [ ] Admin: Usuń rekord → przywrócenie poprzedniego rekordu + cofnięcie osiągnięć + czerwony przycisk
- [ ] Admin: Zablokuj permanentnie → permanentna blokada + usunięcie rekordu
- [ ] Nowy rekord gracza wygasa poprzednią sesję CV i usuwa przycisk ze starego rekordu
- [ ] Etykieta przycisku na rekordzie w języku serwera (nie admina)

---
_Generated by [Claude Code](https://claude.ai/code/session_019tCSs5Yh2zTqKAbFpEUr2t)_