### PR TITLE
EndersEcho: przerwa Global TOP10 z 1 dnia na 4 dni

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -102,7 +102,7 @@
      - Warunek: gracz w TOP10 serwera AND jego pozycja globalna zmieniła się
      - Zawiera: kierunek zmiany (▲/▼), stara → nowa pozycja, 3 linie rankingu globalnego (gracz powyżej, gracz, gracz poniżej) w formacie identycznym jak `/ranking → 🌐 Global`
    - **Cykliczny raport Global TOP10** (`globalTop10Service`) — `services/globalTop10Service.js`:
-     - Interwał: 9 raportów co 3 dni, potem 1 dzień przerwy, powtórz (cykl 10)
+     - Interwał: 9 raportów co 3 dni, potem 4 dni przerwy, powtórz (cykl 10)
      - Konfiguracja w `data/global_top10_config.json` (enabled, nextTrigger, triggerCount, lastSnapshot)
      - Snapshot poprzednich pozycji → zmiany ▲/▼/=/🆕 przy każdym graczu
      - Boss okresu: najczęstszy boss z ostatnich 10 wpisów historii wyników (`wyniki/`)

--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -120,7 +120,7 @@ const pol = {
     globalTop10ReportTitle: '🌐 TOP 10 Globalny',
     globalTop10BossField: '⚔️ Boss okresu',
     globalTop10Footer: 'Następny raport za 3 dni',
-    globalTop10FooterBreak: 'Następny raport za 1 dzień (przerwa)',
+    globalTop10FooterBreak: 'Następny raport za 4 dni (przerwa)',
 
     // /subscribe
     notifDescription: '🔔 Zarządzaj powiadomieniami o nowych rekordach graczy.',
@@ -420,7 +420,7 @@ const eng = {
     globalTop10ReportTitle: '🌐 Global TOP 10',
     globalTop10BossField: '⚔️ Boss of the period',
     globalTop10Footer: 'Next report in 3 days',
-    globalTop10FooterBreak: 'Next report in 1 day (break)',
+    globalTop10FooterBreak: 'Next report in 4 days (break)',
 
     // /subscribe
     notifDescription: '🔔 Manage notifications for player record breaks.',

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -6718,8 +6718,8 @@ class InteractionHandler {
         const formatted = `${dd.padStart(2,'0')}.${mm.padStart(2,'0')}.${yyyy} ${hh.padStart(2,'0')}:${min}`;
         await interaction.editReply({
             content: t(
-                `✅ Harmonogram TOP10 ustawiony.\n📅 Pierwszy raport: **${formatted}**\n🔁 Kolejne: co 3 dni (po 9 raportach — 1 dzień przerwy, powtórz)`,
-                `✅ TOP10 schedule set.\n📅 First report: **${formatted}**\n🔁 Subsequent: every 3 days (after 9 reports — 1 day break, repeat)`
+                `✅ Harmonogram TOP10 ustawiony.\n📅 Pierwszy raport: **${formatted}**\n🔁 Kolejne: co 3 dni (po 9 raportach — 4 dni przerwy, powtórz)`,
+                `✅ TOP10 schedule set.\n📅 First report: **${formatted}**\n🔁 Subsequent: every 3 days (after 9 reports — 4 day break, repeat)`
             )
         });
     }

--- a/EndersEcho/services/globalTop10Service.js
+++ b/EndersEcho/services/globalTop10Service.js
@@ -7,10 +7,10 @@ const { createBotLogger } = require('../../utils/consoleLogger');
 
 const logger = createBotLogger('EndersEcho');
 
-// Interwał: 9 × 3 dni, potem 1 dzień przerwy, powtórz (cykl 10)
+// Interwał: 9 × 3 dni, potem 4 dni przerwy, powtórz (cykl 10)
 const CYCLE_LEN          = 10;
 const REPORT_INTERVAL_MS = 3 * 24 * 60 * 60 * 1000; // 3 dni
-const BREAK_INTERVAL_MS  =     24 * 60 * 60 * 1000;  // 1 dzień
+const BREAK_INTERVAL_MS  = 4 * 24 * 60 * 60 * 1000;  // 4 dni
 
 const CHECK_INTERVAL_MS  = 60_000; // sprawdzaj co minutę
 


### PR DESCRIPTION
## Zmiany

- `BREAK_INTERVAL_MS` w `globalTop10Service.js`: 1 dzień → 4 dni
- Zaktualizowano footer embeda (pol + eng) w `messages.js`
- Zaktualizowano opis potwierdzenia ustawienia harmonogramu w `interactionHandlers.js`
- Zaktualizowano `EndersEcho/CLAUDE.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7RVfVSEV9r38P3gYzTCZR)_