### PR TITLE
EndersEcho: osobny globalny kanał zgłoszeń społeczności

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -275,7 +275,7 @@
 - **Kto może głosować:** tylko gracze obecni w rankingu serwera (`rankingService.loadRanking()` — sprawdzane przy każdym kliknięciu). Autor zgłoszenia jest wykluczony z głosowania na własny wynik
 - **Licznik:** etykieta przycisku aktualizuje się po każdym głosie: `⚠️ Zgłoś (N)`
 - **Próg zgłoszeń:** konfigurowalne 1–25 (domyślnie 5). Po osiągnięciu progu: użytkownik blokowany na **24h** (`userBlockService.blockUser(..., '24h', false)`) + przycisk usuwany z oryginalnej wiadomości + raporty wysyłane na kanały rejected
-- **Raporty:** wysyłane jednocześnie na **per-guild kanał** (`communityVerification.rejectedChannelId`) i **globalny kanał** (`ENDERSECHO_INVALID_REPORT_CHANNEL_ID`). Embed zawiera: nick, serwer, boss, nowy/poprzedni wynik, liczbę zgłoszeń, link do zgłoszonej wiadomości (w polu embeda, nie w przycisku). Footer: `cv:{messageId}|uid:{userId}|gid:{guildId}`
+- **Raporty:** wysyłane jednocześnie na **per-guild kanał** (`communityVerification.rejectedChannelId`) i **globalny kanał** (`ENDERSECHO_COMMUNITY_REPORT_CHANNEL_ID`). Jeśli oba kanały mają to samo ID — wysyłana jest tylko jedna wiadomość (brak duplikatu). Embed zawiera: nick, serwer, boss, nowy/poprzedni wynik, liczbę zgłoszeń, link do zgłoszonej wiadomości (w polu embeda, nie w przycisku). Footer: `cv:{messageId}|uid:{userId}|gid:{guildId}`
 - **Przyciski admina w raporcie:**
   - `cv_admin_approve_{messageId}` → **Zatwierdź**: odblokuj użytkownika + zaktualizuj embedy raportów (usuń przyciski, dodaj info o akcji)
   - `cv_admin_remove_{messageId}` → **Usuń rekord i osiągnięcia**: przywróć poprzedni rekord (lub usuń wpis) + cofnij osiągnięcia zdobyte tym rekordem (`achievementService.revertSubmissionAchievements()`) + odblokuj użytkownika
@@ -386,6 +386,11 @@ ENDERSECHO_LOG_WEBHOOK_URL=webhook_url
 # Wysyła embed gdy screen jest odrzucony (podrobione zdjęcie, brak Victory, brak Best/Total)
 # Embed zawiera: nick na serwerze, Discord username, serwer, czas, powód, zdjęcie
 ENDERSECHO_INVALID_REPORT_CHANNEL_ID=channel_id
+
+# Globalny kanał zgłoszeń społeczności (opcjonalne)
+# Wysyła embed gdy gracz osiągnie próg zgłoszeń weryfikacji społeczności (CV system)
+# Jeśli ten sam ID co per-guild rejectedChannelId → wysyłany tylko jeden raport (bez duplikatu)
+ENDERSECHO_COMMUNITY_REPORT_CHANNEL_ID=channel_id
 
 # Użytkownicy uprawnieni do /ocr-on-off (ID rozdzielone przecinkami)
 # Komenda włącza/wyłącza /update i/lub /test per-guild (parametry: action, target, guild z autocomplete)

--- a/EndersEcho/config/config.js
+++ b/EndersEcho/config/config.js
@@ -100,6 +100,7 @@ module.exports = {
     blockOcrUserIds: (process.env.ENDERSECHO_BLOCK_OCR_USER_IDS || '').split(',').map(id => id.trim()).filter(Boolean),
     logWebhookUrl: process.env.ENDERSECHO_LOG_WEBHOOK_URL || null,
     invalidReportChannelId: process.env.ENDERSECHO_INVALID_REPORT_CHANNEL_ID || null,
+    communityReportChannelId: process.env.ENDERSECHO_COMMUNITY_REPORT_CHANNEL_ID || null,
     appApiKey: process.env.ENDERSECHO_API_KEY || process.env.BOT_API_KEY || null,
 
     // Lista serwerów z .env (fallback gdy guildConfigService niedostępny)

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -3233,13 +3233,16 @@ class InteractionHandler {
                 }
             }
 
-            // Wyślij na globalny kanał (head admin)
-            if (this.config.invalidReportChannelId) {
+            // Wyślij na globalny kanał zgłoszeń społeczności (head admin)
+            // Pomijamy jeśli to ten sam kanał co per-guild (żeby nie duplikować)
+            const globalCvChannelId = this.config.communityReportChannelId;
+            const skipGlobal = globalCvChannelId && cvCfg?.rejectedChannelId && globalCvChannelId === cvCfg.rejectedChannelId;
+            if (globalCvChannelId && !skipGlobal) {
                 try {
-                    const globalCh = await client.channels.fetch(this.config.invalidReportChannelId).catch(() => null);
+                    const globalCh = await client.channels.fetch(globalCvChannelId).catch(() => null);
                     if (globalCh) {
                         const sent = await globalCh.send({ embeds: [reportEmbed], components });
-                        rejectedMsgIds.push(`global:${this.config.invalidReportChannelId}:${sent.id}`);
+                        rejectedMsgIds.push(`global:${globalCvChannelId}:${sent.id}`);
                     }
                 } catch (e) {
                     logger.warn(`⚠️ CV: błąd wysyłania raportu na globalny channel: ${e.message}`);


### PR DESCRIPTION
## Summary

- Dodano nową zmienną środowiskową `ENDERSECHO_COMMUNITY_REPORT_CHANNEL_ID` — dedykowany globalny kanał dla raportów weryfikacji społeczności (CV system)
- Raporty CV kierowane są teraz na `communityReportChannelId` zamiast współdzielonego `invalidReportChannelId` (kanał odrzuconych screenów)
- Jeśli `ENDERSECHO_COMMUNITY_REPORT_CHANNEL_ID` ma to samo ID co per-guild `rejectedChannelId` — wysyłana jest tylko jedna wiadomość (brak duplikatu)

## Test plan

- [ ] Ustawić `ENDERSECHO_COMMUNITY_REPORT_CHANNEL_ID` na inny kanał niż per-guild `rejectedChannelId` → raport trafia na oba kanały
- [ ] Ustawić `ENDERSECHO_COMMUNITY_REPORT_CHANNEL_ID` na ten sam kanał co per-guild `rejectedChannelId` → raport pojawia się tylko raz
- [ ] Nie ustawiać `ENDERSECHO_COMMUNITY_REPORT_CHANNEL_ID` → raport trafia tylko na per-guild kanał (brak globalnego)
- [ ] Raporty odrzuconych screenów (`ENDERSECHO_INVALID_REPORT_CHANNEL_ID`) nadal działają bez zmian

---
_Generated by [Claude Code](https://claude.ai/code/session_011EX2P1crBC5JRAfM7zasUi)_