### PR TITLE
EndersEcho: nazwy zamiast ID w logach

### DIFF
--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -176,9 +176,9 @@ class InteractionHandler {
                     Routes.applicationGuildCommands(this.config.clientId, guildId),
                     { body: commands }
                 );
-                logger.info(`✅ Zarejestrowano komendy dla serwera ${guildId} (${cfg.lang || 'eng'})`);
+                logger.info(`✅ Zarejestrowano komendy dla serwera "${client.guilds.cache.get(guildId)?.name || guildId}" (${cfg.lang || 'eng'})`);
             } catch (error) {
-                logger.error(`Błąd rejestracji slash commands dla serwera ${guildId}:`, error);
+                logger.error(`Błąd rejestracji slash commands dla serwera "${client.guilds.cache.get(guildId)?.name || guildId}":`, error);
             }
         }
         if (skipped.length > 0) {
@@ -198,9 +198,9 @@ class InteractionHandler {
                 Routes.applicationGuildCommands(this.config.clientId, guildId),
                 { body: commands }
             );
-            logger.info(`✅ Zarejestrowano komendy dla nowego serwera ${guildId}`);
+            logger.info(`✅ Zarejestrowano komendy dla nowego serwera "${client.guilds.cache.get(guildId)?.name || guildId}"`);
         } catch (error) {
-            logger.error(`Błąd rejestracji komend dla serwera ${guildId}:`, error);
+            logger.error(`Błąd rejestracji komend dla serwera "${client.guilds.cache.get(guildId)?.name || guildId}":`, error);
         }
     }
 
@@ -1149,7 +1149,7 @@ class InteractionHandler {
                         await reportChannel.send({ embeds: [configEmbed] });
                     }
                 } catch (err) {
-                    logger.error(`Błąd wysyłania powiadomienia cfg_accept (guildId=${interaction.guildId}):`, err.message);
+                    logger.error(`Błąd wysyłania powiadomienia cfg_accept (serwer "${interaction.guild?.name || interaction.guildId}"):`, err.message);
                 }
             }
             return;
@@ -1337,7 +1337,7 @@ class InteractionHandler {
                 ]
             });
         } catch (err) {
-            logger.error(`Błąd _handlePanelRemoveSearch (guildId=${guildId}):`, err);
+            logger.error(`Błąd _handlePanelRemoveSearch (serwer "${interaction.guild?.name || guildId}"):`, err);
             await interaction.editReply({ content: t('❌ Błąd wczytywania rankingu.', '❌ Error loading ranking.'), embeds: [], components: [] });
         }
     }
@@ -1414,7 +1414,7 @@ class InteractionHandler {
                 )]
             });
         } catch (err) {
-            logger.error(`Błąd _handlePanelRemoveConfirm (targetGuildId=${targetGuildId}, userId=${targetUserId}):`, err);
+            logger.error(`Błąd _handlePanelRemoveConfirm (serwer "${interaction.client.guilds.cache.get(targetGuildId)?.name || targetGuildId}", gracz ID ${targetUserId}):`, err);
             await interaction.editReply({ content: t('❌ Błąd usuwania gracza.', '❌ Error removing player.'), embeds: [], components: [] });
         }
     }
@@ -1617,7 +1617,7 @@ class InteractionHandler {
                 ]
             });
         } catch (err) {
-            logger.error(`Błąd _handlePanelBlockSearch (guildId=${interaction.guildId}):`, err);
+            logger.error(`Błąd _handlePanelBlockSearch (serwer "${interaction.guild?.name || interaction.guildId}"):`, err);
             await interaction.editReply({ content: t('❌ Błąd wyszukiwania gracza.', '❌ Error searching for player.'), embeds: [], components: [] });
         }
     }
@@ -1694,7 +1694,7 @@ class InteractionHandler {
                 )]
             });
         } catch (err) {
-            logger.error(`Błąd _handlePanelBlockModal (userId=${targetUserId}):`, err);
+            logger.error(`Błąd _handlePanelBlockModal (serwer "${interaction.client.guilds.cache.get(targetGuildId)?.name || targetGuildId}", gracz ID ${targetUserId}):`, err);
             await interaction.editReply({ content: t('❌ Błąd blokowania gracza.', '❌ Error blocking player.'), embeds: [], components: [] });
         }
     }
@@ -2000,7 +2000,7 @@ class InteractionHandler {
             }
             return result;
         } catch (err) {
-            logger.warn(`Błąd pobierania pozycji ról dla użytkownika ${userId}: ${err.message}`);
+            logger.warn(`Błąd pobierania pozycji ról dla użytkownika "${guild?.members?.cache?.get(userId)?.displayName || userId}": ${err.message}`);
             return [];
         }
     }
@@ -3250,7 +3250,7 @@ class InteractionHandler {
             }
 
             await this.communityVerificationService.markTriggered(messageId, rejectedMsgIds);
-            logger.info(`🚨 CV: zgłoszenie wysłane dla userId=${session.userId} (${session.count} głosów)`);
+            logger.info(`🚨 CV: zgłoszenie wysłane dla "${targetUser?.username || session.userId}" na serwerze "${sourceGuild?.name || session.guildId}" (${session.count} głosów)`);
         } catch (err) {
             logger.error(`CV _triggerCvReport error: ${err.message}`);
         }
@@ -4481,7 +4481,7 @@ class InteractionHandler {
                 await channel.send({ embeds: [embed] });
                 results.push({ label: guildLabel, id: guildCfg.id, status: 'ok', lang, guildObj });
             } catch (err) {
-                logger.error(`Błąd wysyłania /info do serwera ${guildCfg.id}: ${err.message}`);
+                logger.error(`Błąd wysyłania /info do serwera "${guildLabel}": ${err.message}`);
                 results.push({
                     label: guildLabel, id: guildCfg.id, status: 'error', lang,
                     error: this._mapSendError(err),
@@ -5671,7 +5671,7 @@ class InteractionHandler {
                 ]
             });
         } catch (err) {
-            logger.error(`Błąd _handlePanelAchResetSearch (guildId=${guildId}):`, err);
+            logger.error(`Błąd _handlePanelAchResetSearch (serwer "${interaction.guild?.name || guildId}"):`, err);
             await interaction.editReply({ content: t('❌ Błąd wczytywania rankingu.', '❌ Error loading ranking.'), embeds: [], components: [] });
         }
     }
@@ -5721,7 +5721,7 @@ class InteractionHandler {
                 )]
             });
         } catch (err) {
-            logger.error(`Błąd _handlePanelAchResetConfirm (targetGuildId=${targetGuildId}, userId=${targetUserId}):`, err);
+            logger.error(`Błąd _handlePanelAchResetConfirm (serwer "${interaction.client.guilds.cache.get(targetGuildId)?.name || targetGuildId}", gracz ID ${targetUserId}):`, err);
             await interaction.editReply({ content: t('❌ Błąd resetu osiągnięć.', '❌ Error resetting achievements.'), embeds: [], components: [] });
         }
     }

--- a/EndersEcho/index.js
+++ b/EndersEcho/index.js
@@ -185,7 +185,7 @@ client.on('guildCreate', async (guild) => {
             .setTimestamp()
         );
     } catch (err) {
-        logger.error(`Błąd przy dodawaniu do serwera ${guild.id}: ${err.message}`);
+        logger.error(`Błąd przy dodawaniu do serwera "${guild.name}": ${err.message}`);
     }
 });
 
@@ -196,7 +196,7 @@ async function sendAdminNotification(discordClient, embed) {
         const channel = await discordClient.channels.fetch(channelId);
         if (channel) await channel.send({ embeds: [embed] });
     } catch (err) {
-        logger.error(`Błąd wysyłania powiadomienia admin (channelId=${channelId}):`, err.message);
+        logger.error(`Błąd wysyłania powiadomienia admin (kanał "${discordClient.channels.cache.get(channelId)?.name || channelId}"):`, err.message);
     }
 }
 
@@ -229,7 +229,7 @@ async function bootstrapGuildSync(guild) {
         try {
             fetched = await guild.members.fetch();
         } catch (err) {
-            logger.warn(`members.fetch() fail (gid=${guild.id}): ${err.message}`);
+            logger.warn(`members.fetch() fail (serwer "${guild.name}"): ${err.message}`);
             return;
         }
 
@@ -251,9 +251,9 @@ async function bootstrapGuildSync(guild) {
                 totalCount += res.count;
             }
         }
-        logger.info(`appSync bootstrap ${guild.name} (${guild.id}): wysłano ${members.length}, API potwierdziło count=${totalCount}`);
+        logger.info(`appSync bootstrap "${guild.name}": wysłano ${members.length}, API potwierdziło count=${totalCount}`);
     } catch (err) {
-        logger.error(`Błąd bootstrap appSync (guildId=${guild.id}): ${err.message}`);
+        logger.error(`Błąd bootstrap appSync (serwer "${guild.name}"): ${err.message}`);
     }
 }
 
@@ -266,7 +266,7 @@ client.on('guildDelete', async (guild) => {
     try {
         await appSync.guildLeft({ guildId: guild.id });
     } catch (err) {
-        logger.error(`Błąd guildLeft (guildId=${guild.id}):`, err);
+        logger.error(`Błąd guildLeft (serwer "${guild.name}"):`, err);
     }
     await sendAdminNotification(client, new EmbedBuilder()
         .setColor(0xED4245)
@@ -285,7 +285,7 @@ client.on('guildMemberAdd', async (member) => {
         if (!payload) return;
         await appSync.memberSeen(payload);
     } catch (err) {
-        logger.error(`Błąd memberSeen add (guildId=${member?.guild?.id}, discordId=${member?.user?.id}):`, err);
+        logger.error(`Błąd memberSeen add (serwer "${member?.guild?.name}", użytkownik "${member?.displayName || member?.user?.username || member?.user?.id}"):`, err);
     }
 });
 
@@ -295,7 +295,7 @@ client.on('guildMemberUpdate', async (_oldMember, newMember) => {
         if (!payload) return;
         await appSync.memberSeen(payload);
     } catch (err) {
-        logger.error(`Błąd memberSeen update (guildId=${newMember?.guild?.id}, discordId=${newMember?.user?.id}):`, err);
+        logger.error(`Błąd memberSeen update (serwer "${newMember?.guild?.name}", użytkownik "${newMember?.displayName || newMember?.user?.username || newMember?.user?.id}"):`, err);
     }
 });
 

--- a/EndersEcho/services/achievementService.js
+++ b/EndersEcho/services/achievementService.js
@@ -132,7 +132,7 @@ class AchievementService {
             userData.progress.lastRecordBeatAt = prevTs;
             await this.saveData(guildId, data);
         } catch (err) {
-            logger.error(`revertSubmissionAchievements error (${userId}@${guildId}): ${err.message}`);
+            logger.error(`revertSubmissionAchievements error (gracz ID ${userId}, serwer "${this.config.guilds?.find(g => g.id === guildId)?.tag || guildId}"): ${err.message}`);
         }
     }
 

--- a/EndersEcho/services/guildConfigService.js
+++ b/EndersEcho/services/guildConfigService.js
@@ -74,7 +74,7 @@ class GuildConfigService {
                     importedFromEnv: true,
                 };
                 this._guilds.set(envGuild.id, entry);
-                logger.info(`📥 Zaimportowano serwer ${envGuild.id} z .env do guild_configs.json`);
+                logger.info(`📥 Zaimportowano serwer "${envGuild.tag || envGuild.id}" z .env do guild_configs.json`);
                 didImport = true;
             }
         }

--- a/EndersEcho/services/ocrBlockService.js
+++ b/EndersEcho/services/ocrBlockService.js
@@ -43,7 +43,7 @@ class OcrBlockService {
         const existing = new Set(this._guildConfigService.getOcrBlocked(guildId));
         for (const cmd of commands) existing.add(cmd);
         await this._guildConfigService.setOcrBlocked(guildId, [...existing]);
-        logger.info(`🔒 OCR zablokowano [${commands.join(', ')}] na serwerze ${guildId}`);
+        logger.info(`🔒 OCR zablokowano [${commands.join(', ')}] na serwerze "${this._guildConfigService.getConfig(guildId)?.guildName || guildId}"`);
     }
 
     /**
@@ -55,7 +55,7 @@ class OcrBlockService {
         const existing = new Set(this._guildConfigService.getOcrBlocked(guildId));
         for (const cmd of commands) existing.delete(cmd);
         await this._guildConfigService.setOcrBlocked(guildId, [...existing]);
-        logger.info(`🔓 OCR odblokowano [${commands.join(', ')}] na serwerze ${guildId}`);
+        logger.info(`🔓 OCR odblokowano [${commands.join(', ')}] na serwerze "${this._guildConfigService.getConfig(guildId)?.guildName || guildId}"`);
     }
 }
 

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -54,7 +54,7 @@ class RankingService {
             if (this.config.guilds[0]?.id === guildId) {
                 const legacy = await this._loadLegacyRanking();
                 if (legacy) {
-                    logger.info(`🔄 Migruję stary ranking.json do ranking_${guildId}.json`);
+                    logger.info(`🔄 Migruję stary ranking.json do ranking_${guildId}.json (serwer "${this.config.guilds[0]?.tag || guildId}")`);
                     await this.saveRanking(guildId, legacy);
                     return legacy;
                 }
@@ -1047,7 +1047,7 @@ class RankingService {
         // Całe read-modify-write w kolejce per-guild — eliminuje race condition przy równoczesnych /update
         return this._enqueue(guildId, async () => {
             if (this.config.ocr.detailedLogging.enabled) {
-                logger.info(`🔍 DEBUG: updateUserRanking - guildId: ${guildId}, userId: ${userId}, bestScore: "${bestScore}"`);
+                logger.info(`🔍 DEBUG: updateUserRanking - serwer: "${this.config.getAllGuilds().find(g => g.id === guildId)?.tag || guildId}", gracz: "${userName}", bestScore: "${bestScore}"`);
             }
 
             const ranking = await this.loadRanking(guildId);
@@ -1152,7 +1152,9 @@ class RankingService {
             await this._enqueue(guild.id, async () => {
                 const ranking = await this.loadRanking(guild.id);
                 if (ranking[userId] && ranking[userId].scoreValue < newScoreValue) {
-                    logger.info(`🗑️ Usunięto gorszy wynik gracza ${userId} z serwera ${guild.id} (pobity przez rekord na ${currentGuildId})`);
+                    const playerName = ranking[userId].username || userId;
+                    const currentGuildTag = this.config.getAllGuilds().find(g => g.id === currentGuildId)?.tag;
+                    logger.info(`🗑️ Usunięto gorszy wynik gracza "${playerName}" z serwera "${guild.tag || guild.id}" (pobity przez rekord na "${currentGuildTag || currentGuildId}")`);
                     delete ranking[userId];
                     await this.saveRanking(guild.id, ranking);
                 }
@@ -1171,9 +1173,11 @@ class RankingService {
             const ranking = await this.loadRanking(guildId);
 
             if (ranking[userId]) {
+                const playerName = ranking[userId].username || userId;
                 delete ranking[userId];
                 await this.saveRanking(guildId, ranking);
-                logger.info(`🗑️ Usunięto gracza ${userId} z rankingu serwera ${guildId}`);
+                const guildTag = this.config.getAllGuilds().find(g => g.id === guildId)?.tag;
+                logger.info(`🗑️ Usunięto gracza "${playerName}" z rankingu serwera "${guildTag || guildId}"`);
                 return true;
             }
 

--- a/EndersEcho/services/roleRankingConfigService.js
+++ b/EndersEcho/services/roleRankingConfigService.js
@@ -84,11 +84,11 @@ class RoleRankingConfigService {
     async getMembersWithRole(guild, roleId, playerUserIds) {
         const cached = this._getCached(guild.id, roleId);
         if (cached) {
-            logger.info(`[RoleRanking] Cache hit: rola ${roleId} na serwerze ${guild.id}`);
+            logger.info(`[RoleRanking] Cache hit: rola "${guild.roles.cache.get(roleId)?.name || roleId}" na serwerze "${guild.name}"`);
             return cached;
         }
 
-        logger.info(`[RoleRanking] Fetchuję ${playerUserIds.length} graczy dla roli ${roleId} na serwerze ${guild.id}...`);
+        logger.info(`[RoleRanking] Fetchuję ${playerUserIds.length} graczy dla roli "${guild.roles.cache.get(roleId)?.name || roleId}" na serwerze "${guild.name}"...`);
 
         const withRole = new Set();
         // Discord pozwala batch do 100 ID w jednym żądaniu — fetche wykonywane równolegle
@@ -116,7 +116,7 @@ class RoleRankingConfigService {
         }
 
         this._setCache(guild.id, roleId, withRole);
-        logger.info(`[RoleRanking] Znaleziono ${withRole.size} graczy z rolą ${roleId}`);
+        logger.info(`[RoleRanking] Znaleziono ${withRole.size} graczy z rolą "${guild.roles.cache.get(roleId)?.name || roleId}"`);
         return withRole;
     }
 }


### PR DESCRIPTION
## Podsumowanie

- Zastąpiono ID kanałów nazwami kanałów w logach
- Zastąpiono ID serwerów nazwami serwerów w logach
- Zastąpiono ID użytkowników nickami/nazwami w logach
- Zastąpiono ID ról nazwami ról w logach

## Zmienione pliki

| Plik | Zmiany |
|---|---|
| `EndersEcho/index.js` | ID serwera → nazwa, ID kanału → nazwa, ID użytkownika → displayName |
| `EndersEcho/handlers/interactionHandlers.js` | ID serwera → nazwa (przez cache), ID użytkownika → displayName gdzie dostępny |
| `EndersEcho/services/roleRankingConfigService.js` | ID roli → nazwa roli, ID serwera → nazwa serwera |
| `EndersEcho/services/ocrBlockService.js` | ID serwera → nazwa przez guildConfigService |
| `EndersEcho/services/rankingService.js` | ID serwera → tag, ID użytkownika → username z danych rankingu |
| `EndersEcho/services/guildConfigService.js` | ID serwera → tag z konfiguracji |
| `EndersEcho/services/achievementService.js` | ID serwera → tag z konfiguracji |

## Plan testów

- [ ] Sprawdzić czy logi przy starcie bota wyświetlają nazwy serwerów
- [ ] Sprawdzić logi przy `/update` — aktualizacja rankingu z nazwą gracza
- [ ] Sprawdzić logi przy `/manage` → usunięcie gracza — nazwa serwera zamiast ID
- [ ] Sprawdzić logi przy blokadzie OCR — nazwa serwera zamiast ID

---
_Generated by [Claude Code](https://claude.ai/code/session_01462GvKi2wJkiNNBdkhcXjo)_