### PR TITLE
Rekruter: zmiana etykiety przycisku na angielską

### DIFF
--- a/Rekruter/index.js
+++ b/Rekruter/index.js
@@ -173,7 +173,7 @@ client.once(Events.ClientReady, async () => {
                 .addComponents(
                     new ButtonBuilder()
                         .setCustomId('not_polish')
-                        .setLabel('Nie, nie jestem Polakiem')
+                        .setLabel('No, I\'m not Polish')
                         .setStyle(ButtonStyle.Primary)
                         .setEmoji('<:PepeNie:1185134768464076831>'),
                     new ButtonBuilder()


### PR DESCRIPTION
## Zmiana

Zmieniono etykietę przycisku w bocie Rekruter z `"Nie, nie jestem Polakiem"` na `"No, I'm not Polish"`.

**Plik:** `Rekruter/index.js:176`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WucwMPkNvpmeTLzBisgRqG)_