### PR TITLE
Global ranking snippet: strzałka kierunku dla gracza poniżej

### DIFF
--- a/EndersEcho/services/globalTop10Service.js
+++ b/EndersEcho/services/globalTop10Service.js
@@ -335,8 +335,8 @@ class GlobalTop10Service {
         }
 
         return {
-            title,
-            description: `${direction} **${prevLabel} → #${newGlobalPosition}**\n\n` + lines.join('\n\n')
+            title: `${title} ${direction} ${prevLabel} → #${newGlobalPosition}`,
+            description: lines.join('\n\n')
         };
     }
 

--- a/EndersEcho/services/globalTop10Service.js
+++ b/EndersEcho/services/globalTop10Service.js
@@ -328,7 +328,11 @@ class GlobalTop10Service {
         currentLine = `${direction} ${currentLine}`;
         lines.push(currentLine);
 
-        if (below)   lines.push(await buildLine(below, newGlobalPosition + 1));
+        if (below) {
+            // Gracz poniżej nowej pozycji został wypchnięty w przeciwnym kierunku
+            const belowDirection = direction === '↑' ? '↓' : '↑';
+            lines.push(`${belowDirection} ${await buildLine(below, newGlobalPosition + 1)}`);
+        }
 
         return {
             title,


### PR DESCRIPTION
## Opis

W snippecie „🌐 Zmiana w globalnym rankingu" gracz poniżej nowej pozycji nie miał strzałki kierunkowej, mimo że gracz przesunięty w górę (↑) miał ją wyświetloną.

**Przed poprawką:**
```
↑ Gracz → #56  
Gracz poniżej  ← brak strzałki
```

**Po poprawce:**
```
↑ Gracz → #56  
↓ Gracz poniżej
```

## Zmiana

- `EndersEcho/services/globalTop10Service.js` — `buildSnippetFieldData`: gracz poniżej nowej pozycji otrzymuje strzałkę w przeciwnym kierunku (`↑` → gracz poniżej dostaje `↓`, i odwrotnie)

https://claude.ai/code/session_01YaEnatfHKQnfiTP2zFwVeM

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaEnatfHKQnfiTP2zFwVeM)_