### PR TITLE
EndersEcho: paginacja wyboru serwera z priorytetem bieżącego klanu

### DIFF
--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -3025,6 +3025,12 @@ class InteractionHandler {
                 return;
             }
 
+            // === Paginacja ekranu wyboru serwera ===
+            if (customId.startsWith('ranking_srv_prev_') || customId.startsWith('ranking_srv_next_')) {
+                await this._handleRankingSrvPage(interaction, customId);
+                return;
+            }
+
             // === Przyciski wyboru serwera/global ===
             if (customId.startsWith('ranking_select_')) {
                 await this._handleRankingSelect(interaction, customId);
@@ -3072,6 +3078,10 @@ class InteractionHandler {
             }
             if (customId === 'ach_rank_back') {
                 await this._handleAchRankingBack(interaction);
+                return;
+            }
+            if (customId.startsWith('ach_rank_srv_prev_') || customId.startsWith('ach_rank_srv_next_')) {
+                await this._handleAchRankingSrvPage(interaction, customId);
                 return;
             }
             if (customId === 'ach_rank_global' || customId.startsWith('ach_rank_srv_') || customId.startsWith('ach_rank_role_')) {
@@ -3898,9 +3908,24 @@ class InteractionHandler {
     async _handleRankingBack(interaction) {
         await interaction.deferUpdate();
         const msgs = this.msgs(interaction.guildId);
+        const selectRows = this.rankingService.createServerSelectButtons(interaction.client, msgs, interaction.guildId, 0);
+        await interaction.editReply({
+            content: msgs.rankingSelectPrompt,
+            embeds: [],
+            components: selectRows
+        });
+    }
 
-        // Zawsze wróć do wyboru serwerów
-        const selectRows = this.rankingService.createServerSelectButtons(interaction.client, msgs);
+    async _handleRankingSrvPage(interaction, customId) {
+        await interaction.deferUpdate();
+        const msgs = this.msgs(interaction.guildId);
+        const isPrev = customId.startsWith('ranking_srv_prev_');
+        const withoutPrefix = customId.replace(isPrev ? 'ranking_srv_prev_' : 'ranking_srv_next_', '');
+        const underscoreIdx = withoutPrefix.indexOf('_');
+        const currentPage = parseInt(withoutPrefix.substring(0, underscoreIdx)) || 0;
+        const homeGuildId = withoutPrefix.substring(underscoreIdx + 1) || interaction.guildId;
+        const newPage = isPrev ? currentPage - 1 : currentPage + 1;
+        const selectRows = this.rankingService.createServerSelectButtons(interaction.client, msgs, homeGuildId, newPage);
         await interaction.editReply({
             content: msgs.rankingSelectPrompt,
             embeds: [],
@@ -7024,6 +7049,58 @@ class InteractionHandler {
 
     // ─── Ranking osiągnięć (/ranking-osiagniec) ───────────────────────────────
 
+    _buildAchServerSelectRows(client, homeGuildId, isPol, page = 0) {
+        const t = (pol, eng) => isPol ? pol : eng;
+        const allGuilds = this.config.getAllGuilds().filter(gc => client.guilds.cache.has(gc.id));
+        const otherGuilds = allGuilds.filter(gc => gc.id !== homeGuildId);
+
+        const PER_PAGE = 20; // 4 wiersze × 5 = 20 slotów na inne serwery
+        const totalPages = Math.max(1, Math.ceil(otherGuilds.length / PER_PAGE));
+        const safePage = Math.max(0, Math.min(page, totalPages - 1));
+        const pageGuilds = otherGuilds.slice(safePage * PER_PAGE, (safePage + 1) * PER_PAGE);
+
+        const homeGuild = homeGuildId ? allGuilds.find(gc => gc.id === homeGuildId) : null;
+        const homeLabel = homeGuild
+            ? (client.guilds.cache.get(homeGuildId)?.name || homeGuildId).substring(0, 76)
+            : '🏠';
+        const safeHome = homeGuildId || '';
+
+        const row1 = new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId(`ach_rank_srv_${safeHome}`)
+                .setLabel(homeLabel)
+                .setStyle(ButtonStyle.Primary)
+                .setDisabled(!safeHome),
+            new ButtonBuilder()
+                .setCustomId(`ach_rank_srv_prev_${safePage}_${safeHome}`)
+                .setLabel('◀')
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(safePage === 0),
+            new ButtonBuilder()
+                .setCustomId(`ach_rank_srv_next_${safePage}_${safeHome}`)
+                .setLabel('▶')
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(safePage >= totalPages - 1),
+            new ButtonBuilder()
+                .setCustomId('ach_rank_global')
+                .setLabel(t('🌐 Global', '🌐 Global'))
+                .setStyle(ButtonStyle.Secondary)
+        );
+
+        const rows = [row1];
+        for (let i = 0; i < pageGuilds.length; i += 5) {
+            const rowBtns = pageGuilds.slice(i, i + 5).map(gc => {
+                const guildName = client.guilds.cache.get(gc.id)?.name || gc.id;
+                return new ButtonBuilder()
+                    .setCustomId(`ach_rank_srv_${gc.id}`)
+                    .setLabel(guildName.substring(0, 80))
+                    .setStyle(ButtonStyle.Secondary);
+            });
+            rows.push(new ActionRowBuilder().addComponents(rowBtns));
+        }
+        return rows;
+    }
+
     async handleAchRankingCommand(interaction) {
         if (!this._checkConfigured(interaction)) return;
         await interaction.deferReply({ flags: ['Ephemeral'] });
@@ -7032,26 +7109,7 @@ class InteractionHandler {
         const t = (pol, eng) => isPol ? pol : eng;
 
         try {
-            // Buduj przyciski wyboru serwera z wszystkich gildii bota
-            const buttons = [];
-            for (const [guildId, guild] of interaction.client.guilds.cache) {
-                buttons.push(new ButtonBuilder()
-                    .setCustomId(`ach_rank_srv_${guildId}`)
-                    .setLabel(guild.name.substring(0, 80))
-                    .setStyle(ButtonStyle.Primary)
-                );
-            }
-            buttons.push(new ButtonBuilder()
-                .setCustomId('ach_rank_global')
-                .setLabel(t('🌐 Global', '🌐 Global'))
-                .setStyle(ButtonStyle.Secondary)
-            );
-
-            const rows = [];
-            for (let i = 0; i < buttons.length; i += 5) {
-                rows.push(new ActionRowBuilder().addComponents(buttons.slice(i, i + 5)));
-            }
-
+            const rows = this._buildAchServerSelectRows(interaction.client, interaction.guildId, isPol, 0);
             await interaction.editReply({
                 content: t('🏆 Wybierz serwer lub globalny ranking osiągnięć:', '🏆 Select a server or global achievement ranking:'),
                 components: rows
@@ -7068,22 +7126,28 @@ class InteractionHandler {
         const isPol = lang === 'pol';
         const t = (pol, eng) => isPol ? pol : eng;
 
-        const buttons = [];
-        for (const guildConfig of this.config.getAllGuilds()) {
-            if (!interaction.client.guilds.cache.has(guildConfig.id)) continue;
-            const guildName = interaction.client.guilds.cache.get(guildConfig.id)?.name || guildConfig.id;
-            buttons.push(new ButtonBuilder()
-                .setCustomId(`ach_rank_srv_${guildConfig.id}`)
-                .setLabel(guildName.substring(0, 80))
-                .setStyle(ButtonStyle.Primary)
-            );
-        }
+        const rows = this._buildAchServerSelectRows(interaction.client, interaction.guildId, isPol, 0);
+        await interaction.editReply({
+            content: t('🏆 Wybierz serwer:', '🏆 Select a server:'),
+            embeds: [],
+            components: rows
+        });
+    }
 
-        const rows = [];
-        for (let i = 0; i < buttons.length; i += 5) {
-            rows.push(new ActionRowBuilder().addComponents(buttons.slice(i, i + 5)));
-        }
+    async _handleAchRankingSrvPage(interaction, customId) {
+        await interaction.deferUpdate();
+        const lang = this.config.getGuildConfig(interaction.guildId)?.lang || 'pol';
+        const isPol = lang === 'pol';
+        const t = (pol, eng) => isPol ? pol : eng;
 
+        const isPrev = customId.startsWith('ach_rank_srv_prev_');
+        const withoutPrefix = customId.replace(isPrev ? 'ach_rank_srv_prev_' : 'ach_rank_srv_next_', '');
+        const underscoreIdx = withoutPrefix.indexOf('_');
+        const currentPage = parseInt(withoutPrefix.substring(0, underscoreIdx)) || 0;
+        const homeGuildId = withoutPrefix.substring(underscoreIdx + 1) || interaction.guildId;
+        const newPage = isPrev ? currentPage - 1 : currentPage + 1;
+
+        const rows = this._buildAchServerSelectRows(interaction.client, homeGuildId, isPol, newPage);
         await interaction.editReply({
             content: t('🏆 Wybierz serwer:', '🏆 Select a server:'),
             embeds: [],

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -638,32 +638,61 @@ class RankingService {
     /**
      * Tworzy przyciski wyboru serwera/global dla komendy /ranking.
      * Etykiety przycisków serwera to nazwy z Discord, przycisk Global — z komunikatów danego serwera.
+     * Układ: wiersz 1 = [serwer bieżący] [◀] [▶], wiersze 2–5 = inne serwery (paginacja, max 20/strona).
      * @param {Client} client
      * @param {Object} messages - komunikaty serwera wywołującego
+     * @param {string|null} homeGuildId - ID serwera użytkownika (zawsze w wierszu 1)
+     * @param {number} page - strona "innych serwerów" (0-based)
      * @returns {ActionRowBuilder[]}
      */
-    createServerSelectButtons(client, messages = null) {
+    createServerSelectButtons(client, messages = null, homeGuildId = null, page = 0) {
         const msgs = messages || this.config.messages;
-        const buttons = [];
 
-        for (const guildConfig of this.config.getAllGuilds()) {
-            if (!client.guilds.cache.has(guildConfig.id)) continue;
-            const guildName = client.guilds.cache.get(guildConfig.id)?.name || `Server ${guildConfig.id}`;
-            const label = guildName.substring(0, 80);
+        const allGuilds = this.config.getAllGuilds().filter(gc => client.guilds.cache.has(gc.id));
+        const otherGuilds = allGuilds.filter(gc => gc.id !== homeGuildId);
 
-            buttons.push(
-                new ButtonBuilder()
-                    .setCustomId(`ranking_select_server_${guildConfig.id}`)
-                    .setLabel(label)
-                    .setStyle(ButtonStyle.Primary)
-            );
-        }
+        const PER_PAGE = 20; // 4 wiersze × 5 przycisków
+        const totalPages = Math.max(1, Math.ceil(otherGuilds.length / PER_PAGE));
+        const safePage = Math.max(0, Math.min(page, totalPages - 1));
+        const pageGuilds = otherGuilds.slice(safePage * PER_PAGE, (safePage + 1) * PER_PAGE);
 
-        const rows = [];
-        for (let i = 0; i < buttons.length; i += 5) {
-            const row = new ActionRowBuilder();
-            row.addComponents(buttons.slice(i, i + 5));
-            rows.push(row);
+        // Wiersz 1: bieżący serwer + strzałki paginacji
+        const homeGuild = homeGuildId ? allGuilds.find(gc => gc.id === homeGuildId) : null;
+        const homeLabel = homeGuild
+            ? (client.guilds.cache.get(homeGuildId)?.name || homeGuildId).substring(0, 76)
+            : '🏠';
+        const safeHome = homeGuildId || '';
+
+        const row1 = new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId(`ranking_select_server_${safeHome}`)
+                .setLabel(homeLabel)
+                .setStyle(ButtonStyle.Primary)
+                .setDisabled(!safeHome),
+            new ButtonBuilder()
+                .setCustomId(`ranking_srv_prev_${safePage}_${safeHome}`)
+                .setLabel('◀')
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(safePage === 0),
+            new ButtonBuilder()
+                .setCustomId(`ranking_srv_next_${safePage}_${safeHome}`)
+                .setLabel('▶')
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(safePage >= totalPages - 1)
+        );
+
+        const rows = [row1];
+
+        // Wiersze 2–5: inne serwery (max 20)
+        for (let i = 0; i < pageGuilds.length; i += 5) {
+            const rowBtns = pageGuilds.slice(i, i + 5).map(gc => {
+                const guildName = client.guilds.cache.get(gc.id)?.name || gc.id;
+                return new ButtonBuilder()
+                    .setCustomId(`ranking_select_server_${gc.id}`)
+                    .setLabel(guildName.substring(0, 80))
+                    .setStyle(ButtonStyle.Secondary);
+            });
+            rows.push(new ActionRowBuilder().addComponents(rowBtns));
         }
 
         return rows;


### PR DESCRIPTION
## Podsumowanie

- Wiersz 1 ekranu wyboru serwera zawsze pokazuje: **[Bieżący serwer]** **[◀]** **[▶]**
- Wiersze 2–5: inne serwery paginowane (max 20 na stronę = 4 wiersze × 5 przycisków)
- Strzałki ◀/▶ są disabled gdy nie ma kolejnej strony
- Dotyczy `/ranking → ↩️ Powrót` oraz `/achievements → 🏆 Ranking osiągnięć`
- W rankingu osiągnięć przycisk `🌐 Global` przeniesiony do wiersza 1 obok strzałek

## Zmienione pliki

- `EndersEcho/services/rankingService.js` — `createServerSelectButtons` przebudowane z obsługą `homeGuildId` i `page`
- `EndersEcho/handlers/interactionHandlers.js` — nowe handlery `_handleRankingSrvPage`, `_handleAchRankingSrvPage`, helper `_buildAchServerSelectRows`; routing przycisków `ranking_srv_prev/next` i `ach_rank_srv_prev/next`

---
_Generated by [Claude Code](https://claude.ai/code/session_01BupwWgr7PVZMCCaeKfsq48)_