### PR TITLE
Naprawiono duplikat customId w przyciskach nawigacji tokenów (EndersEcho)

### DIFF
--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -5925,7 +5925,7 @@ class InteractionHandler {
 
         const backRow = new ActionRowBuilder().addComponents(
             new ButtonBuilder()
-                .setCustomId(`tk_m_${prevMonthRaw}_all_${userId}`)
+                .setCustomId(`tk_m_${prevMonthRaw}_all_${userId}_p`)
                 .setLabel('◀')
                 .setStyle(ButtonStyle.Secondary)
                 .setDisabled(!hasPrev),
@@ -5935,7 +5935,7 @@ class InteractionHandler {
                 .setStyle(ButtonStyle.Primary)
                 .setDisabled(true),
             new ButtonBuilder()
-                .setCustomId(`tk_m_${nextMonthRaw}_all_${userId}`)
+                .setCustomId(`tk_m_${nextMonthRaw}_all_${userId}_n`)
                 .setLabel('▶')
                 .setStyle(ButtonStyle.Secondary)
                 .setDisabled(!hasNext),


### PR DESCRIPTION
## Opis błędu

`DiscordAPIError[50035]: Invalid Form Body` — `COMPONENT_CUSTOM_ID_DUPLICATED` przy kliknięciu przycisku Zbiorczo w panelu tokenów (`/manage` → Zużycie tokenów).

## Przyczyna

W `_buildTokensMonthBreakdown` (`interactionHandlers.js`), gdy użytkownik jest na pierwszym lub ostatnim dostępnym miesiącu (`hasPrev=false` lub `hasNext=false`), zmienne `prevMonthRaw`/`nextMonthRaw` przyjmują wartość `monthStr` (bieżącego miesiąca). W efekcie przycisk ◀ lub ▶ dostawał ten sam `customId` co środkowy przycisk (etykieta miesiąca), co powodowało duplikat w jednym `ActionRow`.

## Naprawa

Dodano unikalne sufiksy `_p` (prev) i `_n` (next) do `customId` przycisków nawigacyjnych ◀ i ▶. Handler parsuje `parts[4]` jako `userId` i ignoruje `parts[5]`, więc zmiana jest wstecznie kompatybilna i nie wymaga modyfikacji logiki obsługi kliknięcia.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSRmmEARR2br1stf8WfCSx)_