### PR TITLE
Naprawiono niezaznaczanie potwierdzeń PRIVMSG w embedzie

### DIFF
--- a/Stalker/CLAUDE.md
+++ b/Stalker/CLAUDE.md
@@ -46,7 +46,9 @@
 - **Tracking Potwierdzeń:** `reminderStatusTrackingService.js` - embed na kanale WARNING (nie CONFIRMATION) z godziną potwierdzenia obok nicku
 - Format: `✅ NickName • 14:27` - pokazuje kiedy użytkownik potwierdził (oba przypomnienia w jednym embedzie)
 - Struktura: `tracking.reminders[]` - tablica z obu przypomnieniami (reminderNumber, sentAt, users)
+- Klucz trackingu: `{roleId}_YYYY-MM-DD` gdzie roleId = rola klanu moderatora (session.userClanRoleId)
 - Aktualizacja przez usunięcie i ponowne wysłanie embeda (świeża pozycja na dole czatu)
+- **`updateUserStatus` fallback**: Jeśli tracking nie jest znajdowany po roleId użytkownika (moderator z innego klanu), przeszukuje wszystkie trackings z dzisiaj szukając userId. Szuka userId w WSZYSTKICH reminderach (nie tylko najnowszym).
 - **`handleConfirmReminderButton` używa `deferUpdate()` natychmiast** - przed wszystkimi operacjami sieciowymi/I/O, potem `editReply()` / `followUp()`. Zapobiega wygasaniu interakcji Discord (limit 3s) gdy fetch guild lub I/O pliku trwa dłużej.
 
 **Mapowanie Nicków** - System automatycznego mapowania użytkowników po zmianie nicku Discord:

--- a/Stalker/services/reminderStatusTrackingService.js
+++ b/Stalker/services/reminderStatusTrackingService.js
@@ -198,30 +198,56 @@ class ReminderStatusTrackingService {
     async updateUserStatus(userId, roleId, confirmationTimestamp) {
         try {
             const trackingKey = this.getTrackingKey(roleId);
-            const tracking = this.trackingData[trackingKey];
+            let tracking = this.trackingData[trackingKey];
+            let actualTrackingKey = trackingKey;
+
+            // Jeśli nie znaleziono po kluczu z roleId użytkownika (np. moderator z innego klanu),
+            // przeszukaj wszystkie trackings z dziś i znajdź ten który zawiera userId
+            if (!tracking) {
+                const now = new Date();
+                const polandTime = new Date(now.toLocaleString('en-US', { timeZone: this.config.timezone }));
+                const dateStr = polandTime.toISOString().split('T')[0];
+
+                for (const [key, data] of Object.entries(this.trackingData)) {
+                    if (!key.endsWith(`_${dateStr}`)) continue;
+                    const foundInKey = data.reminders.some(r => r.users[userId]);
+                    if (foundInKey) {
+                        tracking = data;
+                        actualTrackingKey = key;
+                        logger.info(`[REMINDER-TRACKING] 🔍 Znaleziono tracking po userId: ${key} (zamiast ${trackingKey})`);
+                        break;
+                    }
+                }
+            }
 
             if (!tracking) {
-                logger.warn(`[REMINDER-TRACKING] ⚠️ Brak trackingu dla ${trackingKey}`);
+                logger.warn(`[REMINDER-TRACKING] ⚠️ Brak trackingu dla ${trackingKey} i nie znaleziono po userId ${userId}`);
                 return false;
             }
 
-            // Znajdź ostatni reminder (najnowszy)
-            const latestReminder = tracking.reminders[tracking.reminders.length - 1];
+            // Znajdź reminder zawierający userId (przeszukaj WSZYSTKIE, nie tylko najnowszy)
+            let targetReminder = null;
+            for (const reminder of tracking.reminders) {
+                if (reminder.users[userId]) {
+                    targetReminder = reminder;
+                    // Nie przerywaj - jeśli jest w kilku reminderach, weź ostatni
+                }
+            }
 
-            if (!latestReminder.users[userId]) {
-                logger.warn(`[REMINDER-TRACKING] ⚠️ Użytkownik ${userId} nie jest w najnowszym reminderze`);
+            if (!targetReminder) {
+                logger.warn(`[REMINDER-TRACKING] ⚠️ Użytkownik ${userId} nie jest w żadnym reminderze trackingu ${actualTrackingKey}`);
                 return false;
             }
 
             // Oznacz jako confirmed i zapisz timestamp
-            latestReminder.users[userId].confirmed = true;
-            latestReminder.users[userId].confirmedAt = confirmationTimestamp;
+            targetReminder.users[userId].confirmed = true;
+            targetReminder.users[userId].confirmedAt = confirmationTimestamp;
 
-            logger.info(`[REMINDER-TRACKING] ✅ Zaktualizowano status użytkownika ${userId} w ${trackingKey} (remind ${latestReminder.reminderNumber})`);
+            logger.info(`[REMINDER-TRACKING] ✅ Zaktualizowano status użytkownika ${userId} w ${actualTrackingKey} (remind ${targetReminder.reminderNumber})`);
 
             // Zapisz i aktualizuj embed
             await this.saveTrackingData();
-            await this.updateEmbed(trackingKey);
+            await this.updateEmbed(actualTrackingKey);
 
             return true;
         } catch (error) {


### PR DESCRIPTION
## Problem

Użytkownicy klikali przycisk „Potwierdź odbiór" w DM, widzieli potwierdzenie w wiadomości prywatnej, ale embed ze statusem potwierdzeń na kanale WARNING nadal pokazywał ich z ❌.

## Przyczyny (dwa bugi w `reminderStatusTrackingService.js`)

### Bug 1 – Mismatch klucza trackingowego (główna przyczyna)
Tracking był tworzony z kluczem `{session.userClanRoleId}_{date}` – czyli rola klanu **moderatora** wykonującego `/remind`.  
`updateUserStatus` szukało trackingu po kluczu `{roleId z customId przycisku}_{date}` – czyli rola klanu **użytkownika** który kliknął przycisk.

Gdy moderator jest z innego klanu niż użytkownik (lub OCR wykrywa graczy z wielu klanów), klucze się nie zgadzały → tracking nie był znajdowany → embed nie był aktualizowany.

### Bug 2 – Szukanie tylko w najnowszym reminderze
`updateUserStatus` szukało `userId` tylko w `latestReminder` (`tracking.reminders[reminders.length - 1]`). Jeśli wysłano dwa przypomnienia, a użytkownik potwierdza pierwsze, nie był znajdowany w drugim.

## Rozwiązanie

W `updateUserStatus`:
1. **Fallback search**: Jeśli tracking nie jest znajdowany po kluczu z `roleId`, przeszukuje wszystkie trackings z dzisiaj i szuka tego który zawiera dany `userId`
2. **Przeszukiwanie wszystkich reminderów**: Zamiast `latestReminder`, iteruje przez wszystkie remindery w trackingu i bierze ten zawierający `userId` (przy wielu reminderach – ostatni znaleziony)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NM83Zv2CJ2qWsySceKXAFK)_