### PR TITLE
Naprawiono odwrócone deltay na wykresie Clan Rankings

### DIFF
--- a/Gary/handlers/interactionHandlers.js
+++ b/Gary/handlers/interactionHandlers.js
@@ -2391,10 +2391,12 @@ class InteractionHandler {
                 if (!entry || entry[metricKey] == null) return null;
                 const hIdx = orderedHistory.findIndex(d => d.weekNumber === w.weekNumber && d.year === w.year);
                 const prevEntry = hIdx > 0 ? orderedHistory[hIdx - 1] : null;
-                const delta = (prevEntry && prevEntry[metricKey] != null)
+                const rawDelta = (prevEntry && prevEntry[metricKey] != null)
                     ? entry[metricKey] - prevEntry[metricKey]
                     : null;
-                const deltaText = delta === null ? '' : delta > 0 ? `+${fmtDot(delta)}` : fmtDot(delta);
+                // For invertY (rank): negate so positive delta = improvement (lower rank number = better)
+                const delta = (invertY && rawDelta !== null) ? -rawDelta : rawDelta;
+                const deltaText = delta === null ? '' : delta > 0 ? `+${fmtDot(Math.abs(rawDelta))}` : delta < 0 ? `-${fmtDot(Math.abs(rawDelta))}` : fmtDot(0);
                 return { x: toX(wi), y: toY(entry[metricKey]), v: entry[metricKey], delta, deltaText, color, weekIdx: wi,
                     preferredY: toY(entry[metricKey]) - 8 };
             }).filter(Boolean);


### PR DESCRIPTION
## Problem

Na wykresie `Clan Rankings` (pierwszy wykres w cotygodniowym raporcie) deltay były wyświetlane odwrotnie:
- Poprawa rankingu (np. z #500 na #203, delta = -297) → pokazywała się jako `#-297` na **czerwono** ❌
- Pogorszenie rankingu (np. z #203 na #500, delta = +297) → pokazywała się jako `#297` na **zielono** ❌

## Przyczyna

W `generateGuildMetricChart` delta była obliczana jako `currentRank - prevRank`. Dla rankingów niższa liczba = lepsza pozycja, więc poprawa dawała ujemną deltę, którą kod kolorował na czerwono.

## Naprawa

W `Gary/handlers/interactionHandlers.js` przy obliczaniu delty:
- Dodano `rawDelta` (surowa różnica wartości)
- Dla `invertY: true` (wykres rankingów): `delta = -rawDelta`, dzięki czemu pozytywna delta = poprawa rankingu = zielony kolor ✅
- Tekst etykiety używa `Math.abs(rawDelta)` z odpowiednim znakiem: `+#N` dla poprawy, `-#N` dla pogorszenia

---
_Generated by [Claude Code](https://claude.ai/code/session_013cDqwnDD8xCJ4xNkgpNfBP)_