### PR TITLE
EndersEcho: naprawa rankingu, CV tryb testowy, czyszczenie historii przy cofaniu wyniku

### DIFF
--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -2173,7 +2173,9 @@ class InteractionHandler {
         await interaction.deferUpdate();
         try {
             const playersBefore = await this.rankingService.getSortedPlayers(targetGuildId).catch(() => []);
-            const playerName = playersBefore.find(p => p.userId === targetUserId)?.username || targetUserId;
+            const playerRecord = playersBefore.find(p => p.userId === targetUserId);
+            const playerName = playerRecord?.username || targetUserId;
+            const playerTimestamp = playerRecord?.timestamp || null;
             const wasRemoved = await this.rankingService.removePlayerFromRanking(targetUserId, targetGuildId);
             if (!wasRemoved) {
                 const { embed, components } = this._buildAdminPanel(interaction);
@@ -2194,6 +2196,10 @@ class InteractionHandler {
                     } else {
                         await this.achievementService.clearUserAchievements(targetGuildId, targetUserId);
                     }
+                }
+                if (this.scoreHistoryService && playerTimestamp) {
+                    this.scoreHistoryService.removeEntriesAfter(targetGuildId, targetUserId, playerTimestamp)
+                        .catch(e => logger.warn(`Błąd czyszczenia historii po usunięciu z rankingu: ${e.message}`));
                 }
                 const guildNameLog = targetGuild?.name || targetGuildId;
                 await this.logService.logMessage('success', `Gracz ${playerName} usunięty z rankingu${resetAllAchievements ? ' (z wszystkimi osiągnięciami)' : ''} (serwer ${guildNameLog}) przez panel admina`, interaction);
@@ -3449,6 +3455,8 @@ class InteractionHandler {
         await interaction.deferReply({ flags: ['Ephemeral'] });
 
         try {
+            const rankingBefore = await this.rankingService.loadRanking(guildId).catch(() => ({}));
+            const playerTimestamp = rankingBefore[targetUser.id]?.timestamp || null;
             const wasRemoved = await this.rankingService.removePlayerFromRanking(targetUser.id, guildId);
 
             if (!wasRemoved) {
@@ -3462,6 +3470,10 @@ class InteractionHandler {
                 await this.roleService.updateTopRoles(interaction.guild, updatedPlayers, guildConfig?.topRoles || null);
                 if (this.achievementService) {
                     await this.achievementService.clearUserAchievements(guildId, targetUser.id);
+                }
+                if (this.scoreHistoryService && playerTimestamp) {
+                    this.scoreHistoryService.removeEntriesAfter(guildId, targetUser.id, playerTimestamp)
+                        .catch(e => logger.warn(`Błąd czyszczenia historii po /remove: ${e.message}`));
                 }
                 await this.logService.logMessage('success', `Gracz ${targetUser.tag} został usunięty z rankingu i zaktualizowano role TOP`, interaction);
             } catch (roleError) {


### PR DESCRIPTION
## Podsumowanie zmian

- **Ranking — wyświetlany wynik:** `/ranking` pokazuje teraz oryginalny string `score` zapisany przy OCR zamiast odtwarzać go przez `formatScore(scoreValue)`. Małe pobicia rekordu (np. `12345B` → `12349B`, oba `12.34T` po zaokrągleniu) są teraz widoczne w rankingu. Dotyczy listy rankingowej, statystyki „najwyższy wynik" i globalnego TOP10.

- **CV tryb testowy (head admin):** Przycisk `⚠️ Zgłoś` pod wynikiem head admina może kliknąć wyłącznie on sam. Jedno kliknięcie uruchamia pełny przepływ zgłoszenia (próg = 1). Inni użytkownicy widzą komunikat `cvVoteHeadAdminOnly`. `_handleCvVote` opakowany w try/catch — błąd nie zostawia interakcji bez odpowiedzi.

- **Czyszczenie historii przy cofaniu wyniku:** Przy akcji CV admina „Usuń rekord", panelowym „Usuń gracza z rankingu" oraz komendzie `/remove` — historia wyników gracza (`wyniki/{userId}.json`) jest czyszczona od timestampu cofniętego rekordu. Usuwany jest sam cofnięty wpis **i wszystkie późniejsze** (pobite na podstawie sfałszowanego wyniku).

## Dotknięte pliki

- `EndersEcho/handlers/interactionHandlers.js`
- `EndersEcho/services/rankingService.js`
- `EndersEcho/services/globalTop10Service.js`
- `EndersEcho/services/communityVerificationService.js`
- `EndersEcho/config/messages.js`
- `EndersEcho/CLAUDE.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkKFYxRQ72Ckdbud7KtAqF)_