### PR TITLE
EndersEcho: wyróżnik w logach dla manualnej analizy admina

### DIFF
--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -6041,7 +6041,7 @@ class InteractionHandler {
             const { isNewRecord, currentScore } = await this.rankingService.updateUserRanking(
                 targetGuildId, targetUserId, userName, aiResult.score, aiResult.bossName
             );
-            await this.logService.logScoreUpdate(userName, aiResult.score, isNewRecord, targetGuildId);
+            await this.logService.logScoreUpdate(userName, aiResult.score, isNewRecord, targetGuildId, { adminName });
             gl.info(`🎯 [Analizuj] Wynik zapisany — isNewRecord: ${isNewRecord}`);
 
             let newAchievements = [];

--- a/EndersEcho/services/logService.js
+++ b/EndersEcho/services/logService.js
@@ -34,9 +34,13 @@ class LogService {
      * @param {boolean} isNewRecord
      * @param {string|null} guildId
      */
-    async logScoreUpdate(userName, score, isNewRecord, guildId = null) {
+    async logScoreUpdate(userName, score, isNewRecord, guildId = null, { adminName } = {}) {
         const status = isNewRecord ? 'NOWY REKORD' : 'Bez rekordu';
-        this._gl(guildId).info(`Aktualizacja wyniku: ${userName} - ${score} [${status}]`);
+        if (adminName) {
+            this._gl(guildId).info(`🔬 MANUALNA ANALIZA ADMINA 🔬 | ${adminName} → ${userName} | ${score} [${status}]`);
+        } else {
+            this._gl(guildId).info(`Aktualizacja wyniku: ${userName} - ${score} [${status}]`);
+        }
     }
 
     /**


### PR DESCRIPTION
## Zmiana

Gdy admin kliknie "Analizuj" i potwierdzi, log w webhooku zamiast standardowego:
```
Aktualizacja wyniku: Thashar - 29211.3Q [NOWY REKORD]
```
wyświetla:
```
🔬 MANUALNA ANALIZA ADMINA 🔬 | AdminName → Thashar | 29211.3Q [NOWY REKORD]
```

`logService.logScoreUpdate` dostał opcjonalny parametr `{ adminName }` — gdy przekazany, log przyjmuje wyróżniony format. Wywołania z `/update` nie zmieniają się (brak `adminName` → stary format).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YcCYNGLpCPJ4PU9jGcAnXy)_