### PR TITLE
EndersEcho: Per-boss rekordy i Ranking Bossów

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -339,6 +339,10 @@
 | `boss_map_boss_modal` | Modal z odczytaną nazwą bossa (edytowalną) |
 | `boss_map_boss_sel` | StringSelectMenu — wybór angielskiej nazwy bossa |
 | `boss_map_lang_sel` | StringSelectMenu języka → zapis aliasu z flow mapowania |
+| `boss_cfg_set_img` | Przycisk "🖼️ Przypisz zdjęcie" — otwiera select bossów |
+| `boss_cfg_img_boss_sel` | StringSelectMenu — wybrany boss → czeka na wiadomość ze zdjęciem |
+| `ranking_boss_list` | Przycisk "🎯 Ranking Bossów" w widoku global ranking |
+| `ranking_boss_sel` | StringSelectMenu — wybrany boss → pokazuje per-boss ranking globalny |
 
 **9. System aliasów bossów** — `services/bossAliasService.js` + `data/boss_aliases.json`:
 - **Cel:** Normalizacja nazw bossów z różnych języków → jedna angielska nazwa (np. "Robak" PL → "Shardstone Bug" EN = jeden boss w osiągnięciach).
@@ -347,24 +351,41 @@
 - **Backward compat:** stare pliki JSON przechowujące nazwy jako klucze `aliases{}` (z dawnego `initFromBaseNames`) są rozpoznawane przez `getExtraEnglishNames()` zwracające sumę `englishNames[]` + `Object.keys(aliases{})`.
 - **Obsługiwane języki:** pl, de, fr, es, pt, ru, it, tr, ja, zh, vi, ko (select menu w UI)
 - **Konfiguracja bossów (head admin):** `/manage` → 🎯 Konfiguracja bossów — dwa rzędy przycisków:
-  - **Rząd 1 (boss):** ➕ Dodaj bossa · 🗑️ Usuń bossa · ✏️ Edytuj bossa
+  - **Rząd 1 (boss):** ➕ Dodaj bossa · 🗑️ Usuń bossa · ✏️ Edytuj bossa · 🖼️ Przypisz zdjęcie
   - **Rząd 2 (alias):** ➕ Dodaj alias · 🗑️ Usuń alias · ✏️ Edytuj alias
   - Embed z listą wszystkich bossów (angielskie nazwy) + ich aliasami per język
   - **➕ Nowy boss (EN):** modal → dodaje custom boss poza KNOWN_BOSS_NAMES → `englishNames[]` w JSON
-  - **🔤 Dodaj alias:** boss select → modal (alias) → language select → zapis do `aliases`
+  - **🔤 Dodaj alias:** boss select → modal (alias) → language select → zapis do `aliases` + **automatyczna migracja boss_records** (surowa nazwa → angielska, zachowując lepszy wynik)
   - **🗑️ Usuń alias:** boss select → alias select → usunięcie
+  - **🖼️ Przypisz zdjęcie:** boss select → czeka 60s na wiadomość ze zdjęciem → pobiera attachment → zapisuje do `data/boss_images/{bossName}.{ext}` → ścieżka w `boss_aliases.json` jako `images["BossEN"]`
   - Sesje robocze: `_bossCfgSessions` Map (RAM, per userId)
 - **Wykrywanie nieznanej nazwy:** `correctBossNameFull(raw, bossAliasService)` zwraca `{ corrected, wasUnknown }`. Gdy `wasUnknown=true` i wynik OCR jest prawidłowy: `_runUpdateFlow` wywołuje `_sendUnknownBossEmbed` (fire-and-forget).
 - **Embed nieznanego bossa (czerwony):** wysyłany na `ENDERSECHO_SERVER_LOG_CHANNEL_ID`. Zawiera: nazwę bossa (OCR), gracza (link Discord), komendę, serwer, screenshot. Przycisk: 🔗 Dopasuj do nazwy angielskiej (`boss_mapm_{sessionKey}`).
 - **Flow mapowania (po kliknięciu przycisku):**
   1. Modal z oryginalną nazwą (edytowalna) → `boss_map_boss_modal`
   2. Select angielskiej nazwy bossa → `boss_map_boss_sel`
-  3. Select języka → `boss_map_lang_sel` → zapis aliasu + potwierdzenie
+  3. Select języka → `boss_map_lang_sel` → zapis aliasu + **automatyczna migracja boss_records** + potwierdzenie
   - Sesje: `_unknownBossEmbeds` Map (sessionKey → rawBoss, TTL 48h) + `_bossMapSessions` Map (userId → dane robocze)
 - **Normalizacja w OCR:** `aiOcrService.parseAIResponse` używa `correctBossNameFull(rawBoss, this.bossAliasService)`. Jeśli alias dopasowany → wraca angielska nazwa. Jeśli nie → wraca surowa nazwa + `wasUnknownBoss: true`.
 - **Osiągnięcia:** `bossesEncountered` w achievementService przechowuje znormalizowaną (angielską) nazwę → "Robak PL" i "Shardstone Bug EN" to ten sam boss.
-- **Persistencja:** `data/boss_aliases.json`: `{ englishNames: [], aliases: { "BossEN": { "pl": ["Alias PL"] } } }`. Przeżywa restart bota.
+- **Persistencja:** `data/boss_aliases.json`: `{ englishNames: [], aliases: { "BossEN": { "pl": ["Alias PL"] } }, images: { "BossEN": "filename.png" } }`. Przeżywa restart bota.
 - **Env:** `ENDERSECHO_SERVER_LOG_CHANNEL_ID`
+
+**10. Per-boss rekordy + Ranking Bossów** — `services/bossRecordService.js` + `data/guilds/{guildId}/boss_records.json`:
+- **Cel:** Śledzenie najlepszego wyniku każdego gracza per boss (niezależnie od ogólnego rekordu).
+- **Zapis:** Przy każdym udanym OCR (`_runUpdateFlow`, bez `dryRun`) → `bossRecordService.updateBossRecord(guildId, userId, bossName, ...)`. Jeśli boss nieznany → zapisuje pod surową nazwą OCR.
+- **Migracja:** Gdy admin doda alias przez `boss_cfg_add_lang_sel` lub `boss_map_lang_sel` → automatyczna `migrateBossName(rawName, englishName, allGuildIds)` (fire-and-forget). Zachowuje lepszy wynik jeśli gracz ma rekordy pod obiema nazwami.
+- **Cofanie:** `_cvRemoveRecord` cofa per-boss rekord (`revertBossRecord`) po cofnięciu rekordu ogólnego + osiągnięć. Sesje CV i `_ocrRevertSessions` przechowują `bossName` + `previousBossRecord`.
+- **Embed rekordu:** Pole `🎯 Rekord na bossie` (msgs.bossRecordField) pokazywane gdy `isNewBossRecord = true`, PRZED polem osiągnięć. Dla braku ogólnego rekordu — pole `🎯 Nowy rekord na bossie` (msgs.bossRecordUpdated) w ephemeral embedzie.
+- **Struktura danych:** `data/guilds/{guildId}/boss_records.json` = `{ userId: { bossName: { score, scoreValue, timestamp, username } } }`. Write queue per-guild (`_enqueue`).
+- **Ranking Bossów (globalny):**
+  - Przycisk `🎯 Ranking Bossów` w widoku Global rankingu → `_handleRankingBossList` → StringSelectMenu z bossami mającymi ≥1 rekord (filtruje do znanych angielskich nazw)
+  - Wybór bossa → `_handleRankingBossShow` → globalny ranking per-boss embed (`createBossRankingEmbed`) z thumbnail zdjęcia bossa (jeśli ustawione)
+  - Paginacja: `ranking_prev/next/mypos` (te same przyciski co standardowy ranking; routing przez `_bossRankings.has(messageId)`)
+  - Stan paginacji: `_bossRankings` Map (RAM, per messageId)
+  - Powrót: przyciski `📋 Lista bossów` i `🌐 Global` w `createBossRankingButtons`
+- **Zdjęcia bossów:** Plik zapisywany w `data/boss_images/{safeName}.{ext}`. Ścieżka (tylko `{safeName}.{ext}`) przechowywana w `boss_aliases.json` jako `images["BossEN"]`. Używane jako thumbnail w `createBossRankingEmbed` (AttachmentBuilder + `attachment://filename`).
+- **Filtrowanie rankingów:** `getBossesWithRecords(allGuildIds, knownEnglishNames)` — pokazuje TYLKO bossów z angielską nazwą (admin musi zmapować alias). Nieznane surowe nazwy niewidoczne w UI dopóki nie zostają zmapowane.
 
 **Komenda /configure** — wizard konfiguracji serwera (admin, dowolny kanał):
 - 8-krokowy dashboard ephemeral z przyciskami szarymi→zielonymi po ukończeniu kroku
@@ -454,8 +475,10 @@ EndersEcho/data/
 │       ├── ranking.json           # Ranking serwera (aktualny rekord per gracz)
 │       ├── achievements.json      # Osiągnięcia graczy serwera
 │       ├── role_rankings.json     # Konfiguracja rankingów ról
+│       ├── boss_records.json      # Per-boss rekordy graczy {userId: {bossName: {score, scoreValue, timestamp, username}}}
 │       └── wyniki/
 │           └── {userId}.json      # Historia rekordów gracza na tym serwerze
+├── boss_images/                   # Zdjęcia bossów ({bossName}.{ext})
 ├── notifications.json             # Subskrypcje powiadomień DM
 ├── guild_configs.json             # Per-guild konfiguracja
 ├── update_cooldowns.json          # Cooldowny /update (userId → expiresAt timestamp ms)

--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -321,6 +321,31 @@ const pol = {
     cvUserBlocked: '🔒 Twój wynik zgłoszony przez społeczność. Możliwość przesyłania wyników zablokowana na 24h lub do weryfikacji przez administratora.',
     cvBtnStatusApproved: '✅ Zatwierdzone przez admina',
     cvBtnStatusRemoved: '🗑️ Usunięte przez admina',
+
+    // Per-boss rekord (w embedzie ogłoszenia + w embedzie braku rekordu)
+    bossRecordField: '🎯 Rekord na bossie',
+    bossRecordFirst: 'pierwszy wynik na tym bossie!',
+    bossRecordUpdated: '🎯 Nowy rekord na bossie',
+
+    // Ranking bossów
+    buttonBossRanking: 'Ranking Bossów',
+    bossRankingTitle: '🎯 Ranking',
+    bossRankingSelectTitle: '🎯 Wybierz bossa',
+    bossRankingSelectDesc: 'Wybierz bossa z listy aby zobaczyć globalny ranking.',
+    bossRankingSelectPlaceholder: 'Wybierz bossa...',
+    bossRankingNoBosses: '📭 Brak wyników bossów do wyświetlenia.\nGracze muszą wysyłać screeny przez `/update` aby pojawili się w rankingu.',
+    bossRankingBackList: 'Lista bossów',
+    bossRankingPlayers: 'graczy',
+
+    // Panel bossów — zdjęcie
+    bossCfgSetImg: 'Przypisz zdjęcie',
+    bossCfgImgSelectBoss: 'Wybierz bossa do przypisania zdjęcia:',
+    bossCfgImgSelectPlaceholder: 'Wybierz bossa...',
+    bossCfgImgWaiting: '🖼️ Wyślij zdjęcie bossa jako wiadomość na tym kanale.\nObsługiwane formaty: jpg, png, gif, webp.\n\n⏳ Czekam **60 sekund**...',
+    bossCfgImgSuccess: '✅ Zdjęcie przypisane do bossa **{bossName}**.',
+    bossCfgImgTimeout: '⏱️ Upłynął czas oczekiwania na zdjęcie. Użyj przycisku ponownie.',
+    bossCfgImgNoAttachment: '❌ Wiadomość nie zawiera zdjęcia.',
+    bossCfgImgInvalidType: '❌ Nieobsługiwany format pliku. Użyj: jpg, png, gif, webp.',
 };
 
 const eng = {
@@ -646,6 +671,31 @@ const eng = {
     cvUserBlocked: '🔒 Your score has been reported by the community. Score submission blocked for 24h or until administrator review.',
     cvBtnStatusApproved: '✅ Approved by admin',
     cvBtnStatusRemoved: '🗑️ Removed by admin',
+
+    // Per-boss record (in announcement embed + no-record embed)
+    bossRecordField: '🎯 Boss Record',
+    bossRecordFirst: 'first score on this boss!',
+    bossRecordUpdated: '🎯 New Boss Record',
+
+    // Boss rankings
+    buttonBossRanking: 'Boss Rankings',
+    bossRankingTitle: '🎯 Ranking',
+    bossRankingSelectTitle: '🎯 Select a Boss',
+    bossRankingSelectDesc: 'Choose a boss from the list to view the global ranking.',
+    bossRankingSelectPlaceholder: 'Choose a boss...',
+    bossRankingNoBosses: '📭 No boss records to display yet.\nPlayers need to submit screenshots via `/update` to appear in the ranking.',
+    bossRankingBackList: 'Boss list',
+    bossRankingPlayers: 'players',
+
+    // Boss config panel — image
+    bossCfgSetImg: 'Set Image',
+    bossCfgImgSelectBoss: 'Select a boss to assign an image:',
+    bossCfgImgSelectPlaceholder: 'Select a boss...',
+    bossCfgImgWaiting: '🖼️ Send the boss image as a message in this channel.\nSupported formats: jpg, png, gif, webp.\n\n⏳ Waiting **60 seconds**...',
+    bossCfgImgSuccess: '✅ Image assigned to boss **{bossName}**.',
+    bossCfgImgTimeout: '⏱️ Timed out waiting for an image. Use the button again.',
+    bossCfgImgNoAttachment: '❌ Message contains no image attachment.',
+    bossCfgImgInvalidType: '❌ Unsupported file type. Use: jpg, png, gif, webp.',
 };
 
 module.exports = { pol, eng };

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -24,7 +24,7 @@ function buildGeminiUsage(aiResult) {
 }
 
 class InteractionHandler {
-    constructor(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService, roleRankingConfigService, usageLimitService, tokenUsageService, _botOps, guildConfigService, ocrBlockService, updateCooldownService, testerService, achievementService, communityVerificationService, scoreHistoryService = null, chartService = null, guildBanService = null, globalTop10Service = null, bossAliasService = null, ocrStatsService = null) {
+    constructor(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService, roleRankingConfigService, usageLimitService, tokenUsageService, _botOps, guildConfigService, ocrBlockService, updateCooldownService, testerService, achievementService, communityVerificationService, scoreHistoryService = null, chartService = null, guildBanService = null, globalTop10Service = null, bossAliasService = null, ocrStatsService = null, bossRecordService = null) {
         this.config = config;
         this.ocrService = ocrService;
         this.aiOcrService = aiOcrService;
@@ -48,6 +48,7 @@ class InteractionHandler {
         this.globalTop10Service = globalTop10Service;
         this.bossAliasService = bossAliasService;
         this.ocrStatsService = ocrStatsService;
+        this.bossRecordService = bossRecordService;
         // Tymczasowe sesje dla /info (userId -> { title, description, icon, image })
         // Każda sesja ma TTL 15 minut — timer usuwający ją automatycznie.
         this._infoSessions = new Map();
@@ -66,6 +67,8 @@ class InteractionHandler {
         this._bossCfgSessions = new Map();
         // Sesje cofnięcia wyniku OCR (userId_guildId -> { guildId, userId, previousRecord, newRecord })
         this._ocrRevertSessions = new Map();
+        // Stan paginacji rankingów per-boss (messageId -> { bossName, players, currentPage, totalPages, userId })
+        this._bossRankings = new Map();
     }
 
     /**
@@ -3600,6 +3603,23 @@ class InteractionHandler {
                 await this.logService.logScoreUpdate(userName, bestScore, isNewRecord, guildId);
             }
 
+            // Per-boss rekord (zawsze po pozytywnym OCR, niezależnie od isNewRecord)
+            let isNewBossRecord = false;
+            let previousBossRecord = null;
+            if (!dryRun && bossName && this.bossRecordService) {
+                const bossTs = newRecordTimestamp || new Date().toISOString();
+                const bossScoreValue = this.rankingService.parseScoreValue(bestScore);
+                try {
+                    const bossResult = await this.bossRecordService.updateBossRecord(
+                        guildId, userId, bossName, userName, bestScore, bossScoreValue, bossTs
+                    );
+                    isNewBossRecord = bossResult.isNewBossRecord;
+                    previousBossRecord = bossResult.previousBossRecord;
+                } catch (bossErr) {
+                    gl.error(`Błąd zapisu per-boss rekordu: ${bossErr.message}`);
+                }
+            }
+
             // Pozycja po zapisie (potrzebna do osiągnięć i do embeda)
             let newAchievements = [];
             let currentPositionForAch = 0;
@@ -3639,6 +3659,17 @@ class InteractionHandler {
                     const resultEmbed = this.rankingService.createResultEmbed(
                         userName, bestScore, currentScore.score, imageAttachment.name, bossName, msgs
                     );
+
+                    // Dodaj pole per-boss rekordu jeśli gracz poprawił wynik na tym bossie
+                    if (isNewBossRecord && bossName) {
+                        let bossFieldVal;
+                        if (previousBossRecord) {
+                            bossFieldVal = `**${bossName}:** ${previousBossRecord.score} ➜ ${bestScore}`;
+                        } else {
+                            bossFieldVal = `**${bossName}:** ${bestScore} *(${msgs.bossRecordFirst || 'pierwszy wynik na tym bossie!'})*`;
+                        }
+                        resultEmbed.addFields({ name: msgs.bossRecordUpdated || '🎯 Nowy rekord na bossie', value: bossFieldVal, inline: false });
+                    }
 
                     try {
                         await interaction.editReply({ embeds: [resultEmbed], files: [imageAttachment] });
@@ -3711,7 +3742,8 @@ class InteractionHandler {
                 currentScore ? currentScore.timestamp : null,
                 rolePositions,
                 achievementsFieldValue,
-                globalSnippetData
+                globalSnippetData,
+                isNewBossRecord ? { isNewBossRecord, previousBossRecord, bossName } : null
             );
 
             // Dodaj pole o usuniętym rekordzie z innego serwera (jeśli nowy wynik go pobił)
@@ -3796,6 +3828,7 @@ class InteractionHandler {
                                 previousRecord: previousRecordSnapshot,
                                 newRecord: { score: bestScore, bossName, timestamp: newRecordTimestamp || new Date().toISOString() },
                                 newAchievements,
+                                previousBossRecord: previousBossRecord ?? null,
                             });
                         } catch (cvErr) {
                             gl.warn(`⚠️ community verification session error: ${cvErr.message}`);
@@ -3837,7 +3870,9 @@ class InteractionHandler {
                     guildId,
                     userId,
                     previousRecord: previousRecordSnapshot ?? null,
-                    newRecord: { timestamp: newRecordTimestamp }
+                    newRecord: { timestamp: newRecordTimestamp },
+                    bossName: bossName || null,
+                    previousBossRecord: previousBossRecord ?? null,
                 });
                 setTimeout(() => this._ocrRevertSessions.delete(revertKey), 24 * 60 * 60 * 1000);
                 const revertRow = [new ActionRowBuilder().addComponents(
@@ -3855,7 +3890,9 @@ class InteractionHandler {
                     guildId,
                     userId,
                     previousRecord: previousRecordSnapshot ?? null,
-                    newRecord: { timestamp: newRecordTimestamp }
+                    newRecord: { timestamp: newRecordTimestamp },
+                    bossName: bossName || null,
+                    previousBossRecord: previousBossRecord ?? null,
                 });
                 setTimeout(() => this._ocrRevertSessions.delete(revertKey), 24 * 60 * 60 * 1000);
                 const revertRow = [new ActionRowBuilder().addComponents(
@@ -4646,6 +4683,18 @@ class InteractionHandler {
                 await this._handleBossMapButton(interaction, customId);
                 return;
             }
+            if (customId === 'boss_cfg_set_img') {
+                if (!this._isHeadAdmin(interaction.user.id)) {
+                    await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+                    return;
+                }
+                await this._handleBossCfgSetImg(interaction);
+                return;
+            }
+            if (customId === 'ranking_boss_list') {
+                await this._handleRankingBossList(interaction);
+                return;
+            }
             if (customId === 'panel_ban_guild') {
                 if (!this._isHeadAdmin(interaction.user.id)) {
                     await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
@@ -4692,6 +4741,12 @@ class InteractionHandler {
 
             // === Przyciski paginacji ===
             await interaction.deferUpdate();
+
+            // Sprawdź najpierw czy to ranking bossa (przechowywany w _bossRankings)
+            if (this._bossRankings.has(interaction.message.id)) {
+                await this._handleRankingBossPage(interaction, customId);
+                return;
+            }
 
             const rankingData = this.rankingService.getActiveRanking(interaction.message.id);
 
@@ -5175,6 +5230,16 @@ class InteractionHandler {
             }
         } catch (e) {
             logger.error(`CV _cvRemoveRecord revert achievements error: ${e.message}`);
+        }
+        // Cofnij per-boss rekord
+        if (this.bossRecordService) {
+            const bossNameToRevert = session.newRecord?.bossName ?? session.bossName ?? null;
+            if (bossNameToRevert) {
+                await this.bossRecordService.revertBossRecord(
+                    session.guildId, session.userId, bossNameToRevert,
+                    session.previousBossRecord ?? null
+                ).catch(e => logger.error(`CV _cvRemoveRecord revert boss record error: ${e.message}`));
+            }
         }
     }
 
@@ -5832,6 +5897,20 @@ class InteractionHandler {
                     return;
                 }
                 await this._handleBossMapLangSel(interaction);
+                return;
+            }
+
+            if (customId === 'boss_cfg_img_boss_sel') {
+                if (!this._isHeadAdmin(interaction.user.id)) {
+                    await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+                    return;
+                }
+                await this._handleBossCfgImgBossSel(interaction);
+                return;
+            }
+
+            if (customId === 'ranking_boss_sel') {
+                await this._handleRankingBossShow(interaction);
                 return;
             }
 
@@ -9709,6 +9788,7 @@ class InteractionHandler {
             new ButtonBuilder().setCustomId('boss_cfg_add_name').setEmoji('➕').setLabel(t('Dodaj bossa', 'Add Boss')).setStyle(ButtonStyle.Success),
             new ButtonBuilder().setCustomId('boss_cfg_rm_entry').setEmoji('🗑️').setLabel(t('Usuń bossa', 'Remove Boss')).setStyle(ButtonStyle.Danger).setDisabled(!hasNames),
             new ButtonBuilder().setCustomId('boss_cfg_edit_entry').setEmoji('✏️').setLabel(t('Edytuj bossa', 'Rename Boss')).setStyle(ButtonStyle.Primary).setDisabled(!hasNames),
+            new ButtonBuilder().setCustomId('boss_cfg_set_img').setEmoji('🖼️').setLabel(t('Przypisz zdjęcie', 'Set Image')).setStyle(ButtonStyle.Secondary).setDisabled(!hasNames),
         );
         const row2 = new ActionRowBuilder().addComponents(
             new ButtonBuilder().setCustomId('boss_cfg_add_alias_start').setEmoji('➕').setLabel(t('Dodaj alias', 'Add Alias')).setStyle(ButtonStyle.Success).setDisabled(!hasNames),
@@ -9863,6 +9943,15 @@ class InteractionHandler {
             return;
         }
         this._bossCfgSessions.delete(interaction.user.id);
+        // Migracja boss_records: przenieś rekordy pod surową nazwą aliasu na nazwę angielską
+        if (this.bossRecordService) {
+            const allGuildIds = this.guildConfigService?.getAllConfiguredGuildIds() || [];
+            const rawAlias = session.pendingAlias;
+            const engName = session.pendingBoss;
+            this.bossRecordService.migrateBossName(rawAlias, engName, allGuildIds)
+                .then(count => { if (count > 0) logger.info(`Migracja boss_records: "${rawAlias}" → "${engName}" (${count} graczy)`); })
+                .catch(e => logger.error(`Błąd migracji boss_records: ${e.message}`));
+        }
         await interaction.update({
             embeds: [new EmbedBuilder().setColor(0x57F287)
                 .setTitle(t('✅ Alias dodany', '✅ Alias Added'))
@@ -10369,6 +10458,15 @@ class InteractionHandler {
         }
         // Wyczyszanie sesji
         this._bossMapSessions.delete(interaction.user.id);
+        // Migracja boss_records: przenieś rekordy pod surową nazwą bossa na nazwę angielską
+        if (this.bossRecordService) {
+            const allGuildIds = this.guildConfigService?.getAllConfiguredGuildIds() || [];
+            const rawBoss = session.adjustedBoss;
+            const engName = session.englishBoss;
+            this.bossRecordService.migrateBossName(rawBoss, engName, allGuildIds)
+                .then(count => { if (count > 0) logger.info(`Migracja boss_records: "${rawBoss}" → "${engName}" (${count} graczy)`); })
+                .catch(e => logger.error(`Błąd migracji boss_records: ${e.message}`));
+        }
 
         await interaction.update({
             embeds: [new EmbedBuilder().setColor(0x57F287)
@@ -10382,6 +10480,258 @@ class InteractionHandler {
 
         // Usuń sesję embeda (już przetworzona)
         if (session.sessionKey) this._unknownBossEmbeds.delete(session.sessionKey);
+    }
+
+    // =========================================================================
+    // Boss Config — przypisywanie zdjęć do bossów
+    // =========================================================================
+
+    /** Wyświetla select menu bossów do przypisania zdjęcia */
+    async _handleBossCfgSetImg(interaction) {
+        const t = this._panelT(interaction.guildId);
+        const msgs = this.msgs(interaction.guildId);
+        const allNames = this._getAllEnglishBossNames();
+        if (!allNames.length) {
+            await interaction.update({
+                embeds: [new EmbedBuilder().setColor(0xFEE75C)
+                    .setTitle(t('⚠️ Brak bossów', '⚠️ No Bosses'))
+                    .setDescription(t('Dodaj najpierw bossa angielską nazwą.', 'Add a boss with an English name first.'))],
+                components: [new ActionRowBuilder().addComponents(
+                    new ButtonBuilder().setCustomId('panel_boss_cfg').setEmoji('◀️').setLabel(t('Wróć', 'Back')).setStyle(ButtonStyle.Secondary),
+                )],
+            });
+            return;
+        }
+        const options = allNames.slice(0, 25).map(n =>
+            new StringSelectMenuOptionBuilder().setValue(n).setLabel(n.substring(0, 100))
+        );
+        const select = new StringSelectMenuBuilder()
+            .setCustomId('boss_cfg_img_boss_sel')
+            .setPlaceholder(msgs.bossCfgImgSelectPlaceholder || 'Wybierz bossa...')
+            .addOptions(options);
+        await interaction.update({
+            embeds: [new EmbedBuilder().setColor(0x5865F2)
+                .setTitle(t('🖼️ Przypisz zdjęcie', '🖼️ Set Boss Image'))
+                .setDescription(msgs.bossCfgImgSelectBoss || t('Wybierz bossa do przypisania zdjęcia:', 'Select a boss to assign an image:'))],
+            components: [new ActionRowBuilder().addComponents(select)],
+        });
+    }
+
+    /** Po wyborze bossa — czeka na wiadomość ze zdjęciem przez message collector */
+    async _handleBossCfgImgBossSel(interaction) {
+        const t = this._panelT(interaction.guildId);
+        const msgs = this.msgs(interaction.guildId);
+        const bossName = interaction.values[0];
+
+        await interaction.update({
+            embeds: [new EmbedBuilder().setColor(0x5865F2)
+                .setTitle(t('🖼️ Oczekiwanie na zdjęcie', '🖼️ Waiting for Image'))
+                .setDescription(msgs.bossCfgImgWaiting || t('Wyślij zdjęcie bossa jako wiadomość na tym kanale...', 'Send the boss image as a message in this channel...'))
+                .setFooter({ text: bossName })],
+            components: [],
+        });
+
+        const channel = interaction.channel;
+        if (!channel) return;
+
+        const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+        const ALLOWED_EXTS = ['.jpg', '.jpeg', '.png', '.gif', '.webp'];
+
+        let collected;
+        try {
+            collected = await channel.awaitMessages({
+                filter: m => m.author.id === interaction.user.id && m.attachments.size > 0,
+                max: 1,
+                time: 60_000,
+                errors: ['time'],
+            });
+        } catch {
+            await interaction.followUp({ content: msgs.bossCfgImgTimeout || t('⏱️ Upłynął czas oczekiwania.', '⏱️ Timed out.'), flags: ['Ephemeral'] });
+            return;
+        }
+
+        const msg = collected.first();
+        const attachment = msg.attachments.first();
+        if (!attachment) {
+            await interaction.followUp({ content: msgs.bossCfgImgNoAttachment || t('❌ Brak załącznika.', '❌ No attachment.'), flags: ['Ephemeral'] });
+            return;
+        }
+
+        const ext = path.extname(attachment.name || '').toLowerCase();
+        const contentType = (attachment.contentType || '').split(';')[0].trim();
+        if (!ALLOWED_TYPES.includes(contentType) && !ALLOWED_EXTS.includes(ext)) {
+            await interaction.followUp({ content: msgs.bossCfgImgInvalidType || t('❌ Nieobsługiwany format.', '❌ Unsupported format.'), flags: ['Ephemeral'] });
+            return;
+        }
+
+        // Pobierz i zapisz zdjęcie
+        try {
+            const imgDir = path.join(__dirname, '../data/boss_images');
+            await fs.mkdir(imgDir, { recursive: true });
+            const safeName = bossName.replace(/[^a-zA-Z0-9_\-]/g, '_');
+            const filename = `${safeName}${ext || '.png'}`;
+            const buffer = await downloadBuffer(attachment.url);
+            await fs.writeFile(path.join(imgDir, filename), buffer);
+            await this.bossAliasService.setBossImage(bossName, filename);
+            const successMsg = (msgs.bossCfgImgSuccess || '✅ Zdjęcie przypisane do bossa **{bossName}**.').replace('{bossName}', bossName);
+            await interaction.followUp({ content: successMsg, flags: ['Ephemeral'] });
+            logger.info(`Zdjęcie bossa "${bossName}" zapisane jako ${filename}`);
+        } catch (e) {
+            logger.error(`Błąd zapisu zdjęcia bossa: ${e.message}`);
+            await interaction.followUp({ content: t('❌ Błąd zapisu zdjęcia.', '❌ Failed to save image.'), flags: ['Ephemeral'] });
+        }
+    }
+
+    // =========================================================================
+    // Ranking bossów — lista bossów i per-boss ranking globalny
+    // =========================================================================
+
+    /** Wyświetla select menu z listą bossów mających rekordy */
+    async _handleRankingBossList(interaction) {
+        await interaction.deferUpdate();
+        const msgs = this.msgs(interaction.guildId);
+        if (!this.bossRecordService) {
+            await interaction.editReply({ content: msgs.rankingError, embeds: [], components: [] });
+            return;
+        }
+        const allGuildIds = this.guildConfigService?.getAllConfiguredGuildIds()
+            || Array.from(interaction.client.guilds.cache.keys());
+        const knownNames = this.bossAliasService?.getExtraEnglishNames() || [];
+        const bosses = await this.bossRecordService.getBossesWithRecords(allGuildIds, knownNames);
+
+        if (!bosses.length) {
+            const backRow = new ActionRowBuilder().addComponents(
+                new ButtonBuilder().setCustomId('ranking_select_global').setEmoji('🌐').setLabel(msgs.rankingGlobal || 'Global').setStyle(ButtonStyle.Primary),
+            );
+            await interaction.editReply({
+                embeds: [new EmbedBuilder().setColor(0x5865F2)
+                    .setTitle(msgs.bossRankingSelectTitle || '🎯 Ranking Bossów')
+                    .setDescription(msgs.bossRankingNoBosses || '📭 Brak wyników bossów do wyświetlenia.')],
+                components: [backRow],
+            });
+            return;
+        }
+
+        const options = bosses.slice(0, 25).map(b =>
+            new StringSelectMenuOptionBuilder()
+                .setValue(b.bossName)
+                .setLabel(b.bossName.substring(0, 100))
+                .setDescription(`${b.totalPlayers} ${msgs.bossRankingPlayers || 'graczy'}`)
+        );
+        const select = new StringSelectMenuBuilder()
+            .setCustomId('ranking_boss_sel')
+            .setPlaceholder(msgs.bossRankingSelectPlaceholder || 'Wybierz bossa...')
+            .addOptions(options);
+        const backRow = new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId('ranking_select_global').setEmoji('🌐').setLabel(msgs.rankingGlobal || 'Global').setStyle(ButtonStyle.Secondary),
+        );
+        await interaction.editReply({
+            embeds: [new EmbedBuilder().setColor(0x5865F2)
+                .setTitle(msgs.bossRankingSelectTitle || '🎯 Ranking Bossów')
+                .setDescription(msgs.bossRankingSelectDesc || 'Wybierz bossa z listy aby zobaczyć globalny ranking.')],
+            components: [new ActionRowBuilder().addComponents(select), backRow],
+        });
+    }
+
+    /** Wyświetla globalny ranking dla wybranego bossa */
+    async _handleRankingBossShow(interaction) {
+        await interaction.deferUpdate();
+        const msgs = this.msgs(interaction.guildId);
+        if (!this.bossRecordService) {
+            await interaction.editReply({ content: msgs.rankingError, embeds: [], components: [] });
+            return;
+        }
+        const bossName = interaction.values[0];
+        const allGuildIds = this.guildConfigService?.getAllConfiguredGuildIds()
+            || Array.from(interaction.client.guilds.cache.keys());
+        const players = await this.bossRecordService.getGlobalBossRanking(allGuildIds, bossName);
+
+        const perPage = this.config.ranking.playersPerPage || 10;
+        const totalPages = Math.max(1, Math.ceil(players.length / perPage));
+        const callerIdx = players.findIndex(p => p.userId === interaction.user.id);
+        const userPage = callerIdx !== -1 ? Math.floor(callerIdx / perPage) : null;
+
+        // Zdjęcie bossa
+        let bossImageName = null;
+        let bossImageAttachment = null;
+        if (this.bossAliasService) {
+            const imgPath = this.bossAliasService.getBossImagePath(bossName);
+            if (imgPath) {
+                try {
+                    const fullPath = path.join(__dirname, '../data/boss_images', imgPath);
+                    const buf = await fs.readFile(fullPath);
+                    bossImageName = imgPath;
+                    bossImageAttachment = new AttachmentBuilder(buf, { name: imgPath });
+                } catch { /* bez zdjęcia */ }
+            }
+        }
+
+        const embed = this.rankingService.createBossRankingEmbed(
+            bossName, players, 0, perPage, msgs, bossImageName, interaction.user.id
+        );
+        const buttons = this.rankingService.createBossRankingButtons(0, totalPages, userPage, false, msgs);
+
+        const rankingData = {
+            bossName,
+            players,
+            currentPage: 0,
+            totalPages,
+            userId: interaction.user.id,
+            userPage,
+        };
+        const reply = await interaction.fetchReply();
+        this._bossRankings.set(reply.id, rankingData);
+
+        const replyOpts = { embeds: [embed], components: buttons };
+        if (bossImageAttachment) replyOpts.files = [bossImageAttachment];
+        await interaction.editReply(replyOpts);
+    }
+
+    /** Paginacja rankingu bossa — prev/next/mypos (wywoływana po deferUpdate z caller) */
+    async _handleRankingBossPage(interaction, customId) {
+        const msgs = this.msgs(interaction.guildId);
+        const rankingData = this._bossRankings.get(interaction.message.id);
+        if (!rankingData) {
+            await interaction.editReply({ content: msgs.rankingError, embeds: [], components: [] });
+            return;
+        }
+
+        let newPage = rankingData.currentPage;
+        if (customId.startsWith('ranking_boss_prev_')) newPage = Math.max(0, rankingData.currentPage - 1);
+        else if (customId.startsWith('ranking_boss_next_')) newPage = Math.min(rankingData.totalPages - 1, rankingData.currentPage + 1);
+        else if (customId.startsWith('ranking_boss_mypos_')) newPage = rankingData.userPage ?? rankingData.currentPage;
+
+        rankingData.currentPage = newPage;
+        this._bossRankings.set(interaction.message.id, rankingData);
+
+        const perPage = this.config.ranking.playersPerPage || 10;
+
+        // Zdjęcie bossa
+        let bossImageName = null;
+        let bossImageAttachment = null;
+        if (this.bossAliasService) {
+            const imgPath = this.bossAliasService.getBossImagePath(rankingData.bossName);
+            if (imgPath) {
+                try {
+                    const fullPath = path.join(__dirname, '../data/boss_images', imgPath);
+                    const buf = await fs.readFile(fullPath);
+                    bossImageName = imgPath;
+                    bossImageAttachment = new AttachmentBuilder(buf, { name: imgPath });
+                } catch { /* bez zdjęcia */ }
+            }
+        }
+
+        const embed = this.rankingService.createBossRankingEmbed(
+            rankingData.bossName, rankingData.players, newPage, perPage, msgs, bossImageName, interaction.user.id
+        );
+        const buttons = this.rankingService.createBossRankingButtons(newPage, rankingData.totalPages, rankingData.userPage, false, msgs);
+
+        const replyOpts = { embeds: [embed], components: buttons, attachments: [] };
+        if (bossImageAttachment) {
+            replyOpts.files = [bossImageAttachment];
+            delete replyOpts.attachments;
+        }
+        await interaction.editReply(replyOpts);
     }
 
 } // end InteractionHandler

--- a/EndersEcho/index.js
+++ b/EndersEcho/index.js
@@ -34,6 +34,7 @@ const { fixBossNamesInData } = require('./fix-boss-names');
 const GlobalTop10Service = require('./services/globalTop10Service');
 const { BossAliasService } = require('./services/bossAliasService');
 const OcrStatsService = require('./services/ocrStatsService');
+const BossRecordService = require('./services/bossRecordService');
 const { generateScoreHistoryChart, generateGlobalPlayerGrowthChart, generatePerServerGrowthChart, generatePlayersProgressChart, generateGuildComparisonChart } = require('./services/chartService');
 const { createBotLogger } = require('../utils/consoleLogger');
 const KingBumChatService = require('./services/kingBumChatService');
@@ -110,8 +111,9 @@ const communityVerificationService = new CommunityVerificationService(config.ran
 const guildBanService = new GuildBanService(config.ranking.dataDir);
 const globalTop10Service = new GlobalTop10Service(config.ranking.dataDir, rankingService, guildConfigService, config);
 const ocrStatsService = new OcrStatsService(config.ranking.dataDir, logger);
+const bossRecordService = new BossRecordService(config.ranking.dataDir);
 const kingBumChatService = new KingBumChatService(config, rankingService);
-const interactionHandler = new InteractionHandler(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService, roleRankingConfigService, usageLimitService, tokenUsageService, null, guildConfigService, ocrBlockService, updateCooldownService, testerService, achievementService, communityVerificationService, scoreHistoryService, chartService, guildBanService, globalTop10Service, bossAliasService, ocrStatsService);
+const interactionHandler = new InteractionHandler(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService, roleRankingConfigService, usageLimitService, tokenUsageService, null, guildConfigService, ocrBlockService, updateCooldownService, testerService, achievementService, communityVerificationService, scoreHistoryService, chartService, guildBanService, globalTop10Service, bossAliasService, ocrStatsService, bossRecordService);
 
 /**
  * Inicjalizuje bota EndersEcho

--- a/EndersEcho/migrate-boss-records.js
+++ b/EndersEcho/migrate-boss-records.js
@@ -1,0 +1,180 @@
+'use strict';
+
+/**
+ * Jednorazowy skrypt migracji — wypełnia boss_records.json z historii wyników.
+ *
+ * Źródło: data/guilds/{guildId}/wyniki/{userId}.json
+ *   Każdy wpis: { score, scoreValue, timestamp, bossName }
+ *
+ * Wynik: data/guilds/{guildId}/boss_records.json
+ *   Format: { userId: { bossName: { score, scoreValue, timestamp, username } } }
+ *
+ * Logika:
+ *   - Dla każdego gracza per guild → per bossName zachowuje wpis z największym scoreValue
+ *   - Normalizuje bossName przez bossAliasService (alias → angielska nazwa)
+ *   - Jeśli boss_records.json już istnieje — zachowuje lepszy wynik (nie nadpisuje gorszym)
+ *   - Dodaje username z ranking.json (jeśli brakuje w historii)
+ *
+ * Użycie: node EndersEcho/migrate-boss-records.js [--dry-run]
+ */
+
+const fs = require('fs').promises;
+const fsSync = require('fs');
+const path = require('path');
+
+const DATA_DIR = path.join(__dirname, 'data');
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function loadJson(filePath) {
+    try {
+        const raw = await fs.readFile(filePath, 'utf8');
+        return JSON.parse(raw);
+    } catch {
+        return null;
+    }
+}
+
+async function getAllGuildIds() {
+    const guildsDir = path.join(DATA_DIR, 'guilds');
+    try {
+        const entries = await fs.readdir(guildsDir, { withFileTypes: true });
+        return entries.filter(e => e.isDirectory()).map(e => e.name);
+    } catch {
+        return [];
+    }
+}
+
+// Ładuje bossAliasService żeby normalizować nazwy bossów
+function loadBossAliasService() {
+    try {
+        const { BossAliasService } = require('./services/bossAliasService');
+        return new BossAliasService();
+    } catch (e) {
+        console.warn(`⚠️  Nie można załadować BossAliasService: ${e.message} — normalizacja pominięta`);
+        return null;
+    }
+}
+
+function resolveBossName(rawName, bossAliasService) {
+    if (!bossAliasService || !rawName) return rawName;
+    const resolved = bossAliasService.resolveAlias(rawName);
+    return resolved || rawName;
+}
+
+async function processGuild(guildId, bossAliasService) {
+    const guildDir = path.join(DATA_DIR, 'guilds', guildId);
+    const wynikDir = path.join(guildDir, 'wyniki');
+    const rankingFile = path.join(guildDir, 'ranking.json');
+    const bossRecordsFile = path.join(guildDir, 'boss_records.json');
+
+    // Wczytaj ranking dla uzupełnienia username
+    const ranking = await loadJson(rankingFile) || {};
+    const usernameMap = {};
+    for (const [userId, entry] of Object.entries(ranking)) {
+        usernameMap[userId] = entry.username || entry.name || userId;
+    }
+
+    // Wczytaj istniejące boss_records żeby nie nadpisać lepszego wyniku
+    const existingRecords = await loadJson(bossRecordsFile) || {};
+
+    // Zbierz pliki historii
+    let historyFiles = [];
+    try {
+        historyFiles = await fs.readdir(wynikDir);
+    } catch {
+        // Brak katalogu wyniki — pomiń guild
+        return { guildId, players: 0, bosses: 0, skipped: true };
+    }
+
+    const newRecords = JSON.parse(JSON.stringify(existingRecords)); // kopia
+
+    let totalPlayers = 0;
+    let totalBossEntries = 0;
+
+    for (const file of historyFiles) {
+        if (!file.endsWith('.json')) continue;
+        const userId = file.replace('.json', '');
+        const history = await loadJson(path.join(wynikDir, file));
+        if (!Array.isArray(history) || !history.length) continue;
+
+        const username = usernameMap[userId] || userId;
+
+        // Grupuj per bossName → najlepszy scoreValue
+        const bestPerBoss = {};
+        for (const entry of history) {
+            if (!entry.bossName) continue;
+            const normalized = resolveBossName(entry.bossName, bossAliasService);
+            const scoreValue = typeof entry.scoreValue === 'number' ? entry.scoreValue : -Infinity;
+            if (!bestPerBoss[normalized] || scoreValue > bestPerBoss[normalized].scoreValue) {
+                bestPerBoss[normalized] = {
+                    score: entry.score,
+                    scoreValue,
+                    timestamp: entry.timestamp,
+                    username,
+                };
+            }
+        }
+
+        if (!Object.keys(bestPerBoss).length) continue;
+        totalPlayers++;
+
+        if (!newRecords[userId]) newRecords[userId] = {};
+        for (const [bossName, record] of Object.entries(bestPerBoss)) {
+            const existing = newRecords[userId][bossName];
+            const existingValue = existing?.scoreValue ?? -Infinity;
+            if (record.scoreValue > existingValue) {
+                newRecords[userId][bossName] = record;
+                totalBossEntries++;
+            }
+        }
+    }
+
+    if (!DRY_RUN && totalBossEntries > 0) {
+        await fs.mkdir(guildDir, { recursive: true });
+        await fs.writeFile(bossRecordsFile, JSON.stringify(newRecords, null, 2), 'utf8');
+    }
+
+    return { guildId, players: totalPlayers, bosses: totalBossEntries };
+}
+
+async function main() {
+    console.log(`🎯 Migracja boss_records${DRY_RUN ? ' [DRY RUN]' : ''}`);
+    console.log(`📁 Katalog danych: ${DATA_DIR}\n`);
+
+    const bossAliasService = loadBossAliasService();
+    const guildIds = await getAllGuildIds();
+
+    if (!guildIds.length) {
+        console.log('⚠️  Brak serwerów w data/guilds/ — nic do migracji.');
+        return;
+    }
+
+    console.log(`📋 Znaleziono ${guildIds.length} serwer(ów): ${guildIds.join(', ')}\n`);
+
+    let totalPlayers = 0;
+    let totalBosses = 0;
+
+    for (const guildId of guildIds) {
+        const result = await processGuild(guildId, bossAliasService);
+        if (result.skipped) {
+            console.log(`  ⏭️  Guild ${guildId} — brak katalogu wyniki/, pominięto`);
+            continue;
+        }
+        const action = DRY_RUN ? '[dry]' : '✅';
+        console.log(`  ${action} Guild ${guildId}: ${result.players} graczy, ${result.bosses} nowych wpisów boss_records`);
+        totalPlayers += result.players;
+        totalBosses += result.bosses;
+    }
+
+    console.log(`\n📊 Łącznie: ${totalPlayers} graczy, ${totalBosses} wpisów boss_records`);
+    if (DRY_RUN) {
+        console.log('\n💡 Uruchom bez --dry-run żeby zapisać dane.');
+    } else {
+        console.log('\n✅ Migracja zakończona.');
+    }
+}
+
+main().catch(e => {
+    console.error('❌ Błąd migracji:', e);
+    process.exit(1);
+});

--- a/EndersEcho/services/bossAliasService.js
+++ b/EndersEcho/services/bossAliasService.js
@@ -23,7 +23,7 @@ const SUPPORTED_LANGUAGES = [
 
 class BossAliasService {
     constructor() {
-        this._data = { englishNames: [], aliases: {} };
+        this._data = { englishNames: [], aliases: {}, images: {} };
         this._load();
     }
 
@@ -34,6 +34,7 @@ class BossAliasService {
                 const parsed = JSON.parse(raw);
                 this._data.englishNames = Array.isArray(parsed.englishNames) ? parsed.englishNames : [];
                 this._data.aliases = parsed.aliases && typeof parsed.aliases === 'object' ? parsed.aliases : {};
+                this._data.images = parsed.images && typeof parsed.images === 'object' ? parsed.images : {};
             }
         } catch { /* zostaw domyślne */ }
     }
@@ -194,12 +195,42 @@ class BossAliasService {
     }
 
     /**
-     * Usuwa angielską nazwę bossa wraz ze wszystkimi jej aliasami.
+     * Usuwa angielską nazwę bossa wraz ze wszystkimi jej aliasami i zdjęciem.
      * @param {string} name
      */
     async removeEnglishName(name) {
         this._data.englishNames = (this._data.englishNames || []).filter(n => n !== name);
         if (this._data.aliases) delete this._data.aliases[name];
+        if (this._data.images) delete this._data.images[name];
+        await this._save();
+    }
+
+    /**
+     * Zwraca ścieżkę do pliku zdjęcia bossa (względem katalogu data/) lub null.
+     * @param {string} bossName - angielska nazwa bossa
+     * @returns {string|null}
+     */
+    getBossImagePath(bossName) {
+        return this._data.images?.[bossName] || null;
+    }
+
+    /**
+     * Zapisuje ścieżkę do zdjęcia bossa.
+     * @param {string} bossName
+     * @param {string} relativePath - względna ścieżka od katalogu data/
+     */
+    async setBossImage(bossName, relativePath) {
+        if (!this._data.images) this._data.images = {};
+        this._data.images[bossName] = relativePath;
+        await this._save();
+    }
+
+    /**
+     * Usuwa zdjęcie bossa z danych (nie usuwa pliku z dysku).
+     * @param {string} bossName
+     */
+    async removeBossImage(bossName) {
+        if (this._data.images) delete this._data.images[bossName];
         await this._save();
     }
 
@@ -219,6 +250,11 @@ class BossAliasService {
         if (this._data.aliases && oldName in this._data.aliases) {
             this._data.aliases[trimmed] = this._data.aliases[oldName];
             delete this._data.aliases[oldName];
+        }
+
+        if (this._data.images && oldName in this._data.images) {
+            this._data.images[trimmed] = this._data.images[oldName];
+            delete this._data.images[oldName];
         }
 
         await this._save();

--- a/EndersEcho/services/bossRecordService.js
+++ b/EndersEcho/services/bossRecordService.js
@@ -1,0 +1,161 @@
+'use strict';
+
+const fs = require('fs').promises;
+const path = require('path');
+
+class BossRecordService {
+    constructor(dataDir) {
+        this.dataDir = dataDir;
+        this._queues = new Map(); // guildId → Promise (kolejka zapisu per-guild)
+    }
+
+    _file(guildId) {
+        return path.join(this.dataDir, 'guilds', guildId, 'boss_records.json');
+    }
+
+    async _load(guildId) {
+        try {
+            const raw = await fs.readFile(this._file(guildId), 'utf8');
+            return JSON.parse(raw);
+        } catch {
+            return {};
+        }
+    }
+
+    async _save(guildId, data) {
+        const file = this._file(guildId);
+        await fs.mkdir(path.dirname(file), { recursive: true });
+        await fs.writeFile(file, JSON.stringify(data, null, 2), 'utf8');
+    }
+
+    _enqueue(guildId, fn) {
+        const prev = this._queues.get(guildId) || Promise.resolve();
+        const next = prev.then(fn).catch(err => { throw err; });
+        this._queues.set(guildId, next.catch(() => {}));
+        return next;
+    }
+
+    /**
+     * Aktualizuje rekord per-boss gracza jeśli nowy wynik jest lepszy.
+     * Wywoływane zawsze po pozytywnym OCR — niezależnie od wyniku rekordu ogólnego.
+     * @returns {{ isNewBossRecord: boolean, previousBossRecord: object|null }}
+     */
+    async updateBossRecord(guildId, userId, bossName, username, score, scoreValue, timestamp) {
+        return this._enqueue(guildId, async () => {
+            const data = await this._load(guildId);
+            if (!data[userId]) data[userId] = {};
+            const existing = data[userId][bossName];
+            const existingValue = existing && typeof existing.scoreValue === 'number' ? existing.scoreValue : -Infinity;
+            if (scoreValue <= existingValue) {
+                return { isNewBossRecord: false, previousBossRecord: existing ? { ...existing } : null };
+            }
+            const previousBossRecord = existing ? { ...existing } : null;
+            data[userId][bossName] = { score, scoreValue, timestamp, username };
+            await this._save(guildId, data);
+            return { isNewBossRecord: true, previousBossRecord };
+        });
+    }
+
+    /**
+     * Cofnięcie rekordu per-boss (CV remove / ocr revert).
+     * previousBossRecord = null → usuwa rekord bossa dla gracza.
+     */
+    async revertBossRecord(guildId, userId, bossName, previousBossRecord) {
+        return this._enqueue(guildId, async () => {
+            const data = await this._load(guildId);
+            if (!data[userId]) return;
+            if (previousBossRecord) {
+                data[userId][bossName] = { ...previousBossRecord };
+            } else {
+                delete data[userId][bossName];
+                if (Object.keys(data[userId]).length === 0) delete data[userId];
+            }
+            await this._save(guildId, data);
+        });
+    }
+
+    /**
+     * Globalny ranking graczy wg najlepszego wyniku na danym bossie (cross-guild).
+     * @param {string[]} allGuildIds
+     * @param {string} bossName - angielska nazwa bossa
+     * @returns {Array<{ userId, username, score, scoreValue, timestamp, sourceGuildId }>}
+     */
+    async getGlobalBossRanking(allGuildIds, bossName) {
+        const bestPerPlayer = new Map();
+        for (const guildId of allGuildIds) {
+            const data = await this._load(guildId);
+            for (const [userId, bosses] of Object.entries(data)) {
+                const entry = bosses[bossName];
+                if (!entry) continue;
+                const prev = bestPerPlayer.get(userId);
+                if (!prev || entry.scoreValue > prev.scoreValue) {
+                    bestPerPlayer.set(userId, { ...entry, sourceGuildId: guildId });
+                }
+            }
+        }
+        return Array.from(bestPerPlayer.entries())
+            .map(([userId, entry]) => ({ userId, ...entry }))
+            .sort((a, b) => b.scoreValue - a.scoreValue);
+    }
+
+    /**
+     * Lista bossów które mają ≥1 rekord, filtrowana do znanych angielskich nazw.
+     * Surowe/nieznane nazwy są niewidoczne w rankingach dopóki nie zostaną zmapowane.
+     * @param {string[]} allGuildIds
+     * @param {string[]} knownEnglishNames - z bossAliasService.getExtraEnglishNames()
+     * @returns {Array<{ bossName: string, totalPlayers: number }>} posortowane alfabetycznie
+     */
+    async getBossesWithRecords(allGuildIds, knownEnglishNames) {
+        const knownSet = new Set(knownEnglishNames);
+        const bossPlayers = new Map();
+        for (const guildId of allGuildIds) {
+            const data = await this._load(guildId);
+            for (const [userId, bosses] of Object.entries(data)) {
+                for (const bossName of Object.keys(bosses)) {
+                    if (!knownSet.has(bossName)) continue;
+                    if (!bossPlayers.has(bossName)) bossPlayers.set(bossName, new Set());
+                    bossPlayers.get(bossName).add(userId);
+                }
+            }
+        }
+        return Array.from(bossPlayers.entries())
+            .map(([bossName, players]) => ({ bossName, totalPlayers: players.size }))
+            .sort((a, b) => a.bossName.localeCompare(b.bossName));
+    }
+
+    /**
+     * Migracja: przenosi rekordy z surowej/starej nazwy bossa do angielskiej.
+     * Wywoływana po dodaniu aliasu przez admina (boss_map_lang_sel, boss_cfg_add_lang_sel).
+     * Jeśli gracz ma rekordy pod obiema nazwami — zachowuje lepszy wynik.
+     * @param {string} rawName - stara/surowa nazwa bossa
+     * @param {string} englishName - angielska nazwa (cel)
+     * @param {string[]} allGuildIds
+     * @returns {number} liczba zmigrowanych wpisów graczy
+     */
+    async migrateBossName(rawName, englishName, allGuildIds) {
+        if (rawName === englishName) return 0;
+        let migratedCount = 0;
+        for (const guildId of allGuildIds) {
+            await this._enqueue(guildId, async () => {
+                const data = await this._load(guildId);
+                let changed = false;
+                for (const [userId, bosses] of Object.entries(data)) {
+                    const rawEntry = bosses[rawName];
+                    if (!rawEntry) continue;
+                    const engEntry = bosses[englishName];
+                    if (!engEntry || rawEntry.scoreValue > engEntry.scoreValue) {
+                        data[userId][englishName] = { ...rawEntry };
+                    }
+                    delete data[userId][rawName];
+                    if (Object.keys(data[userId]).length === 0) delete data[userId];
+                    changed = true;
+                    migratedCount++;
+                }
+                if (changed) await this._save(guildId, data);
+            });
+        }
+        return migratedCount;
+    }
+}
+
+module.exports = BossRecordService;

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -592,7 +592,94 @@ class RankingService {
             backBtn
         );
 
+        // W trybie global dodaj dodatkowy rząd z przyciskiem Ranking Bossów
+        if (mode === 'global') {
+            const bossRow = new ActionRowBuilder().addComponents(
+                new ButtonBuilder()
+                    .setCustomId('ranking_boss_list')
+                    .setEmoji('🎯')
+                    .setLabel(msgs.buttonBossRanking || 'Ranking Bossów')
+                    .setStyle(ButtonStyle.Primary)
+                    .setDisabled(disabled)
+            );
+            return [navRow, bossRow, ...roleRows];
+        }
+
         return [navRow, ...roleRows];
+    }
+
+    /**
+     * Tworzy przyciski nawigacji dla rankingu bossa (tryb 'boss').
+     */
+    createBossRankingButtons(page, totalPages, userPage, disabled, messages) {
+        const msgs = messages || this.config.messages;
+        const navRow = new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId('ranking_prev')
+                .setEmoji('◀️')
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(disabled || page === 0),
+
+            new ButtonBuilder()
+                .setCustomId('ranking_mypos')
+                .setEmoji('🎯')
+                .setLabel(msgs.buttonMyPos || 'Moja pozycja')
+                .setStyle(ButtonStyle.Primary)
+                .setDisabled(disabled || userPage === null),
+
+            new ButtonBuilder()
+                .setCustomId('ranking_next')
+                .setEmoji('▶️')
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(disabled || page >= totalPages - 1),
+
+            new ButtonBuilder()
+                .setCustomId('ranking_boss_list')
+                .setEmoji('📋')
+                .setLabel(msgs.bossRankingBackList || 'Lista bossów')
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(disabled),
+
+            new ButtonBuilder()
+                .setCustomId('ranking_select_global')
+                .setEmoji('🌐')
+                .setLabel(msgs.buttonGlobal || 'Global')
+                .setStyle(ButtonStyle.Danger)
+                .setDisabled(disabled)
+        );
+        return [navRow];
+    }
+
+    /**
+     * Tworzy embed rankingu bossa (globalny, tryb 'boss').
+     */
+    createBossRankingEmbed(bossName, players, page, perPage, messages, bossImageName = null, callerUserId = null) {
+        const msgs = messages || this.config.messages;
+        const startIdx = page * perPage;
+        const pagePlayers = players.slice(startIdx, startIdx + perPage);
+        const totalPages = Math.max(1, Math.ceil(players.length / perPage));
+
+        const medals = ['🥇', '🥈', '🥉'];
+        const lines = pagePlayers.map((p, idx) => {
+            const rank = startIdx + idx + 1;
+            const medal = rank <= 3 ? medals[rank - 1] : `**#${rank}**`;
+            const tag = p.sourceGuildId ? '' : '';
+            const isMe = p.userId === callerUserId ? ' 👈' : '';
+            return `${medal} **${p.username || p.userId}** — ${p.score}${isMe}`;
+        });
+
+        const embed = new EmbedBuilder()
+            .setColor(0x5865F2)
+            .setTitle(`${msgs.bossRankingTitle || '🎯 Ranking'} — ${bossName}`)
+            .setDescription(lines.length > 0 ? lines.join('\n') : (msgs.rankingEmpty || 'Brak wyników.'))
+            .setFooter({ text: `${msgs.rankingPage?.replace('{current}', page + 1).replace('{total}', totalPages) || `Strona ${page + 1} z ${totalPages}`} · ${players.length} ${msgs.bossRankingPlayers || 'graczy'}` })
+            .setTimestamp();
+
+        if (bossImageName) {
+            embed.setThumbnail(`attachment://${bossImageName}`);
+        }
+
+        return embed;
     }
 
     /**
@@ -821,7 +908,7 @@ class RankingService {
         return parts.join(' ');
     }
 
-    async createRecordEmbed(userName, bestScore, userAvatarUrl, attachmentName, previousScore = null, userId = null, guildId = null, messages = null, guild = null, guildTopRoles = null, previousTimestamp = null, rolePositions = [], achievementsFieldValue = null, globalSnippetData = null) {
+    async createRecordEmbed(userName, bestScore, userAvatarUrl, attachmentName, previousScore = null, userId = null, guildId = null, messages = null, guild = null, guildTopRoles = null, previousTimestamp = null, rolePositions = [], achievementsFieldValue = null, globalSnippetData = null, bossRecordData = null) {
         const msgs = messages || this.config.messages;
 
         // Oblicz postęp i poprawę w jednej linii
@@ -934,6 +1021,17 @@ class RankingService {
 
         if (globalSnippetData) {
             embed.addFields({ name: globalSnippetData.title, value: globalSnippetData.description, inline: false });
+        }
+
+        // Per-boss rekord (tuż przed osiągnięciami)
+        if (bossRecordData?.isNewBossRecord && bossRecordData.bossName) {
+            let bossFieldVal;
+            if (bossRecordData.previousBossRecord) {
+                bossFieldVal = `**${bossRecordData.bossName}:** ${bossRecordData.previousBossRecord.score} ➜ ${bestScore}`;
+            } else {
+                bossFieldVal = `**${bossRecordData.bossName}:** ${bestScore} *(${msgs.bossRecordFirst || 'pierwszy wynik na tym bossie!'})*`;
+            }
+            embed.addFields({ name: msgs.bossRecordField || '🎯 Rekord na bossie', value: bossFieldVal, inline: false });
         }
 
         if (achievementsFieldValue) {


### PR DESCRIPTION
## Podsumowanie

- **Per-boss rekordy** (`bossRecordService.js`) — śledzenie najlepszego wyniku gracza per boss, niezależnie od ogólnego rekordu
- **Ranking Bossów** — przycisk `🎯 Ranking Bossów` w widoku Global → lista bossów → per-boss ranking globalny z zdjęciem bossa
- **Zdjęcia bossów** — nowy przycisk `🖼️ Przypisz zdjęcie` w panelu konfiguracji bossów; obraz pobierany z wiadomości i zapisywany do `data/boss_images/`
- **Automatyczna migracja** — gdy admin doda alias, bot przenosi rekordy z surowej nazwy na angielską we wszystkich serwerach
- **Rollback** — `_cvRemoveRecord` i `_ocrRevertSessions` cofają per-boss rekordy razem z ogólnymi
- **Embed ogłoszeń** — pole `🎯 Rekord na bossie` pojawia się przed osiągnięciami gdy gracz pobije swój rekord na danym bossie

## Plan testów

- [ ] `/update` ze screenshotem — sprawdź czy pojawia się pole "Rekord na bossie" w embedzie ogłoszenia
- [ ] Gracz bez ogólnego rekordu, ale z nowym boss rekordem — sprawdź ephemeral z polem "Nowy rekord na bossie"
- [ ] `/ranking` → Global → przycisk 🎯 Ranking Bossów → wybierz bossa → sprawdź embed i paginację
- [ ] Panel `/manage` → Konfiguracja bossów → 🖼️ Przypisz zdjęcie — wyślij zdjęcie i sprawdź thumbnail w rankingu bossa
- [ ] Dodaj alias przez panel → sprawdź logi migracji `boss_records`
- [ ] CV "Usuń rekord" — sprawdź że per-boss rekord też jest cofany

https://claude.ai/code/session_016VFS6p9LsXZ7wZBbCekjKY

---
_Generated by [Claude Code](https://claude.ai/code/session_016VFS6p9LsXZ7wZBbCekjKY)_