### PR TITLE
EndersEcho: ephemeral o duplikacie wyników cross-server

### DIFF
--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -54,6 +54,7 @@ const pol = {
     // Nowy rekord — ogłoszenie ephemeral
     newRecordConfirmed: '✅ **Nowy rekord został pobity i pozytywnie ogłoszony!**\n🏆 Gratulacje! Twój wynik został opublikowany dla wszystkich.',
     newRecordFallback: '🏆 **NOWY REKORD!**\n**Gracz:** {username}\n**Nowy rekord:** {score}\n**Poprzedni:** {previous}\n\n*Błąd wysyłania pełnego embed*',
+    sameScoreOtherServer: '✅ Wynik **{score}** zapisany na tym serwerze.\n⚠️ Taki sam wynik masz już na serwerze **{guildName}** — nie jest to nowy rekord globalny.',
     noRecordFallback: '❌ Nie pobito rekordu\n**Gracz:** {username}\n**Wynik:** {score}\n**Obecny rekord:** {current}\n\n*Błąd wysyłania embed z obrazem*',
     rankingImageCaption: '📎 **Oryginalny obraz wyniku:**',
 
@@ -350,6 +351,7 @@ const eng = {
     // New record — ephemeral announcement
     newRecordConfirmed: '✅ **New record set and announced!**\n🏆 Congratulations! Your score has been published for everyone.',
     newRecordFallback: '🏆 **NEW RECORD!**\n**Player:** {username}\n**New record:** {score}\n**Previous:** {previous}\n\n*Error sending full embed*',
+    sameScoreOtherServer: '✅ Score **{score}** saved for this server.\n⚠️ You already have the same score on server **{guildName}** — this is not a new global record.',
     noRecordFallback: '❌ Record not beaten\n**Player:** {username}\n**Score:** {score}\n**Current record:** {current}\n\n*Error sending embed with image*',
     rankingImageCaption: '📎 **Original result image:**',
 

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -2398,9 +2398,17 @@ class InteractionHandler {
                 achievementsFieldValue
             );
 
+            // Wykryj duplikat cross-server: wynik nowy dla tego serwera, ale globalnie się nie poprawił
+            const _newScoreValue = this.rankingService.parseScoreValue(bestScore);
+            const _prevGlobalUser = !dryRun ? prevGlobalRanking?.find(p => p.userId === userId) : null;
+            const isCrossServerDuplicate = !dryRun &&
+                _prevGlobalUser &&
+                _prevGlobalUser.scoreValue >= _newScoreValue &&
+                _prevGlobalUser.sourceGuildId !== guildId;
+
             // Pobierz subskrybentów i dodaj liczbę obserwujących do embeda
             let recordSubscribers = [];
-            if (!dryRun) {
+            if (!dryRun && !isCrossServerDuplicate) {
                 try {
                     recordSubscribers = await this.notificationService.getSubscribersForTarget(userId, guildId);
                     if (recordSubscribers.length > 0) {
@@ -2421,6 +2429,15 @@ class InteractionHandler {
                         files: [imageAttachment]
                     });
                     gl.info('✅ Wysłano ephemeral podgląd nowego rekordu (tryb testowy)');
+                } else if (isCrossServerDuplicate) {
+                    const sourceGuildName = interaction.client.guilds.cache.get(_prevGlobalUser.sourceGuildId)?.name
+                        || _prevGlobalUser.sourceGuildId;
+                    await interaction.editReply({
+                        content: formatMessage(msgs.sameScoreOtherServer, { score: bestScore, guildName: sourceGuildName }),
+                        embeds: [publicEmbed],
+                        files: [imageAttachment]
+                    });
+                    gl.info(`✅ [${userName}] Wysłano ephemeral o duplikacie cross-server (serwer źródłowy: "${sourceGuildName}")`);
                 } else {
                     await interaction.editReply({ content: msgs.newRecordConfirmed });
 


### PR DESCRIPTION
## Podsumowanie

- Wykrywanie duplikatu cross-server: gdy gracz przesyła ten sam (lub gorszy) wynik na nowym serwerze, a jego globalny rekord pochodzi z innego serwera
- Zamiast publicznego ogłoszenia „nowy rekord" bot wysyła ephemeral z informacją o duplikacie (embed z wynikiem + komunikat o serwerze źródłowym)
- Pominięcie powiadomień DM i licznika obserwujących dla duplikatów cross-server

## Szczegóły techniczne

**Warunek duplikatu** (`isCrossServerDuplicate`):
- `isNewRecord = true` na bieżącym serwerze (brak wpisu dla gracza)
- Ale gracz miał już taki sam lub lepszy wynik w globalnym rankingu przed zapisem (`prevGlobalRanking`)
- I ten globalny rekord pochodzi z INNEGO serwera (`sourceGuildId !== guildId`)

**Zachowanie po zmianie:**
- Wynik jest nadal zapisywany do rankingu lokalnego serwera
- Role TOP są nadal aktualizowane
- Zamiast publicznego `followUp` → ephemeral `editReply` z komunikatem `sameScoreOtherServer` + embed rekordu + screenshot
- Brak powiadomień DM dla subskrybentów (score nie jest nowym globalnym rekordem)
- Global Top 3 nie odpala się (warunek `globalScoreChanged = false` — bez zmian)

## Plan testów

- [ ] Gracz z wynikiem X na Serwerze A przesyła X na Serwerze B → ephemeral z adnotacją, brak publicznego ogłoszenia
- [ ] Gracz z wynikiem Y (wyższym) na Serwerze A przesyła niższy X na Serwerze B → ephemeral z adnotacją
- [ ] Gracz przesyła NOWY wynik (lepszy niż na jakimkolwiek serwerze) → normalne publiczne ogłoszenie bez zmian
- [ ] Tryb `/test` (dryRun) → bez zmian (dryRun zawsze ephemeral, warunek pomijany)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3yNfRxe3vP3yFynCgdj4e)_