### PR TITLE
EndersEcho: tłumaczenie tekstu rankingu serwerów na angielski

### DIFF
--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -106,6 +106,8 @@ const pol = {
     buttonBack: '↩️ Rankingi serwerów',
     guildRankingTitle: '🏛️ Ranking Serwerów',
     guildRankingFooter: 'Suma wyników top 30 graczy per serwer',
+    guildRankingPlayers: 'graczy',
+    guildRankingBest: 'najlepszy',
 
     // Role TOP
     topRoleUpdated: '🏆 Role TOP zostały zaktualizowane!',
@@ -406,6 +408,8 @@ const eng = {
     buttonBack: '↩️ Server rankings',
     guildRankingTitle: '🏛️ Server Ranking',
     guildRankingFooter: 'Sum of top 30 players per server',
+    guildRankingPlayers: 'players',
+    guildRankingBest: 'best',
 
     // TOP roles
     topRoleUpdated: '🏆 TOP roles have been updated!',

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -168,7 +168,9 @@ class RankingService {
         const lines = pageItems.map((gs, idx) => {
             const rank = start + idx + 1;
             const medal = MEDALS[rank - 1] || `**#${rank}**`;
-            return `${medal} **${gs.guildName}** — ${gs.totalScore}\n┗ ${gs.playerCount} graczy • najlepszy: ${gs.topScore}`;
+            const playersLabel = msgs.guildRankingPlayers || 'graczy';
+            const bestLabel = msgs.guildRankingBest || 'najlepszy';
+            return `${medal} **${gs.guildName}** — ${gs.totalScore}\n┗ ${gs.playerCount} ${playersLabel} • ${bestLabel}: ${gs.topScore}`;
         });
 
         const embed = new EmbedBuilder()


### PR DESCRIPTION
## Opis

W widoku `🏛️ Server Ranking` (ranking serwerów) w EndersEcho, tekst wierszy był hardkodowany po polsku niezależnie od języka serwera:

```
🥇 **NazwaSerwera** — 1.5B
┗ 25 graczy • najlepszy: 500M
```

Słowa `graczy` i `najlepszy` nie używały systemu tłumaczeń.

## Zmiany

- `EndersEcho/config/messages.js` — dodano klucze `guildRankingPlayers` i `guildRankingBest` do sekcji `pol` i `eng`
- `EndersEcho/services/rankingService.js` — linia 171 używa teraz `msgs.guildRankingPlayers` i `msgs.guildRankingBest` zamiast hardkodowanego tekstu

Po poprawce serwery z `lang: eng` zobaczą:
```
🥇 **ServerName** — 1.5B
┗ 25 players • best: 500M
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaEnatfHKQnfiTP2zFwVeM)_