### PR TITLE
EndersEcho: wyświetlanie testerów po nicku w panelu admina

### DIFF
--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -5815,12 +5815,47 @@ class InteractionHandler {
         }
     }
 
+    async _resolveTesterNames(testers, guild) {
+        const nameMap = new Map();
+        const toFetch = [];
+        for (const te of testers) {
+            if (te.username) {
+                nameMap.set(te.userId, te.username);
+            } else {
+                const cached = guild.members.cache.get(te.userId);
+                if (cached) {
+                    nameMap.set(te.userId, cached.displayName || cached.user.username);
+                } else {
+                    toFetch.push(te.userId);
+                }
+            }
+        }
+        if (toFetch.length > 0) {
+            try {
+                const fetched = await guild.members.fetch({ user: toFetch });
+                for (const [id, member] of fetched) {
+                    nameMap.set(id, member.displayName || member.user.username);
+                }
+            } catch {}
+        }
+        return nameMap;
+    }
+
     async _handlePanelTester(interaction) {
         const t = this._panelT(interaction.guildId);
         const testers = this.testerService ? this.testerService.getTesters() : [];
-        const desc = testers.length > 0
-            ? testers.map((t2, i) => `${i + 1}. <@${t2.userId}>`).join('\n')
-            : t('Brak testerów.', 'No testers.');
+        let desc;
+        if (testers.length > 0) {
+            const nameMap = await this._resolveTesterNames(testers, interaction.guild);
+            desc = testers.map((te, i) => {
+                const name = nameMap.get(te.userId);
+                return name
+                    ? `${i + 1}. **${name}** (<@${te.userId}>)`
+                    : `${i + 1}. <@${te.userId}>`;
+            }).join('\n');
+        } else {
+            desc = t('Brak testerów.', 'No testers.');
+        }
         const embed = new EmbedBuilder()
             .setColor(0x5865F2)
             .setTitle(t('🧪 Testerzy OCR', '🧪 OCR Testers'))
@@ -5858,12 +5893,18 @@ class InteractionHandler {
             await interaction.reply({ content: t('❌ Nieprawidłowe ID użytkownika.', '❌ Invalid user ID.'), flags: ['Ephemeral'] });
             return;
         }
-        const added = await this.testerService.addTester(userId, interaction.user.id);
+        let username = null;
+        try {
+            const member = await interaction.guild.members.fetch(userId);
+            username = member.displayName || member.user.username || null;
+        } catch {}
+        const added = await this.testerService.addTester(userId, interaction.user.id, username);
         if (!added) {
             await interaction.reply({ content: t(`⚠️ Użytkownik <@${userId}> jest już testerem.`, `⚠️ User <@${userId}> is already a tester.`), flags: ['Ephemeral'] });
             return;
         }
-        await interaction.reply({ content: t(`✅ Dodano <@${userId}> jako testera OCR.`, `✅ Added <@${userId}> as OCR tester.`), flags: ['Ephemeral'] });
+        const displayName = username ? `**${username}** (<@${userId}>)` : `<@${userId}>`;
+        await interaction.reply({ content: t(`✅ Dodano ${displayName} jako testera OCR.`, `✅ Added ${displayName} as OCR tester.`), flags: ['Ephemeral'] });
     }
 
     async _handlePanelTesterRemove(interaction) {
@@ -5878,8 +5919,9 @@ class InteractionHandler {
             });
             return;
         }
+        const nameMap = await this._resolveTesterNames(testers.slice(0, 25), interaction.guild);
         const options = testers.slice(0, 25).map(te => ({
-            label: te.userId,
+            label: (nameMap.get(te.userId) || te.userId).slice(0, 100),
             value: te.userId,
             description: t(`Dodany: ${new Date(te.addedAt).toLocaleDateString('pl-PL')}`, `Added: ${new Date(te.addedAt).toLocaleDateString('en-US')}`),
         }));

--- a/EndersEcho/services/testerService.js
+++ b/EndersEcho/services/testerService.js
@@ -36,9 +36,9 @@ class TesterService {
         return [...this._testers];
     }
 
-    async addTester(userId, addedBy) {
+    async addTester(userId, addedBy, username = null) {
         if (this.isTester(userId)) return false;
-        this._testers.push({ userId, addedBy, addedAt: new Date().toISOString() });
+        this._testers.push({ userId, username: username || null, addedBy, addedAt: new Date().toISOString() });
         await this._save();
         return true;
     }


### PR DESCRIPTION
## Podsumowanie

- Lista testerów w embeddzie: `1. <@id>` → `1. **NickGracza** (<@id>)`
- Select menu "Usuń testera": label zmieniony z surowego ID na nick gracza
- Przy dodaniu testera: bot fetchuje nick z serwera i zapisuje go w `testers.json`

## Szczegóły techniczne

**`testerService.addTester(userId, addedBy, username = null)`** — nowy opcjonalny parametr `username`, zapisywany w `testers.json`.

**`_resolveTesterNames(testers, guild)`** — nowy helper batch-fetchujący nicki:
1. Sprawdza pole `te.username` (zapisane przy dodaniu)
2. Jeśli brak → sprawdza `guild.members.cache`
3. Jeśli brak → batch-fetch przez `guild.members.fetch({ user: [...] })`
4. Fallback: mention `<@userId>` gdy użytkownik niedostępny

**Wynik w UI:**
- Embed: `1. **NazwaGracza** (<@123456789>)`
- Select menu: label = `NazwaGracza` (max 100 znaków), description = data dodania

## Plan testów

- [ ] Otwórz panel admina → 🧪 Dodaj/usuń testera → lista pokazuje nicki zamiast ID
- [ ] Dodaj nowego testera → potwierdzenie zawiera nick
- [ ] Kliknij ➖ Usuń → select menu pokazuje nick jako label

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3yNfRxe3vP3yFynCgdj4e)_