### PR TITLE
EndersEcho: obraz wyniku (brak rekordu) wewnątrz embeda

### DIFF
--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -3110,12 +3110,7 @@ class InteractionHandler {
                     );
 
                     try {
-                        await interaction.editReply({ embeds: [resultEmbed] });
-                        await interaction.followUp({
-                            content: msgs.rankingImageCaption,
-                            files: [imageAttachment],
-                            flags: ['Ephemeral']
-                        });
+                        await interaction.editReply({ embeds: [resultEmbed], files: [imageAttachment] });
                         gl.info('✅ Wysłano embed z wynikiem (brak rekordu)');
                     } catch (editReplyError) {
                         gl.error(`❌ Błąd podczas wysyłania embed (brak rekordu): ${editReplyError.message}`);


### PR DESCRIPTION
## Problem

Gdy wynik /update nie pobił rekordu, obraz był wysyłany jako osobna wiadomość (`followUp` z `rankingImageCaption`) zamiast wewnątrz embeda.

Embed już miał `.setImage('attachment://filename')`, ale plik był w innej wiadomości — Discord nie może rozwiązać `attachment://` bez pliku w tej samej wiadomości.

## Zmiana

`EndersEcho/handlers/interactionHandlers.js`:
- Dodano `files: [imageAttachment]` do `interaction.editReply` (tam gdzie jest embed)
- Usunięto osobny `followUp` z samym obrazem (`rankingImageCaption` + plik)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YcCYNGLpCPJ4PU9jGcAnXy)_