### PR TITLE
EndersEcho: dynamiczne podwajanie cooldownu /update

### DIFF
--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -2926,7 +2926,12 @@ class InteractionHandler {
 
         // Ustaw cooldown od razu — chroni przed spamem niezależnie od wyniku OCR
         if (!dryRun && this.updateCooldownService) {
-            await this.updateCooldownService.setCooldown(interaction.user.id);
+            const appliedCooldownMs = await this.updateCooldownService.setCooldown(interaction.user.id);
+            const { formatCooldownDuration: fcd } = require('../services/updateCooldownService');
+            const base = this.updateCooldownService.getCooldownDuration();
+            if (appliedCooldownMs > base) {
+                logger.info(`⏫ Cooldown podwojony dla ${interaction.user.username}: ${fcd(appliedCooldownMs)}`);
+            }
         }
 
         let tempImagePath = null;

--- a/EndersEcho/services/updateCooldownService.js
+++ b/EndersEcho/services/updateCooldownService.js
@@ -6,7 +6,7 @@ const DEFAULT_COOLDOWN_MS = 5 * 60 * 1000; // 5 minut
 class UpdateCooldownService {
     constructor(config) {
         this.filePath = path.join(config.ranking.dataDir, 'update_cooldowns.json');
-        this._cooldowns = new Map(); // userId -> expiresAt (timestamp ms)
+        this._cooldowns = new Map(); // userId -> { expiresAt, cooldownMs, lastSetAt }
         this._cooldownDurationMs = DEFAULT_COOLDOWN_MS;
     }
 
@@ -16,17 +16,31 @@ class UpdateCooldownService {
             const data = JSON.parse(raw);
             const now = Date.now();
             if (typeof data.cooldownDurationMs === 'number') {
-                // Nowy format: { cooldownDurationMs, cooldowns: {userId: expiresAt} }
                 this._cooldownDurationMs = data.cooldownDurationMs;
-                for (const [userId, expiresAt] of Object.entries(data.cooldowns || {})) {
-                    if (expiresAt > now) this._cooldowns.set(userId, expiresAt);
+                for (const [userId, val] of Object.entries(data.cooldowns || {})) {
+                    if (typeof val === 'number') {
+                        // Stary format: samo expiresAt — migruj do nowego
+                        if (val > now) {
+                            this._cooldowns.set(userId, {
+                                expiresAt: val,
+                                cooldownMs: this._cooldownDurationMs,
+                                lastSetAt: val - this._cooldownDurationMs,
+                            });
+                        }
+                    } else if (val && typeof val === 'object' && val.expiresAt > now) {
+                        this._cooldowns.set(userId, val);
+                    }
                 }
             } else {
-                // Stary format: { userId: expiresAt } — migracja
+                // Najstarszy format: { userId: expiresAt } — migracja
                 this._cooldownDurationMs = DEFAULT_COOLDOWN_MS;
                 for (const [userId, expiresAt] of Object.entries(data)) {
                     if (typeof expiresAt === 'number' && expiresAt > now) {
-                        this._cooldowns.set(userId, expiresAt);
+                        this._cooldowns.set(userId, {
+                            expiresAt,
+                            cooldownMs: this._cooldownDurationMs,
+                            lastSetAt: expiresAt - this._cooldownDurationMs,
+                        });
                     }
                 }
             }
@@ -38,8 +52,8 @@ class UpdateCooldownService {
     async save() {
         const now = Date.now();
         const cooldowns = {};
-        for (const [userId, expiresAt] of this._cooldowns) {
-            if (expiresAt > now) cooldowns[userId] = expiresAt;
+        for (const [userId, entry] of this._cooldowns) {
+            if (entry.expiresAt > now) cooldowns[userId] = entry;
         }
         await fs.mkdir(path.dirname(this.filePath), { recursive: true });
         await fs.writeFile(this.filePath, JSON.stringify({
@@ -50,9 +64,9 @@ class UpdateCooldownService {
 
     // Zwraca pozostały czas w ms, lub null jeśli brak cooldownu
     getRemainingMs(userId) {
-        const expiresAt = this._cooldowns.get(userId);
-        if (!expiresAt) return null;
-        const remaining = expiresAt - Date.now();
+        const entry = this._cooldowns.get(userId);
+        if (!entry) return null;
+        const remaining = entry.expiresAt - Date.now();
         if (remaining <= 0) {
             this._cooldowns.delete(userId);
             return null;
@@ -60,9 +74,38 @@ class UpdateCooldownService {
         return remaining;
     }
 
+    // Ustawia cooldown z logiką podwajania:
+    // Jeśli od poprzedniego setCooldown minęło <= 3x poprzedniego cooldownu → podwój.
+    // Jeśli minęło więcej → reset do bazy (_cooldownDurationMs).
     async setCooldown(userId) {
-        this._cooldowns.set(userId, Date.now() + this._cooldownDurationMs);
+        const now = Date.now();
+        const entry = this._cooldowns.get(userId);
+        const base = this._cooldownDurationMs;
+
+        let newCooldownMs;
+        if (entry && entry.lastSetAt) {
+            const timeSinceLastSet = now - entry.lastSetAt;
+            const windowMs = 3 * entry.cooldownMs;
+            newCooldownMs = timeSinceLastSet <= windowMs
+                ? entry.cooldownMs * 2
+                : base;
+        } else {
+            newCooldownMs = base;
+        }
+
+        this._cooldowns.set(userId, {
+            expiresAt: now + newCooldownMs,
+            cooldownMs: newCooldownMs,
+            lastSetAt: now,
+        });
         await this.save().catch(() => {});
+        return newCooldownMs;
+    }
+
+    // Zwraca aktualny efektywny cooldown danego usera (lub bazę jeśli brak wpisu)
+    getUserCooldownMs(userId) {
+        const entry = this._cooldowns.get(userId);
+        return entry ? entry.cooldownMs : this._cooldownDurationMs;
     }
 
     getCooldownDuration() {


### PR DESCRIPTION
## Zmiana

Dynamiczne podwajanie cooldownu `/update` przy zbyt częstym użyciu.

### Logika

Przy każdym `setCooldown(userId)`:
- Sprawdza czas od poprzedniego użycia (`timeSinceLastSet`)
- Jeśli `timeSinceLastSet ≤ 3 × poprzedniCooldown` → nowy cooldown = poprzedni × 2
- Jeśli `timeSinceLastSet > 3 × poprzedniCooldown` → reset do bazy (wartości z `/manage → Ustaw limity`)

### Przykład (baza = 5 min)
| Użycie | Czas od poprzedniego | Cooldown |
|---|---|---|
| 1 | — | 5 min |
| 2 | 7 min (≤ 15 = 3×5) | 10 min |
| 3 | 12 min (≤ 30 = 3×10) | 20 min |
| 4 | 65 min (> 60 = 3×20) | 5 min (reset) |

### Szczegóły implementacji
- `_cooldowns` Map zmieniony z `userId → expiresAt` na `userId → { expiresAt, cooldownMs, lastSetAt }`
- `setCooldown()` zwraca zastosowany cooldown w ms (używane do loga `⏫ Cooldown podwojony`)
- Pełny backward compat: stary format pliku (`number` lub `{ expiresAt: number }`) migrowany przy wczytaniu
- Nowa metoda `getUserCooldownMs(userId)` — zwraca aktualny efektywny cooldown gracza

---
_Generated by [Claude Code](https://claude.ai/code/session_01YcCYNGLpCPJ4PU9jGcAnXy)_