### PR TITLE
Allow ManageGuild permission for admin commands

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -179,7 +179,7 @@
 **Komendy slash:** `/achievements`, `/configure`, `/manage`, `/ranking`, `/subscribe`, `/test`, `/update`
 
 **Panel Admina** — dostępny przez `/manage`:
-- Dostęp: każdy admin Discord (Administrator)
+- Dostęp: Administrator Discord lub Manage Server (`ManageGuild`)
 - **Układ rzędów (Tryb Admin):**
   - Rząd 1: `🗑️ Usuń gracza z rankingu`, `🔓 Odblokuj gracza`
   - Rząd 2: `📊 Zużycie tokenów`
@@ -349,7 +349,7 @@
 - Bez konfiguracji (zawsze): `/configure` (wizard), `/manage` (bezpośredni panel admina)
 - Wymaga konfiguracji, dowolny kanał: `/test` (Administrator + `ENDERSECHO_BLOCK_OCR_USER_IDS`)
 - Wymaga konfiguracji + bot channel: `/update`, `/ranking`, `/subscribe`
-- Panel Admina (tryb Admin): Administrator Discord → usuń gracza, odblokuj, tokeny
+- Panel Admina (tryb Admin): Administrator lub Manage Server → usuń gracza, odblokuj, tokeny
 - Panel Admina (tryb Head Admin): `ENDERSECHO_BLOCK_OCR_USER_IDS` → wszystko + info, OCR toggle, limit
 
 **Struktura danych:**

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -150,13 +150,13 @@ class InteractionHandler {
                 .setName('configure')
                 .setDescription('Configure EndersEcho for this server (admins only)')
                 .setDescriptionLocalizations(pl('Skonfiguruj EndersEcho na tym serwerze (tylko dla adminów)'))
-                .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+                .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild),
 
             new SlashCommandBuilder()
                 .setName('manage')
                 .setDescription('Open EndersEcho admin panel (admins only)')
                 .setDescriptionLocalizations(pl('Otwórz panel administracyjny EndersEcho (tylko dla adminów)'))
-                .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+                .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild),
         ];
     }
 
@@ -534,7 +534,7 @@ class InteractionHandler {
     }
 
     async handleConfigureCommand(interaction) {
-        if (!interaction.member.permissions.has(PermissionFlagsBits.Administrator)) {
+        if (!interaction.member.permissions.has(PermissionFlagsBits.Administrator) && !interaction.member.permissions.has(PermissionFlagsBits.ManageGuild)) {
             const msgs = this.msgs(interaction.guildId);
             await interaction.reply({ content: msgs.configureNotAdmin, flags: ['Ephemeral'] });
             return;
@@ -584,7 +584,7 @@ class InteractionHandler {
     }
 
     async handleManageCommand(interaction) {
-        if (!interaction.member.permissions.has(PermissionFlagsBits.Administrator)) {
+        if (!interaction.member.permissions.has(PermissionFlagsBits.Administrator) && !interaction.member.permissions.has(PermissionFlagsBits.ManageGuild)) {
             const msgs = this.msgs(interaction.guildId);
             await interaction.reply({ content: msgs.configureNotAdmin, flags: ['Ephemeral'] });
             return;


### PR DESCRIPTION
## Summary
Updated admin command permissions to allow users with the `ManageGuild` permission to access configuration and management features, in addition to users with the `Administrator` permission.

## Key Changes
- Changed default member permissions for `/configure` and `/manage` commands from `Administrator` to `ManageGuild`
- Updated permission checks in `handleConfigureCommand()` and `handleManageCommand()` to accept either `Administrator` OR `ManageGuild` permissions
- Updated documentation to reflect that both permission levels can access the admin panel

## Implementation Details
- The permission checks now use a logical OR condition: `!has(Administrator) && !has(ManageGuild)` to deny access only if the user has neither permission
- This allows server managers with `ManageGuild` permission (but not full `Administrator` role) to configure and manage EndersEcho
- Maintains backward compatibility with existing administrators while expanding access to a broader set of server managers

https://claude.ai/code/session_019ukR8pW9ysGV1ombmEJBpt