### PR TITLE
EndersEcho: poprawki rankingu i weryfikacji społeczności

### DIFF
--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -312,7 +312,7 @@ class RankingService {
                 const unitValue = value / unit.value;
                 return unitValue % 1 === 0 ?
                     `${unitValue}${unit.name}` :
-                    `${unitValue.toFixed(2)}${unit.name}`;
+                    `${parseFloat(unitValue.toFixed(2))}${unit.name}`;
             }
         }
 

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -143,7 +143,7 @@ class RankingService {
                 guildName,
                 totalScoreValue,
                 totalScore: this.formatScore(totalScoreValue),
-                playerCount: top30.length,
+                playerCount: players.length,
                 topScore: players[0]?.score || '0',
                 topScoreValue: players[0]?.scoreValue || 0
             });

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -445,7 +445,10 @@ class RankingService {
             .setTitle(title)
             .setDescription(rankingText);
 
-        // Pole statystyk wywołującego (pierwsze)
+        // Pole statystyk ogólnych (pierwsze)
+        embed.addFields({ name: isGlobal ? msgs.rankingStatsGlobal : msgs.rankingStats, value: statsLines.join('\n'), inline: false });
+
+        // Pole statystyk wywołującego (drugie)
         if (callerStats !== null) {
             let callerValue;
             if (!callerStats.score) {
@@ -465,9 +468,6 @@ class RankingService {
             }
             embed.addFields({ name: msgs.rankingYourStats, value: callerValue, inline: false });
         }
-
-        // Pole statystyk ogólnych (drugie)
-        embed.addFields({ name: isGlobal ? msgs.rankingStatsGlobal : msgs.rankingStats, value: statsLines.join('\n'), inline: false });
 
         embed
             .setFooter({ text: formatMessage(msgs.rankingPage, { current: page + 1, total: totalPages }) })


### PR DESCRIPTION
## Zmiany

### Weryfikacja społeczności (CV)
- **Nowy globalny kanał zgłoszeń** — dodano zmienną `ENDERSECHO_COMMUNITY_REPORT_CHANNEL_ID` dedykowaną dla raportów CV (oddzielna od `ENDERSECHO_INVALID_REPORT_CHANNEL_ID` używanej przez odrzucone screeny)
- **Deduplikacja** — jeśli `ENDERSECHO_COMMUNITY_REPORT_CHANNEL_ID` ma to samo ID co per-guild `rejectedChannelId`, wysyłany jest tylko jeden raport
- **Ukryty licznik głosów** — przycisk `⚠️ Zgłoś` nie aktualizuje już etykiety po każdym kliknięciu; po osiągnięciu progu przycisk wyświetla `⚠️ Zgłoszono` (bez liczby)

### Ranking
- **Usunięto trailing zero** — `formatScore()` nie wyświetla już `1.50M`, tylko `1.5M`
- **Zamiana kolejności pól** — w embeddzie rankingu pole **Statystyki** pojawia się przed **Twoimi statystykami** (dotyczy rankingu serwerowego i globalnego)
- **Ranking Serwerów — poprawna liczba użytkowników** — `playerCount` pokazuje teraz łączną liczbę wszystkich użytkowników w rankingu serwera, nie tylko tych z top 30 użytych do obliczenia sumy

## Konfiguracja (nowa zmienna)

```env
# Globalny kanał zgłoszeń społeczności (opcjonalne)
# Oddzielny od ENDERSECHO_INVALID_REPORT_CHANNEL_ID (odrzucone screeny)
ENDERSECHO_COMMUNITY_REPORT_CHANNEL_ID=channel_id
```

## Test plan

- [ ] Ustawić `ENDERSECHO_COMMUNITY_REPORT_CHANNEL_ID` na nowy kanał → raport CV trafia na oba kanały (per-guild + globalny)
- [ ] Ustawić ten sam ID co per-guild kanał → tylko jedna wiadomość (brak duplikatu)
- [ ] Kliknąć `⚠️ Zgłoś` kilka razy → etykieta przycisku bez licznika
- [ ] Sprawdzić wyniki w rankingu — brak trailing zero (np. `1.5M` zamiast `1.50M`)
- [ ] Sprawdzić kolejność pól: Statystyki → Twoje statystyki
- [ ] Sprawdzić Ranking Serwerów — liczba graczy to suma wszystkich, nie max 30

---
_Generated by [Claude Code](https://claude.ai/code/session_011EX2P1crBC5JRAfM7zasUi)_