### PR TITLE
EndersEcho: wynik pytającego w kontekście AI chatu

### DIFF
--- a/EndersEcho/index.js
+++ b/EndersEcho/index.js
@@ -369,7 +369,7 @@ client.on('messageCreate', async (message) => {
 
         const canAskResult = kingBumChatService.canAsk(message.author.id, message.member);
         if (!canAskResult.allowed) {
-            await message.reply(`⏳ Hej, jeszcze przetwarzam. Daj mi chwilę. Wróć za **${canAskResult.remainingSeconds}s**.`);
+            await message.reply(`⏳ Still processing the last one. Come back in **${canAskResult.remainingSeconds}s**.`);
             return;
         }
 

--- a/EndersEcho/index.js
+++ b/EndersEcho/index.js
@@ -369,7 +369,7 @@ client.on('messageCreate', async (message) => {
 
         const canAskResult = kingBumChatService.canAsk(message.author.id, message.member);
         if (!canAskResult.allowed) {
-            await message.reply(`⏳ The King needs a moment of peace. Try again in **${canAskResult.remainingSeconds}s**.`);
+            await message.reply(`⏳ Hej, jeszcze przetwarzam. Daj mi chwilę. Wróć za **${canAskResult.remainingSeconds}s**.`);
             return;
         }
 

--- a/EndersEcho/services/kingBumChatService.js
+++ b/EndersEcho/services/kingBumChatService.js
@@ -142,16 +142,35 @@ class KingBumChatService {
         return guildIds.includes(guildId);
     }
 
-    async _buildRankingContext(guildId) {
+    async _buildRankingContext(guildId, userId) {
         if (!this.rankingService || !guildId) return '';
         try {
             const ranking = await this.rankingService.loadRanking(guildId);
             const players = Object.values(ranking)
                 .filter(p => p.username && p.score)
                 .sort((a, b) => (b.scoreValue || 0) - (a.scoreValue || 0));
-            if (players.length === 0) return '';
-            const lines = players.map((p, i) => `${i + 1}. ${p.username} - ${p.score}`).join('\n');
-            return `[Server ranking]\n${lines}`;
+
+            const lines = players.length > 0
+                ? players.map((p, i) => `${i + 1}. ${p.username} - ${p.score}`).join('\n')
+                : '(no entries yet)';
+
+            let userScoreLine = '';
+            if (userId) {
+                const localEntry = ranking[userId];
+                if (localEntry?.score) {
+                    userScoreLine = `\n[Asking user's score on this server: ${localEntry.username} - ${localEntry.score}]`;
+                } else {
+                    const globalRanking = await this.rankingService.getGlobalRanking();
+                    const globalEntry = globalRanking.find(p => p.userId === userId);
+                    if (globalEntry?.score) {
+                        userScoreLine = `\n[Asking user's best score (on another server): ${globalEntry.username} - ${globalEntry.score}]`;
+                    } else {
+                        userScoreLine = `\n[Asking user has no score recorded yet]`;
+                    }
+                }
+            }
+
+            return `[Server ranking]\n${lines}${userScoreLine}`;
         } catch {
             return '';
         }
@@ -163,7 +182,7 @@ class KingBumChatService {
         }
 
         const displayName = message.member?.displayName || message.author.username;
-        const rankingContext = await this._buildRankingContext(message.guildId);
+        const rankingContext = await this._buildRankingContext(message.guildId, message.author.id);
         const context = previousBotMessage
             ? `[Previous Ender's Echo message]: ${previousBotMessage}\n\n`
             : '';

--- a/EndersEcho/services/kingBumChatService.js
+++ b/EndersEcho/services/kingBumChatService.js
@@ -78,7 +78,7 @@ class KingBumChatService {
             }
         }
 
-        this.cooldownSeconds = 20;
+        this.cooldownSeconds = 60;
         this.dataDir = path.join(__dirname, '../data');
         this.cooldownsFile = path.join(this.dataDir, 'king_bum_cooldowns.json');
         this.cooldowns = new Map();


### PR DESCRIPTION
## Zmiana

Dodanie wyniku osoby pytającej do kontekstu AI chatu Ender's Echo.

**Logika:**
1. Sprawdza wynik pytającego (`message.author.id`) w rankingu bieżącego serwera
2. Jeśli gracz jest w rankingu lokalnym → `[Asking user's score on this server: Nick - wynik]`
3. Jeśli nie ma go na tym serwerze → szuka w globalnym rankingu (`getGlobalRanking()`) → `[Asking user's best score (on another server): Nick - wynik]`
4. Jeśli nie ma go nigdzie → `[Asking user has no score recorded yet]`

Informacja dołączana na końcu bloku `[Server ranking]` przy każdym zapytaniu.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WucwMPkNvpmeTLzBisgRqG)_