### PR TITLE
EndersEcho: naprawiono ranking i cofanie wyników

### DIFF
--- a/EndersEcho/services/achievementService.js
+++ b/EndersEcho/services/achievementService.js
@@ -195,7 +195,7 @@ class AchievementService {
                 userData.progress.recordCount = Math.max(0, (userData.progress.recordCount || 0) - removedRecordCount);
                 const prevTs = previousRecord?.timestamp || null;
                 userData.progress.lastRecordAt = prevTs;
-                userData.progress.lastRecordBeatAt = prevTs;
+                userData.progress.lastRecordBeatAt = fromTimestamp;
             }
             await this.saveData(guildId, data);
         } catch (err) {


### PR DESCRIPTION
$(cat <<'EOF'
## Podsumowanie

- Naprawiono wyświetlanie wyniku w rankingu (string `score` zamiast zaokrąglonego `formatScore(scoreValue)`)
- Naprawiono tryb testowy CV dla head admina (może kliknąć własny przycisk ⚠️ Zgłoś, próg=1)
- Naprawiono czyszczenie historii wyników przy cofaniu rekordu (`wyniki/{userId}.json`)
- Naprawiono kasowanie osiągnięć przy cofaniu — usuwane są tylko te zdobyte od cofniętego rekordu, nie wszystkie
- Naprawiono wyświetlanie "nowych" osiągnięć po cofnięciu + ponownym dodaniu wyniku — `lastRecordBeatAt` ustawiane na timestamp cofniętego rekordu zamiast poprzedniego, dzięki czemu zachowane osiągnięcia nie pojawiają się jako nowe

## Plan testów

- [ ] Cofnij wynik gracza przez CV (przycisk "Usuń rekord") — sprawdź że `wyniki/{userId}.json` traci wpisy od cofniętego rekordu wzwyż
- [ ] Sprawdź że osiągnięcia zdobyte przed cofniętym rekordem pozostają
- [ ] Dodaj nowy wynik po cofnięciu — embed rekordu powinien pokazać tylko NOWE osiągnięcia (nie te już posiadane)
- [ ] Sprawdź `/achievements` — liczba powinna zgadzać się z tym co pokazał embed

https://claude.ai/code/session_01WkKFYxRQ72Ckdbud7KtAqF
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WkKFYxRQ72Ckdbud7KtAqF)_