### PR TITLE
EndersEcho: Pełne wsparcie angielskie we wszystkich interakcjach

### DIFF
--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -123,6 +123,7 @@ const pol = {
     globalTop10BossField: '⚔️ Boss okresu',
     globalTop10Footer: 'Następny raport za 3 dni',
     globalTop10FooterBreak: 'Następny raport za 4 dni (przerwa)',
+    globalTop10FooterNext: 'Następny raport za {days} dni',
 
     // /subscribe
     notifDescription: '🔔 Zarządzaj powiadomieniami o nowych rekordach graczy.',
@@ -150,6 +151,7 @@ const pol = {
     notifDmBeatYourRecord: '🚨 Pobił Twój rekord o {diff}',
     notifDmMissingToRecord: '✅ Brakuje {diff} do Twojego rekordu',
     notifDmNoSubscriberRecord: '📊 Nie masz jeszcze wyniku na tym serwerze',
+    notifDmScoresEqual: '🎯 Wyniki równe!',
 
     // /block-ocr
     ocrBlocked: '🚫 **Analiza zdjęć jest tymczasowo zablokowana.**\nZostaniesz powiadomiony gdy zostanie wznowiona.',
@@ -165,6 +167,10 @@ const pol = {
 
     // Uprawnienia
     noPermission: 'Brak uprawnień do tej komendy.',
+    commandError: '❌ Wystąpił błąd podczas przetwarzania komendy.',
+    gatewayRateLimited: '⏱️ Zbyt wiele żądań. Spróbuj ponownie za{retry}.',
+    gatewayNotEntitled: '🔒 Operacja nie jest dostępna dla tego serwera.',
+    gatewayDefault: '❌ Żądanie odrzucone przez gateway.',
 
     // Blokada użytkownika
     userBlocked: '🚫 Twoje konto zostało zablokowane z powodu próby przesłania fałszywego zdjęcia. W celu odblokowania skontaktuj się z administratorem serwera.',
@@ -187,6 +193,9 @@ const pol = {
     roleRankingLimitReached: '❌ Osiągnięto limit **{max}** rankingów ról. Usuń istniejący przed dodaniem nowego.',
     roleRankingAdded: '✅ Dodano ranking dla roli **{roleName}**. Pojawi się w komendzie `/ranking` po wybraniu tego serwera.',
     roleRankingNoRankings: '⚠️ Brak skonfigurowanych rankingów ról na tym serwerze.',
+    roleRankingEmpty: '📋 Brak graczy z rolą **{roleName}** w rankingu.',
+    analyzeNoImage: '❌ Brak zdjęcia w raporcie.',
+    analyzeError: '❌ Błąd analizy: {error}',
 
     // /unblock
     unblockTitle: '🔒 Zablokowani użytkownicy OCR',
@@ -276,6 +285,7 @@ const pol = {
 
     // Weryfikacja społeczności
     cvVoteButton: '⚠️ Zgłoś',
+    cvReported: '⚠️ Zgłoszono',
     cvVoteAlreadyVoted: '⚠️ Już zgłosiłeś ten wynik.',
     cvVoteNotInRanking: '⚠️ Możesz głosować tylko jeśli jesteś w rankingu.',
     cvVoteSelf: '⚠️ Nie możesz zgłosić własnego wyniku.',
@@ -425,6 +435,7 @@ const eng = {
     globalTop10BossField: '⚔️ Boss of the period',
     globalTop10Footer: 'Next report in 3 days',
     globalTop10FooterBreak: 'Next report in 4 days (break)',
+    globalTop10FooterNext: 'Next report in {days} days',
 
     // /subscribe
     notifDescription: '🔔 Manage notifications for player record breaks.',
@@ -452,6 +463,7 @@ const eng = {
     notifDmBeatYourRecord: '🚨 Beat your record by {diff}',
     notifDmMissingToRecord: '✅ {diff} away from your record',
     notifDmNoSubscriberRecord: '📊 You have no score on this server yet',
+    notifDmScoresEqual: '🎯 Scores are equal!',
 
     // /block-ocr
     ocrBlocked: '🚫 **Screenshot analysis is temporarily blocked.**\nYou will be notified when it resumes.',
@@ -467,6 +479,10 @@ const eng = {
 
     // Permissions
     noPermission: 'You do not have permission to use this command.',
+    commandError: '❌ An error occurred while processing the command.',
+    gatewayRateLimited: '⏱️ Too many requests. Try again in{retry}.',
+    gatewayNotEntitled: '🔒 This operation is not available for this server.',
+    gatewayDefault: '❌ Request rejected by the gateway.',
 
     // User block
     userBlocked: '🚫 Your account has been blocked due to submitting a fake screenshot. Contact a server administrator to appeal.',
@@ -489,6 +505,9 @@ const eng = {
     roleRankingLimitReached: '❌ Reached the limit of **{max}** role rankings. Remove an existing one before adding a new one.',
     roleRankingAdded: '✅ Added ranking for role **{roleName}**. It will appear in the `/ranking` command when this server is selected.',
     roleRankingNoRankings: '⚠️ No role rankings configured on this server.',
+    roleRankingEmpty: '📋 No players with role **{roleName}** in the ranking.',
+    analyzeNoImage: '❌ No image found in the report.',
+    analyzeError: '❌ Analysis error: {error}',
 
     // /unblock
     unblockTitle: '🔒 Blocked OCR Users',
@@ -578,6 +597,7 @@ const eng = {
 
     // Community verification
     cvVoteButton: '⚠️ Report',
+    cvReported: '⚠️ Reported',
     cvVoteAlreadyVoted: '⚠️ You have already reported this score.',
     cvVoteNotInRanking: '⚠️ Only players in the ranking can vote.',
     cvVoteSelf: '⚠️ You cannot report your own score.',

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -18,14 +18,14 @@ function mapGatewayErrorMessage(gwError, msgs) {
         case 'QUOTA_EXCEEDED':
             return formatMessage(msgs.dailyLimitExceeded, { limit: gwError.retryAfter || '' });
         case 'RATE_LIMITED':
-            return `⏱️ Zbyt wiele żądań. Spróbuj ponownie${gwError.retryAfter ? ` za ${gwError.retryAfter}s` : ''}.`;
+            return formatMessage(msgs.gatewayRateLimited, { retry: gwError.retryAfter ? ` ${gwError.retryAfter}s` : '' });
         case 'OPERATION_NOT_ENTITLED':
-            return `🔒 Operacja nie jest dostępna dla tego serwera.`;
+            return msgs.gatewayNotEntitled;
         case 'VALIDATION_FAILED':
         case 'GATEWAY_UNAVAILABLE':
             return msgs.updateError;
         default:
-            return `❌ ${gwError.message || 'Żądanie odrzucone przez gateway.'}`;
+            return `❌ ${gwError.message || msgs.gatewayDefault}`;
     }
 }
 
@@ -1639,23 +1639,25 @@ class InteractionHandler {
 
             // Powiadomienie o skonfigurowanym serwerze — webhook logów lub fallback na kanał raportów
             try {
+                const isEng = (newData.lang || 'pol') === 'eng';
+                const tCfg = (p, e) => isEng ? e : p;
                 let configEmbed;
                 if (!wasAlreadyConfigured) {
                     // Pierwsza konfiguracja — pełny embed ze wszystkimi ustawieniami
                     configEmbed = new EmbedBuilder()
                         .setColor(0x5865F2)
-                        .setTitle('⚙️ Nowy serwer skonfigurowany')
+                        .setTitle(tCfg('⚙️ Nowy serwer skonfigurowany', '⚙️ New server configured'))
                         .setThumbnail(interaction.guild.iconURL({ dynamic: true, size: 128 }))
                         .addFields(
-                            { name: 'Serwer', value: interaction.guild.name },
-                            { name: 'Administrator', value: interaction.member?.displayName || interaction.user.username },
-                            { name: 'Kanał bota', value: `<#${newData.allowedChannelId}>` },
-                            { name: 'Język', value: newData.lang || 'pol' },
+                            { name: tCfg('Serwer', 'Server'), value: interaction.guild.name },
+                            { name: tCfg('Administrator', 'Administrator'), value: interaction.member?.displayName || interaction.user.username },
+                            { name: tCfg('Kanał bota', 'Bot channel'), value: `<#${newData.allowedChannelId}>` },
+                            { name: tCfg('Język', 'Language'), value: newData.lang || 'pol' },
                             { name: 'Tag', value: newData.tag || '—' },
-                            { name: 'Role TOP', value: newData.topRoles ? '✅ Skonfigurowane' : '❌ Brak' },
-                            { name: 'Raporty Global TOP10', value: newData.globalTop3Notifications !== false ? '✅ Włączone' : '❌ Wyłączone' },
-                            { name: 'Kanał raportów', value: newData.invalidReportChannelId ? `<#${newData.invalidReportChannelId}>` : '—' },
-                            { name: 'Weryfikacja społeczności', value: newData.communityVerification?.enabled ? `✅ Włączona (próg: ${newData.communityVerification.threshold})` : '❌ Wyłączona' }
+                            { name: 'Role TOP', value: newData.topRoles ? tCfg('✅ Skonfigurowane', '✅ Configured') : tCfg('❌ Brak', '❌ None') },
+                            { name: tCfg('Raporty Global TOP10', 'Global TOP10 Reports'), value: newData.globalTop3Notifications !== false ? tCfg('✅ Włączone', '✅ Enabled') : tCfg('❌ Wyłączone', '❌ Disabled') },
+                            { name: tCfg('Kanał raportów', 'Reports channel'), value: newData.invalidReportChannelId ? `<#${newData.invalidReportChannelId}>` : '—' },
+                            { name: tCfg('Weryfikacja społeczności', 'Community verification'), value: newData.communityVerification?.enabled ? `${tCfg('✅ Włączona', '✅ Enabled')} (${tCfg('próg', 'threshold')}: ${newData.communityVerification.threshold})` : tCfg('❌ Wyłączona', '❌ Disabled') }
                         )
                         .setTimestamp();
                 } else {
@@ -1665,15 +1667,15 @@ class InteractionHandler {
 
                     if (old?.allowedChannelId !== newData.allowedChannelId) {
                         const oldVal = old?.allowedChannelId ? `<#${old.allowedChannelId}>` : '—';
-                        diffFields.push({ name: 'Kanał bota', value: `${oldVal} → <#${newData.allowedChannelId}>` });
+                        diffFields.push({ name: tCfg('Kanał bota', 'Bot channel'), value: `${oldVal} → <#${newData.allowedChannelId}>` });
                     }
                     if ((old?.invalidReportChannelId || null) !== newData.invalidReportChannelId) {
                         const oldVal = old?.invalidReportChannelId ? `<#${old.invalidReportChannelId}>` : '—';
                         const newVal = newData.invalidReportChannelId ? `<#${newData.invalidReportChannelId}>` : '—';
-                        diffFields.push({ name: 'Kanał raportów', value: `${oldVal} → ${newVal}` });
+                        diffFields.push({ name: tCfg('Kanał raportów', 'Reports channel'), value: `${oldVal} → ${newVal}` });
                     }
                     if ((old?.lang || 'pol') !== newData.lang) {
-                        diffFields.push({ name: 'Język', value: `${old?.lang || 'pol'} → ${newData.lang}` });
+                        diffFields.push({ name: tCfg('Język', 'Language'), value: `${old?.lang || 'pol'} → ${newData.lang}` });
                     }
                     if ((old?.tag || null) !== newData.tag) {
                         diffFields.push({ name: 'Tag', value: `${old?.tag || '—'} → ${newData.tag || '—'}` });
@@ -1681,19 +1683,19 @@ class InteractionHandler {
                     const oldRolesJson = JSON.stringify(old?.topRoles || null);
                     const newRolesJson = JSON.stringify(newData.topRoles || null);
                     if (oldRolesJson !== newRolesJson) {
-                        const oldLabel = old?.topRoles ? '✅ Skonfigurowane' : '❌ Brak';
-                        const newLabel = newData.topRoles ? '✅ Skonfigurowane' : '❌ Brak';
+                        const oldLabel = old?.topRoles ? tCfg('✅ Skonfigurowane', '✅ Configured') : tCfg('❌ Brak', '❌ None');
+                        const newLabel = newData.topRoles ? tCfg('✅ Skonfigurowane', '✅ Configured') : tCfg('❌ Brak', '❌ None');
                         diffFields.push({ name: 'Role TOP', value: `${oldLabel} → ${newLabel}` });
                     }
                     if ((old?.globalTop3Notifications !== false) !== (newData.globalTop3Notifications !== false)) {
-                        const oldVal = old?.globalTop3Notifications !== false ? '✅ Włączone' : '❌ Wyłączone';
-                        const newVal = newData.globalTop3Notifications !== false ? '✅ Włączone' : '❌ Wyłączone';
-                        diffFields.push({ name: 'Raporty Global TOP10', value: `${oldVal} → ${newVal}` });
+                        const oldVal = old?.globalTop3Notifications !== false ? tCfg('✅ Włączone', '✅ Enabled') : tCfg('❌ Wyłączone', '❌ Disabled');
+                        const newVal = newData.globalTop3Notifications !== false ? tCfg('✅ Włączone', '✅ Enabled') : tCfg('❌ Wyłączone', '❌ Disabled');
+                        diffFields.push({ name: tCfg('Raporty Global TOP10', 'Global TOP10 Reports'), value: `${oldVal} → ${newVal}` });
                     }
                     const oldCvEnabled = old?.communityVerification?.enabled || false;
                     const newCvEnabled = newData.communityVerification?.enabled || false;
                     if (oldCvEnabled !== newCvEnabled) {
-                        diffFields.push({ name: 'Weryfikacja społeczności', value: `${oldCvEnabled ? '✅ Włączona' : '❌ Wyłączona'} → ${newCvEnabled ? '✅ Włączona' : '❌ Wyłączona'}` });
+                        diffFields.push({ name: tCfg('Weryfikacja społeczności', 'Community verification'), value: `${oldCvEnabled ? tCfg('✅ Włączona', '✅ Enabled') : tCfg('❌ Wyłączona', '❌ Disabled')} → ${newCvEnabled ? tCfg('✅ Włączona', '✅ Enabled') : tCfg('❌ Wyłączona', '❌ Disabled')}` });
                     }
                     if (newCvEnabled) {
                         const oldCvChannel = old?.communityVerification?.rejectedChannelId || null;
@@ -1701,23 +1703,23 @@ class InteractionHandler {
                         if (oldCvChannel !== newCvChannel) {
                             const oldVal = oldCvChannel ? `<#${oldCvChannel}>` : '—';
                             const newVal = newCvChannel ? `<#${newCvChannel}>` : '—';
-                            diffFields.push({ name: 'Kanał weryfikacji', value: `${oldVal} → ${newVal}` });
+                            diffFields.push({ name: tCfg('Kanał weryfikacji', 'Verification channel'), value: `${oldVal} → ${newVal}` });
                         }
                         const oldThreshold = old?.communityVerification?.threshold || 5;
                         const newThreshold = newData.communityVerification?.threshold || 5;
                         if (oldThreshold !== newThreshold) {
-                            diffFields.push({ name: 'Próg zgłoszeń', value: `${oldThreshold} → ${newThreshold}` });
+                            diffFields.push({ name: tCfg('Próg zgłoszeń', 'Report threshold'), value: `${oldThreshold} → ${newThreshold}` });
                         }
                     }
 
                     if (diffFields.length === 0) return; // nic się nie zmieniło
                     configEmbed = new EmbedBuilder()
                         .setColor(0xFEE75C)
-                        .setTitle('⚙️ Zmiana konfiguracji serwera')
+                        .setTitle(tCfg('⚙️ Zmiana konfiguracji serwera', '⚙️ Server configuration changed'))
                         .setThumbnail(interaction.guild.iconURL({ dynamic: true, size: 128 }))
                         .addFields(
-                            { name: 'Serwer', value: interaction.guild.name, inline: true },
-                            { name: 'Administrator', value: interaction.member?.displayName || interaction.user.username, inline: true },
+                            { name: tCfg('Serwer', 'Server'), value: interaction.guild.name, inline: true },
+                            { name: tCfg('Administrator', 'Administrator'), value: interaction.member?.displayName || interaction.user.username, inline: true },
                             ...diffFields
                         )
                         .setTimestamp();
@@ -2060,8 +2062,9 @@ class InteractionHandler {
             });
             return;
         }
+        const blockLabels = { permanent: t('∞ Permanentnie', '∞ Permanent'), expired: t('Wygasła', 'Expired') };
         const options = filtered.slice(0, 25).map(entry => {
-            const timeLabel = this.userBlockService.formatTimeRemaining(entry.blockedUntil);
+            const timeLabel = this.userBlockService.formatTimeRemaining(entry.blockedUntil, blockLabels);
             return {
                 label: entry.username.slice(0, 100),
                 description: `${entry.guildName} | ${t('Pozostało', 'Remaining')}: ${timeLabel}`.slice(0, 100),
@@ -2076,7 +2079,7 @@ class InteractionHandler {
                 .setDescription(
                     subtitle + '\n\n' +
                     filtered.slice(0, 25).map((entry, i) => {
-                        const timeLabel = this.userBlockService.formatTimeRemaining(entry.blockedUntil);
+                        const timeLabel = this.userBlockService.formatTimeRemaining(entry.blockedUntil, blockLabels);
                         return `${i + 1}. **${entry.username}** — ${entry.guildName} | \`${timeLabel}\``;
                     }).join('\n')
                 )
@@ -2266,7 +2269,7 @@ class InteractionHandler {
                 true // blockedByHeadAdmin
             );
             const timeLabel = blockedUntil
-                ? this.userBlockService.formatTimeRemaining(blockedUntil)
+                ? this.userBlockService.formatTimeRemaining(blockedUntil, { permanent: t('∞ Permanentnie', '∞ Permanent'), expired: t('Wygasła', 'Expired') })
                 : t('∞ Permanentnie', '∞ Permanent');
             logger.info(`🔒 Head Admin zablokował ${username} (${targetUserId}) na serwerze ${guildName} — ${timeLabel}`);
             await interaction.editReply({
@@ -3526,7 +3529,7 @@ class InteractionHandler {
                     return;
                 }
                 const prefill = this._infoSessions.get(interaction.user.id) || {};
-                await interaction.showModal(this._buildInfoModal(prefill));
+                await interaction.showModal(this._buildInfoModal(prefill, interaction.guildId));
                 return;
             }
             if (customId === 'panel_tester') {
@@ -3886,9 +3889,10 @@ class InteractionHandler {
                 if (ch) {
                     const orig = await ch.messages.fetch(messageId).catch(() => null);
                     if (orig) {
+                        const cvMsgs = this.msgs(session.guildId);
                         const disabledBtn = new ButtonBuilder()
                             .setCustomId(`cv_vote_${messageId}`)
-                            .setLabel(`⚠️ Zgłoszono`)
+                            .setLabel(cvMsgs.cvReported || '⚠️ Reported')
                             .setStyle(ButtonStyle.Secondary)
                             .setDisabled(true);
                         await orig.edit({ components: [new ActionRowBuilder().addComponents(disabledBtn)] }).catch(() => {});
@@ -3947,7 +3951,7 @@ class InteractionHandler {
                         await this._dmPermissionAlert(client, session.guildId, {
                             channelId: cvCfg.rejectedChannelId,
                             missingPerms: e.code === 50001 ? ['ViewChannel'] : ['SendMessages', 'EmbedLinks'],
-                            context: 'Kanał zgłoszeń weryfikacji społeczności (CV)',
+                            context: { pol: 'Kanał zgłoszeń weryfikacji społeczności (CV)', eng: 'Community verification reports channel (CV)' },
                         });
                     }
                 }
@@ -4346,7 +4350,7 @@ class InteractionHandler {
             if (players.length === 0) {
                 const emptyButtons = this.rankingService.createRankingButtons(0, 1, false, msgs, roleRows, btnOptions);
                 await interaction.editReply({
-                    content: `📋 Brak graczy z rolą **${roleName}** w rankingu.`,
+                    content: formatMessage(msgs.roleRankingEmpty, { roleName }),
                     embeds: [],
                     components: emptyButtons
                 });
@@ -5039,12 +5043,13 @@ class InteractionHandler {
      * Buduje modal do tworzenia/edycji wiadomości informacyjnej.
      * @param {{ title?: string, description?: string, icon?: string, image?: string }} prefill
      */
-    _buildInfoModal(prefill = {}) {
+    _buildInfoModal(prefill = {}, guildId = null) {
+        const tM = guildId ? this._panelT(guildId) : (p, _e) => p;
         const titleInput = new TextInputBuilder()
             .setCustomId('embedTitle')
-            .setLabel('Tytuł (opcjonalnie)')
+            .setLabel(tM('Tytuł (opcjonalnie)', 'Title (optional)'))
             .setStyle(TextInputStyle.Short)
-            .setPlaceholder('Tytuł wiadomości')
+            .setPlaceholder(tM('Tytuł wiadomości', 'Message title'))
             .setRequired(false)
             .setMaxLength(256);
         if (prefill.title) titleInput.setValue(prefill.title);
@@ -5069,7 +5074,7 @@ class InteractionHandler {
 
         const iconInput = new TextInputBuilder()
             .setCustomId('embedIcon')
-            .setLabel('Ikona URL (opcjonalnie)')
+            .setLabel(tM('Ikona URL (opcjonalnie)', 'Icon URL (optional)'))
             .setStyle(TextInputStyle.Short)
             .setPlaceholder('https://...')
             .setRequired(false);
@@ -5077,7 +5082,7 @@ class InteractionHandler {
 
         const imageInput = new TextInputBuilder()
             .setCustomId('embedImage')
-            .setLabel('Obraz URL (opcjonalnie)')
+            .setLabel(tM('Obraz URL (opcjonalnie)', 'Image URL (optional)'))
             .setStyle(TextInputStyle.Short)
             .setPlaceholder('https://...')
             .setRequired(false);
@@ -5085,7 +5090,7 @@ class InteractionHandler {
 
         return new ModalBuilder()
             .setCustomId('info_modal')
-            .setTitle('Nowa wiadomość informacyjna')
+            .setTitle(tM('Nowa wiadomość informacyjna', 'New Info Message'))
             .addComponents(
                 new ActionRowBuilder().addComponents(titleInput),
                 new ActionRowBuilder().addComponents(descPolInput),
@@ -5122,7 +5127,7 @@ class InteractionHandler {
             return;
         }
         const prefill = this._infoSessions.get(interaction.user.id) || {};
-        await interaction.showModal(this._buildInfoModal(prefill));
+        await interaction.showModal(this._buildInfoModal(prefill, interaction.guildId));
     }
 
     /**
@@ -5363,7 +5368,7 @@ class InteractionHandler {
      */
     async _handleInfoEdit(interaction) {
         const data = this._infoSessions.get(interaction.user.id) || {};
-        await interaction.showModal(this._buildInfoModal(data));
+        await interaction.showModal(this._buildInfoModal(data, interaction.guildId));
     }
 
     /**
@@ -5707,7 +5712,7 @@ class InteractionHandler {
         const imageUrl = interaction.message.embeds[0]?.image?.url;
         if (!imageUrl) {
             await interaction.editReply({
-                content: '❌ Brak zdjęcia w raporcie.',
+                content: msgs.analyzeNoImage,
                 embeds: interaction.message.embeds,
                 attachments: [],
                 components: [],
@@ -5863,7 +5868,7 @@ class InteractionHandler {
         } catch (err) {
             gl.error(`❌ [Analizuj] Błąd ee_analyze: ${err.message}`);
             await interaction.editReply({
-                content: `❌ Błąd analizy: ${err.message}`,
+                content: formatMessage(msgs.analyzeError, { error: err.message }),
                 embeds: interaction.message.embeds,
                 components: [],
             }).catch(() => {});
@@ -5879,6 +5884,10 @@ class InteractionHandler {
             const guildName = guild?.name || guildId;
             const isPol = storedCfg?.lang !== 'eng';
 
+            const ctxText = typeof context === 'object'
+                ? (isPol ? context.pol : context.eng)
+                : context;
+
             const missingList = missingPerms.length
                 ? missingPerms.map(p => `• **${p}**`).join('\n')
                 : isPol ? '• *(nieznane uprawnienie)*' : '• *(unknown permission)*';
@@ -5887,8 +5896,8 @@ class InteractionHandler {
                 .setColor(0xFF4444)
                 .setTitle(isPol ? '⚠️ EndersEcho — brak uprawnień' : '⚠️ EndersEcho — missing permissions')
                 .setDescription(isPol
-                    ? `Bot napotkał błąd uprawnień na serwerze **${guildName}** i nie może wykonać swojego zadania.\n\n**Kanał:** <#${channelId}>\n**Kontekst:** ${context}\n\n**Brakujące uprawnienia:**\n${missingList}\n\nPrzejdź do ustawień kanału i nadaj botowi brakujące uprawnienia, lub zmień kanał przez \`/configure\`.`
-                    : `The bot encountered a permission error on **${guildName}** and cannot complete its task.\n\n**Channel:** <#${channelId}>\n**Context:** ${context}\n\n**Missing permissions:**\n${missingList}\n\nGo to the channel settings and grant the bot the missing permissions, or change the channel via \`/configure\`.`
+                    ? `Bot napotkał błąd uprawnień na serwerze **${guildName}** i nie może wykonać swojego zadania.\n\n**Kanał:** <#${channelId}>\n**Kontekst:** ${ctxText}\n\n**Brakujące uprawnienia:**\n${missingList}\n\nPrzejdź do ustawień kanału i nadaj botowi brakujące uprawnienia, lub zmień kanał przez \`/configure\`.`
+                    : `The bot encountered a permission error on **${guildName}** and cannot complete its task.\n\n**Channel:** <#${channelId}>\n**Context:** ${ctxText}\n\n**Missing permissions:**\n${missingList}\n\nGo to the channel settings and grant the bot the missing permissions, or change the channel via \`/configure\`.`
                 )
                 .setTimestamp();
 
@@ -6046,7 +6055,7 @@ class InteractionHandler {
                             await this._dmPermissionAlert(interaction.client, interaction.guildId, {
                                 channelId: perGuildChannelId,
                                 missingPerms: missing,
-                                context: 'Kanał raportów odrzuconych screenów',
+                                context: { pol: 'Kanał raportów odrzuconych screenów', eng: 'Rejected screenshots reports channel' },
                             });
                         } catch (diagErr) {
                             gl.warn(`⚠️ Nie można wysłać raportu do per-guild kanału (${err.code} ${err.message}): diagnostyka nieudana — ${diagErr.message}`);
@@ -6146,7 +6155,8 @@ class InteractionHandler {
         }
 
         if (userId !== interaction.user.id) {
-            await interaction.reply({ content: 'Tylko osoba która użyła komendy może klikać te przyciski.', flags: ['Ephemeral'] });
+            const tTk = this._panelT(interaction.guildId);
+            await interaction.reply({ content: tTk('Tylko osoba która użyła komendy może klikać te przyciski.', 'Only the person who used the command can click these buttons.'), flags: ['Ephemeral'] });
             return;
         }
 
@@ -7109,7 +7119,7 @@ class InteractionHandler {
     async _handlePanelBanGuildConfirm(interaction, guildIdToBan) {
         const t = this._panelT(interaction.guildId);
         if (!this.guildBanService) {
-            await interaction.update({ embeds: [new EmbedBuilder().setColor(0xFF0000).setDescription('❌ GuildBanService niedostępny.')], components: [] });
+            await interaction.update({ embeds: [new EmbedBuilder().setColor(0xFF0000).setDescription(t('❌ GuildBanService niedostępny.', '❌ GuildBanService unavailable.'))], components: [] });
             return;
         }
 

--- a/EndersEcho/index.js
+++ b/EndersEcho/index.js
@@ -200,14 +200,16 @@ client.on('interactionCreate', async (interaction) => {
         logger.error('Błąd podczas obsługi interakcji:', error);
 
         try {
+            const errMsgs = interaction.guildId ? config.getMessages(interaction.guildId) : null;
+            const errContent = errMsgs?.commandError || '❌ An error occurred while processing the command.';
             if (!interaction.replied && !interaction.deferred) {
                 await interaction.reply({
-                    content: '❌ Wystąpił błąd podczas przetwarzania komendy.',
+                    content: errContent,
                     flags: ['Ephemeral']
                 });
             } else if (interaction.deferred) {
                 await interaction.editReply({
-                    content: '❌ Wystąpił błąd podczas przetwarzania komendy.'
+                    content: errContent
                 });
             }
         } catch (replyError) {
@@ -235,13 +237,15 @@ client.on('guildCreate', async (guild) => {
                 '⚙️ **EndersEcho** has been added to your server!\nAn administrator must run **/configure** to set up the bot before it can be used.'
             ).catch(() => {});
         }
+        const guildLang = guildConfigService.getConfig(guild.id)?.lang || 'pol';
+        const tGC = guildLang === 'eng' ? ((_p, e) => e) : ((p, _e) => p);
         await sendAdminNotification(client, new EmbedBuilder()
             .setColor(0x57F287)
-            .setTitle('🆕 Bot dodany do serwera')
+            .setTitle(tGC('🆕 Bot dodany do serwera', '🆕 Bot added to server'))
             .setThumbnail(guild.iconURL({ dynamic: true, size: 128 }))
             .addFields(
-                { name: 'Serwer', value: `${guild.name} (\`${guild.id}\`)` },
-                { name: 'Członkowie', value: `${guild.memberCount}` }
+                { name: tGC('Serwer', 'Server'), value: `${guild.name} (\`${guild.id}\`)` },
+                { name: tGC('Członkowie', 'Members'), value: `${guild.memberCount}` }
             )
             .setTimestamp()
         );
@@ -333,12 +337,14 @@ client.on('guildDelete', async (guild) => {
     } catch (err) {
         logger.error(`Błąd guildLeft (serwer "${guild.name}"):`, err);
     }
+    const guildLangDel = guildConfigService.getConfig(guild.id)?.lang || 'pol';
+    const tGD = guildLangDel === 'eng' ? ((_p, e) => e) : ((p, _e) => p);
     await sendAdminNotification(client, new EmbedBuilder()
         .setColor(0xED4245)
-        .setTitle('🚪 Bot usunięty z serwera')
+        .setTitle(tGD('🚪 Bot usunięty z serwera', '🚪 Bot removed from server'))
         .setThumbnail(guild.iconURL({ dynamic: true, size: 128 }))
         .addFields(
-            { name: 'Serwer', value: `${guild.name} (\`${guild.id}\`)` }
+            { name: tGD('Serwer', 'Server'), value: `${guild.name} (\`${guild.id}\`)` }
         )
         .setTimestamp()
     );

--- a/EndersEcho/services/globalTop10Service.js
+++ b/EndersEcho/services/globalTop10Service.js
@@ -4,6 +4,7 @@ const fs   = require('fs');
 const path = require('path');
 const { EmbedBuilder } = require('discord.js');
 const { createBotLogger } = require('../../utils/consoleLogger');
+const { formatMessage } = require('../utils/helpers');
 
 const logger = createBotLogger('EndersEcho');
 
@@ -225,7 +226,7 @@ class GlobalTop10Service {
             })
             .setTimestamp()
             .setFooter({
-                text: `Następny raport za ${nextIntervalDays} dni`,
+                text: formatMessage(msgs.globalTop10FooterNext || 'Next report in {days} days', { days: nextIntervalDays }),
             });
 
         const botIconUrl = this.client?.user?.displayAvatarURL({ size: 128 });

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -988,7 +988,7 @@ class RankingService {
             } else if (diff < 0) {
                 comparisonText = formatMessage(msgs.notifDmMissingToRecord, { diff: this.formatScore(Math.abs(diff)) });
             } else {
-                comparisonText = '🎯 Wyniki równe!';
+                comparisonText = msgs.notifDmScoresEqual;
             }
         } else {
             comparisonText = msgs.notifDmNoSubscriberRecord;

--- a/EndersEcho/services/userBlockService.js
+++ b/EndersEcho/services/userBlockService.js
@@ -100,10 +100,12 @@ class UserBlockService {
         });
     }
 
-    formatTimeRemaining(blockedUntil) {
-        if (blockedUntil === null) return '∞ Permanentnie';
+    formatTimeRemaining(blockedUntil, labels = {}) {
+        const permanent = labels.permanent ?? '∞ Permanentnie';
+        const expired = labels.expired ?? 'Wygasła';
+        if (blockedUntil === null) return permanent;
         const remaining = blockedUntil - Date.now();
-        if (remaining <= 0) return 'Wygasła';
+        if (remaining <= 0) return expired;
         const days = Math.floor(remaining / 86400000);
         const hours = Math.floor((remaining % 86400000) / 3600000);
         const minutes = Math.floor((remaining % 3600000) / 60000);


### PR DESCRIPTION
## Podsumowanie

Gruntowne przeszukanie i naprawienie WSZYSTKICH hardkodowanych polskich stringów we wszystkich interakcjach EndersEcho bota.

## Zmiany

**`config/messages.js`** — nowe klucze w obu sekcjach `pol` i `eng`:
- `roleRankingEmpty` — "Brak graczy z rolą X w rankingu" (błąd z screenshota)
- `analyzeNoImage` — brak zdjęcia w raporcie
- `analyzeError` — błąd analizy z `{error}`
- `notifDmScoresEqual` — wyniki równe w DM powiadomieniu
- `globalTop10FooterNext` — stopka raportu TOP10 z `{days}`
- `cvReported` — etykieta przycisku po osiągnięciu progu zgłoszeń
- `commandError` — błąd przetwarzania komendy (fallback w `interactionCreate`)
- `gatewayRateLimited`, `gatewayNotEntitled`, `gatewayDefault` — błędy Operations Gateway

**`handlers/interactionHandlers.js`**:
- `_handleRoleRankingSelect` (linia 4349): `formatMessage(msgs.roleRankingEmpty, { roleName })`
- `_handleAnalyzeButton` (linia 5710): `msgs.analyzeNoImage`, `formatMessage(msgs.analyzeError, { error })`
- `mapGatewayErrorMessage`: zastąpiono hardkodowane polskie stringi kluczami z `msgs`
- `_handlePanelUnblockSearch`: `blockLabels` z `t()` przekazywane do `formatTimeRemaining`
- `_buildInfoModal`: dodano parametr `guildId`, tłumaczenie tytułu i etykiet przez `_panelT`
- `_handleTokensButton`: tłumaczenie "Tylko osoba która użyła komendy..."
- `_triggerCvReport`: etykieta `cvReported` zamiast `'⚠️ Zgłoszono'`
- `_dmPermissionAlert`: obsługa `context` jako obiektu `{pol, eng}`; wywołania zaktualizowane
- Embedy konfiguracji serwera (`cfg_accept`): przetłumaczone przez `tCfg` na podstawie `newData.lang`
- `_handlePanelBanGuildConfirm`: błąd GuildBanService przez `t()`

**`index.js`**:
- Fallback błąd `interactionCreate`: używa `config.getMessages(interaction.guildId).commandError`
- Embedy `guildCreate`/`guildDelete` webhook: tłumaczone przez język serwera z `guildConfigService`

**`services/rankingService.js`**:
- `createDmNotifEmbed`: `msgs.notifDmScoresEqual` zamiast `'🎯 Wyniki równe!'`

**`services/globalTop10Service.js`**:
- `_buildTop10Embed`: `formatMessage(msgs.globalTop10FooterNext, { days })` zamiast hardkodowanego stringa

**`services/userBlockService.js`**:
- `formatTimeRemaining(blockedUntil, labels = {})`: opcjonalne etykiety `permanent`/`expired` przez parametr

---
_Generated by [Claude Code](https://claude.ai/code/session_018FRVtbNaeVLsyYHgBfhwD3)_