### PR TITLE
EndersEcho: napraw fałszywe odrzucenia w porównaniu wzorca /update

### DIFF
--- a/EndersEcho/services/aiOcrService.js
+++ b/EndersEcho/services/aiOcrService.js
@@ -364,7 +364,6 @@ WZORZEC (pierwsze zdjęcie) ma DOKŁADNIE:
 CZEGO NIE PORÓWNUJESZ (treść ZAWSZE się różni — to jest NORMALNE):
 - Nazwa bossa — każdy gracz wgrywa INNEGO bossa niż wzorzec — NIE jest to powód do odrzucenia
 - Liczby wyników, jednostki (K/M/B/T/Q/Qi/Sx) — zawsze inne — NIE jest to powód do odrzucenia
-- Kolor tła, grafika gameplay — może wyglądać inaczej — NIE jest to powód do odrzucenia
 Porównujesz TYLKO STRUKTURĘ layoutu: czy te same elementy UI (panel, baner, ikona, statystyki, żółty przycisk) są na swoich miejscach.
 
 Format odpowiedzi:

--- a/EndersEcho/services/aiOcrService.js
+++ b/EndersEcho/services/aiOcrService.js
@@ -18,7 +18,7 @@ const SAFETY_SETTINGS_OFF = [
  */
 const PROMPT_VERSIONS = {
     'extract-data-eng':  'v2',
-    'compare-template':  'v4',
+    'compare-template':  'v5',
 };
 const sharp = require('sharp');
 const { createBotLogger } = require('../../utils/consoleLogger');
@@ -360,6 +360,12 @@ WZORZEC (pierwsze zdjęcie) ma DOKŁADNIE:
 - poniżej: dwie linie statystyk (Best / Total) — mogą mieć RÓŻNE jednostki (np. Best: 25015.1Qi, Total: 103.2Sx) — to jest normalne
 - na dole panelu: rząd małych okrągłych lub sześciokątnych szarych ikon
 - pod panelem: jeden żółty przycisk
+
+CZEGO NIE PORÓWNUJESZ (treść ZAWSZE się różni — to jest NORMALNE):
+- Nazwa bossa — każdy gracz wgrywa INNEGO bossa niż wzorzec — NIE jest to powód do odrzucenia
+- Liczby wyników, jednostki (K/M/B/T/Q/Qi/Sx) — zawsze inne — NIE jest to powód do odrzucenia
+- Kolor tła, grafika gameplay — może wyglądać inaczej — NIE jest to powód do odrzucenia
+Porównujesz TYLKO STRUKTURĘ layoutu: czy te same elementy UI (panel, baner, ikona, statystyki, żółty przycisk) są na swoich miejscach.
 
 Format odpowiedzi:
 - Jeśli drugie zdjęcie pasuje do wzorca → odpowiedz TYLKO: OK


### PR DESCRIPTION
## Problem

AI w metodzie `_compareWithTemplate` odrzucało prawidłowe screeny z powodów takich jak:
- `NOK: Boss name is different and units are different` — AI porównywało nazwę bossa ze wzorcem zamiast tylko sprawdzać strukturę
- `NOK: Panel has a close button (X)` — możliwe hallucination podparte przykładem z `exampleReasons`

Prompt opisywał wzorzec z `"pod banerem: nazwa własna Bossa"` ale **nigdzie nie informował AI, że nazwa bossa i liczby wyników ZAWSZE będą inne** między wzorcem a wgrywanym screenem. AI traktowało to jako niezgodność strukturalną.

## Zmiana

`EndersEcho/services/aiOcrService.js` — metoda `_compareWithTemplate`:

- Dodano sekcję **„CZEGO NIE PORÓWNUJESZ"** po opisie wzorca, która jawnie mówi AI:
  - Nazwa bossa będzie inna — nie jest to powód do odrzucenia
  - Liczby, jednostki (K/M/B/T/Q/Qi/Sx) — zawsze inne — nie jest to powód do odrzucenia  
  - Kolor tła/grafika gameplay — może wyglądać inaczej — nie jest to powód do odrzucenia
  - Porównuje się TYLKO strukturę layoutu (panel, baner, ikona, statystyki, żółty przycisk)
- Zbumpowano `PROMPT_VERSIONS['compare-template']` z `v4` → `v5` (Langfuse tracking)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YcCYNGLpCPJ4PU9jGcAnXy)_