### PR TITLE
Fix: Invalid string length w EndersEcho — skrócono etykiety modalu blokady

### DIFF
--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -225,7 +225,7 @@ const pol = {
 
     // Modal blokady użytkownika
     blockUserModalTitle: 'Zablokuj użytkownika',
-    blockUserTimeLabel: 'Czas blokady (np. 1h, 7d, 30m) — puste = permanentnie',
+    blockUserTimeLabel: 'Czas blokady (np. 1h, 7d, 30m)',
 
     // /achievements
     achievementsTitle: '🏆 Twoje Osiągnięcia',
@@ -550,7 +550,7 @@ const eng = {
 
     // User block modal
     blockUserModalTitle: 'Block user',
-    blockUserTimeLabel: 'Block duration (e.g. 1h, 7d, 30m) — empty = permanent',
+    blockUserTimeLabel: 'Block duration (e.g. 1h, 7d, 30m)',
 
     // /achievements
     achievementsTitle: '🏆 Your Achievements',

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -2872,7 +2872,7 @@ class InteractionHandler {
         modal.addComponents(new ActionRowBuilder().addComponents(
             new TextInputBuilder()
                 .setCustomId('block_duration')
-                .setLabel(t('Czas blokady (30m, 2h, 7d, 2w — puste = permanentnie)', 'Duration (30m, 2h, 7d, 2w — empty = permanent)'))
+                .setLabel(t('Czas blokady (30m, 2h, 7d, 2w)', 'Duration (30m, 2h, 7d, 2w)'))
                 .setStyle(TextInputStyle.Short)
                 .setPlaceholder(t('Puste = permanentna blokada', 'Empty = permanent block'))
                 .setRequired(false)


### PR DESCRIPTION
## Problem

Błąd `Invalid string length` w `EndersEcho/handlers/interactionHandlers.js:4084` przy wywołaniu `TextInputBuilder.setLabel()`.

Discord API ogranicza etykiety pól tekstowych w modalach do **45 znaków**. Obie etykiety przekraczały ten limit:
- PL: `'Czas blokady (np. 1h, 7d, 30m) — puste = permanentnie'` → 54 znaki ❌
- EN: `'Block duration (e.g. 1h, 7d, 30m) — empty = permanent'` → 55 znaków ❌

## Rozwiązanie

Skrócono etykiety do dopuszczalnego limitu (informacja o permanentnej blokadzie jest już w polu `placeholder`):
- PL: `'Czas blokady (np. 1h, 7d, 30m)'` → 31 znaków ✅
- EN: `'Block duration (e.g. 1h, 7d, 30m)'` → 34 znaki ✅

## Zmieniony plik

`EndersEcho/config/messages.js` — klucz `blockUserTimeLabel` w sekcji `pol` i `eng`

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6bt4BYP7KoXXtU6WQswER)_