### PR TITLE
EndersEcho: nowy format wizualny TOP 10 + komenda /generate

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -111,6 +111,8 @@
      - Boss okresu: najczęstszy boss z ostatnich 10 wpisów historii wyników (`wyniki/`)
      - Wysyłany na każdy serwer z `globalTopNotifications !== false` do `allowedChannelId`
      - Konfiguracja przez panel admina → **📅 Interwał TOP10** (tylko head admin) → modal z datą i godziną pierwszego raportu (format `DD.MM.RRRR GG:MM`); puste pole = wyłącz harmonogram
+     - **Format embeda:** TOP 3 — blok blockquote z paskiem postępu `█░` (% względem lidera) i kolorowym wskaźnikiem zmiany `▲/▼`; pozycje 4–10 — kompaktowa jednolinijkowa z tagiem serwera
+     - **Komenda /generate (head admin):** `buildOnDemandEmbed()` — generuje ten sam embed bez aktualizacji snapshootu/harmonogramu i wysyła go na `allowedChannelId` serwera; widoczna tylko dla adminów (`setDefaultMemberPermissions(Administrator)`), wykonać może wyłącznie head admin (`ENDERSECHO_BLOCK_OCR_USER_IDS`)
 
 4. **Paginacja + Wybór Rankingu** - `interactionHandlers.js`:
    - `/ranking` → ephemeral z przyciskami: `[NazwaSerwera1]`, `[NazwaSerwera2]`, `[🌐 Global]`
@@ -179,7 +181,7 @@
    - **Wyślij Info (head admin):** modal → podgląd PL+ENG → wyślij na wszystkie serwery. `_infoSessions` Map (RAM)
    - **Zbanuj serwer (head admin):** modal wyszukiwania nazwy → lista → potwierdzenie → bot wychodzi z serwera + ID zapisywane w `data/banned_guilds.json`. Odblokowanie przez listę zbanowanych. Check w `guildCreate` — bot natychmiast wychodzi, jeśli serwer jest na liście. `GuildBanService`.
 
-**Komendy slash:** `/achievements`, `/configure`, `/manage`, `/ranking`, `/subscribe`, `/test`, `/update`
+**Komendy slash:** `/achievements`, `/configure`, `/generate`, `/manage`, `/ranking`, `/subscribe`, `/test`, `/update`
 
 **Panel Admina** — dostępny przez `/manage`:
 - Dostęp: Administrator Discord

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -157,6 +157,12 @@ class InteractionHandler {
                 .setDescription('Open EndersEcho admin panel (admins only)')
                 .setDescriptionLocalizations(pl('Otwórz panel administracyjny EndersEcho (tylko dla adminów)'))
                 .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+
+            new SlashCommandBuilder()
+                .setName('generate')
+                .setDescription('Generate Global TOP 10 report on demand (head admins only)')
+                .setDescriptionLocalizations(pl('Wygeneruj raport Global TOP 10 na żądanie (tylko head adminowie)'))
+                .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
         ];
     }
 
@@ -235,6 +241,11 @@ class InteractionHandler {
             if (interaction.commandName === 'manage') {
                 if (!this._checkConfigured(interaction)) return;
                 await this.handleManageCommand(interaction);
+                return;
+            }
+
+            if (interaction.commandName === 'generate') {
+                await this.handleGenerateCommand(interaction);
                 return;
             }
 
@@ -605,6 +616,44 @@ class InteractionHandler {
         }
         const { embed, components } = this._buildAdminPanel(interaction);
         await interaction.reply({ embeds: [embed], components, flags: ['Ephemeral'] });
+    }
+
+    async handleGenerateCommand(interaction) {
+        if (!this._isHeadAdmin(interaction.user.id)) {
+            const msgs = this.msgs(interaction.guildId);
+            await interaction.reply({ content: msgs.noPermission, flags: ['Ephemeral'] });
+            return;
+        }
+
+        await interaction.deferReply({ flags: ['Ephemeral'] });
+
+        try {
+            const msgs  = this.msgs(interaction.guildId);
+            const embed = await this.globalTop10Service.buildOnDemandEmbed(msgs, interaction.client);
+
+            // Wyślij na dozwolony kanał serwera
+            const guildCfg  = this.config.getAllGuilds().find(g => g.id === interaction.guildId)
+                           || this.guildConfigService?.getConfig(interaction.guildId);
+            const channelId = guildCfg?.allowedChannelId;
+
+            if (channelId) {
+                const channel = await interaction.client.channels.fetch(channelId).catch(() => null);
+                if (channel) {
+                    await channel.send({ embeds: [embed] });
+                    const lang  = this.guildConfigService?.getConfig(interaction.guildId)?.lang
+                               || this.config.getAllGuilds().find(g => g.id === interaction.guildId)?.lang
+                               || 'pol';
+                    await interaction.editReply({ content: lang === 'pol' ? `✅ Wysłano TOP 10 na <#${channelId}>` : `✅ TOP 10 sent to <#${channelId}>` });
+                    return;
+                }
+            }
+
+            // Fallback — wyślij ephemeral jeśli kanał niedostępny
+            await interaction.editReply({ embeds: [embed] });
+        } catch (err) {
+            logger.error(`[/generate] Błąd: ${err.message}`);
+            await interaction.editReply({ content: '❌ Błąd podczas generowania TOP 10.' });
+        }
     }
 
     /** Buduje embed kroku konfiguracji (step 1–6) i aktualizuje wiadomość */

--- a/EndersEcho/services/globalTop10Service.js
+++ b/EndersEcho/services/globalTop10Service.js
@@ -177,7 +177,8 @@ class GlobalTop10Service {
 
     async _buildTop10Embed(top10, lastSnapshot, bossName, msgs, guildCfg, client) {
         const guildTagMap = new Map(this.config.getAllGuilds().map(g => [g.id, g.tag || null]));
-        const medals = ['🥇', '🥈', '🥉'];
+        const medals      = ['👑', '🥈', '🥉'];
+        const top1Score   = top10[0]?.scoreValue || 1;
 
         let lines = '';
         for (let i = 0; i < top10.length; i++) {
@@ -185,15 +186,23 @@ class GlobalTop10Service {
             const position = i + 1;
             const prevPos  = lastSnapshot[player.userId] || null;
 
-            // Ikona pozycji
-            const posLabel = position <= 3 ? medals[i] : `**${position}.**`;
-
             // Zmiana pozycji
-            let changeLabel;
-            if (!prevPos)                         changeLabel = '🆕';
-            else if (prevPos === position)        changeLabel = '`=`';
-            else if (prevPos > position)          changeLabel = `\`▲${prevPos - position}\``;
-            else                                  changeLabel = `\`▼${position - prevPos}\``;
+            let changeStr, changeSign;
+            if (!prevPos) {
+                changeStr  = '🆕';
+                changeSign = null;
+            } else if (prevPos === position) {
+                changeStr  = '`=`';
+                changeSign = 'eq';
+            } else if (prevPos > position) {
+                const diff = prevPos - position;
+                changeStr  = `**▲ +${diff}**`;
+                changeSign = 'up';
+            } else {
+                const diff = position - prevPos;
+                changeStr  = `**▼ −${diff}**`;
+                changeSign = 'down';
+            }
 
             // Nick (pobieramy z Discord)
             let displayName = player.username || `ID:${player.userId}`;
@@ -205,12 +214,27 @@ class GlobalTop10Service {
                 }
             } catch { /* fallback na username */ }
 
-            const tag = guildTagMap.get(player.sourceGuildId);
-            const date = new Date(player.timestamp);
+            const tag       = guildTagMap.get(player.sourceGuildId);
+            const date      = new Date(player.timestamp);
             const shortDate = `${date.getDate().toString().padStart(2, '0')}.${(date.getMonth() + 1).toString().padStart(2, '0')}`;
-            const serverSuffix = tag ? ` • ${tag}` : '';
+            const tagSuffix = tag ? `  ·  ${tag}` : '';
+            const scoreStr  = this.rankingService.formatScore(player.scoreValue);
+            const bossStr   = player.bossName || msgs.unknownBoss;
 
-            lines += `${posLabel} ${changeLabel} ${displayName} • **${this.rankingService.formatScore(player.scoreValue)}**\n*(${shortDate})* • ${player.bossName || msgs.unknownBoss}${serverSuffix}\n\n`;
+            if (position <= 3) {
+                // TOP 3 — blok z blockquote i paskiem postępu
+                const pct      = Math.round((player.scoreValue / top1Score) * 100);
+                const filled   = Math.round(pct / 5); // 20 kratek = 100%
+                const bar      = '█'.repeat(filled) + '░'.repeat(20 - filled);
+                const posLabel = medals[i];
+
+                lines += `\`${String(position).padStart(2, '0')}\` ${posLabel}  **${displayName}**  ·  **${scoreStr}**\n`;
+                lines += `> ${changeStr}  ·  ${bossStr}  ·  *${shortDate}*${tagSuffix}\n`;
+                lines += `> ${bar}  \`${pct}%\`\n\n`;
+            } else {
+                // 4–10 — kompaktowa jednolinijkowa
+                lines += `\`${String(position).padStart(2, '0')}\`  ${changeStr}  **${displayName}**  —  ${scoreStr}  ·  ${bossStr}  *${shortDate}*${tagSuffix}\n`;
+            }
         }
 
         const nextIntervalDays = Math.round(this._nextIntervalMs() / (24 * 60 * 60 * 1000));
@@ -220,8 +244,8 @@ class GlobalTop10Service {
             .setTitle(msgs.globalTop10ReportTitle || '🌐 TOP 10 Globalny')
             .setDescription(lines || msgs.rankingEmpty)
             .addFields({
-                name: msgs.globalTop10BossField || '⚔️ Boss tygodnia',
-                value: bossName || msgs.unknownBoss,
+                name:   msgs.globalTop10BossField || '⚔️ Boss okresu',
+                value:  bossName || msgs.unknownBoss,
                 inline: true,
             })
             .setTimestamp()
@@ -233,6 +257,21 @@ class GlobalTop10Service {
         if (botIconUrl) embed.setThumbnail(botIconUrl);
 
         return embed;
+    }
+
+    /**
+     * Generuje embed TOP 10 na żądanie (komenda /generate).
+     * Nie aktualizuje snapshootu ani harmonogramu.
+     */
+    async buildOnDemandEmbed(msgs, client) {
+        const globalRanking = await this.rankingService.getGlobalRanking(
+            new Set(client.guilds.cache.keys())
+        );
+        const top10      = globalRanking.slice(0, 10);
+        const bossName   = await this._getMostFrequentBoss(10);
+        const lastSnapshot = this._cfg.lastSnapshot || {};
+
+        return this._buildTop10Embed(top10, lastSnapshot, bossName, msgs, null, client);
     }
 
     // ── most frequent boss ─────────────────────────────────────────────────────

--- a/Muteusz/config/all_commands.json
+++ b/Muteusz/config/all_commands.json
@@ -575,6 +575,12 @@
           "requiredPermission": "administrator"
         },
         {
+          "name": "/generate",
+          "description": "Generuje raport Global TOP 10 na żądanie i wysyła go na kanał bota. Dostępna tylko dla head adminów (ENDERSECHO_BLOCK_OCR_USER_IDS), widoczna tylko dla administratorów.",
+          "usage": "/generate",
+          "requiredPermission": "administrator"
+        },
+        {
           "name": "/manage",
           "description": "Otwiera bezpośrednio Panel Administracyjny EndersEcho. Operacje: usuń gracza z rankingu, odblokuj gracza, tokeny AI, zablokuj gracza (head admin), OCR on/off (head admin), ustaw limity (head admin), wyślij info (head admin), testerzy (head admin).",
           "usage": "/manage",


### PR DESCRIPTION
## Summary

- **Nowy format wizualny cyklicznego raportu Global TOP 10** — TOP 3 dostaje blok blockquote z paskiem postępu `█░` (% względem lidera) i kolorowym wskaźnikiem zmiany `▲ +N` / `▼ −N`; pozycje 4–10 kompaktowe jednolinijkowe z tagiem serwera
- **Komenda `/generate`** — generuje raport TOP 10 na żądanie i wysyła na kanał bota; widoczna tylko dla adminów (`Administrator`), wykonać może wyłącznie head admin (`ENDERSECHO_BLOCK_OCR_USER_IDS`)
- **Nowa metoda `buildOnDemandEmbed()`** w `globalTop10Service.js` — generuje embed bez aktualizacji snapshootu ani harmonogramu

## Test plan

- [ ] Cykliczny raport TOP 10 wysyła się z nowym formatem (blockquote dla TOP 3, paski postępu, kompaktowe 4–10)
- [ ] Tag serwera widoczny w wierszach 4–10
- [ ] `/generate` jako zwykły admin → odmowa (ephemeral)
- [ ] `/generate` jako head admin → embed wysłany na kanał bota, ephemeral potwierdzenie z `<#channelId>`
- [ ] Komenda `/generate` niewidoczna dla nie-adminów (Discord ukrywa ją przez `setDefaultMemberPermissions(Administrator)`)
- [ ] `/komendy` w Muteuszu pokazuje `/generate` w sekcji EndersEcho

---
_Generated by [Claude Code](https://claude.ai/code/session_0178wyR5reDo3jJwMuMWmHd7)_