### PR TITLE
EndersEcho: poprawki rankingów bossów i obsługa nieznanej nazwy bossa

### DIFF
--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -331,6 +331,7 @@ const pol = {
     bossRecordOnlyStatus: '🎯 Pobito rekord na bossie! Rekord globalny bez zmian (obecny: {currentScore})',
     unknownBossAccepted: '⚠️ Wynik zapamiętany — nazwa bossa nierozpoznana. Po weryfikacji przez admina wpis zostanie zaktualizowany lub usunięty z rankingu.',
     unknownBossRankingNotice: '⚠️ Wykryto **nową nazwę bossa**: *{bossName}*\nWynik **nie pojawi się w rankingu bossów** do czasu weryfikacji przez admina.\nPo weryfikacji: nazwa zostanie dodana jako alias lub wynik zostanie cofnięty do poprzedniego stanu.',
+    unknownBossRankingField: '⚠️ Niezweryfikowana nazwa bossa',
     bossRecordOnlyConfirmed: '✅ **Nowy rekord na bossie ogłoszony!** 🎯 Twój wynik na tym bossie został opublikowany.',
     bossRecordPublicTitle: '🎯 Nowy Rekord Bossa!',
 
@@ -688,6 +689,7 @@ const eng = {
     bossRecordOnlyStatus: '🎯 Boss record beaten! Global record unchanged (current: {currentScore})',
     unknownBossAccepted: '⚠️ Score noted — boss name unrecognized. After admin verification, the entry will be updated or removed from the ranking.',
     unknownBossRankingNotice: '⚠️ **New boss name** detected: *{bossName}*\nThe score **won\'t appear in the boss ranking** until verified by an admin.\nAfter verification: the name will be added as an alias or the score will be reverted.',
+    unknownBossRankingField: '⚠️ Unverified Boss Name',
     bossRecordOnlyConfirmed: '✅ **New boss record announced!** 🎯 Your score on this boss has been published.',
     bossRecordPublicTitle: '🎯 New Boss Record!',
 

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -3810,7 +3810,7 @@ class InteractionHandler {
                         msgs.unknownBossRankingNotice || '⚠️ Wykryto nową nazwę bossa: *{bossName}*\nWynik nie pojawi się w rankingu bossów do czasu weryfikacji przez admina.',
                         { bossName }
                     );
-                    bossPublicEmbed.addFields({ name: '⚠️ Niezweryfikowana nazwa bossa', value: noticeVal, inline: false });
+                    bossPublicEmbed.addFields({ name: msgs.unknownBossRankingField || '⚠️ Unverified Boss Name', value: noticeVal, inline: false });
                 }
 
                 gl.info(`🎯 [/${commandName}] Pobito rekord na bossie "${bossName}"${wasUnknownBoss ? ' (nieznany boss)' : ''} (rekord globalny bez zmian)`);
@@ -3979,7 +3979,7 @@ class InteractionHandler {
                     msgs.unknownBossRankingNotice || '⚠️ Wykryto nową nazwę bossa: *{bossName}*\nWynik nie pojawi się w rankingu bossów do czasu weryfikacji przez admina.',
                     { bossName }
                 );
-                publicEmbed.addFields({ name: '⚠️ Niezweryfikowana nazwa bossa', value: noticeVal, inline: false });
+                publicEmbed.addFields({ name: msgs.unknownBossRankingField || '⚠️ Unverified Boss Name', value: noticeVal, inline: false });
             }
 
             // Dodaj pole o usuniętym rekordzie z innego serwera (jeśli nowy wynik go pobił)


### PR DESCRIPTION
## Podsumowanie

- **Pozycja bossa w embedzie globalnego rekordu** — gdy gracz pobija rekord globalny i jednocześnie bossowy, w opisie embeda pojawia się linia `🎯 Pozycja (boss): 🏅 #7 *(awans o +5)*` obok globalnej pozycji
- **Snippet „Zmiana w rankingu bossa"** — pole z 3 graczami (powyżej/gracz/poniżej) teraz pojawia się też przy pobiciu globalnego rekordu, nie tylko boss-only; `_buildBossSnippetData` zwraca `{ snippetData, override }` w jednym API call
- **Log zmiany pozycji bossa** — linia logu pokazuje teraz `🎯 Snippet bossa "Name": 8 → #7` zamiast ogólnego komunikatu
- **Nieznana nazwa bossa** — gdy boss nie jest w bazie aliasów, embed **nie pokazuje** informacji o rankingu bossów; zamiast tego pojawia się pole `⚠️ Unverified Boss Name / Niezweryfikowana nazwa bossa` z informacją, że wynik nie pojawi się w rankingu do czasu weryfikacji przez admina; dwujęzyczne (`pol`/`eng`)

## Test plan

- [ ] Pobij rekord globalny na bossie który jest w bazie → oba pola pozycji (globalna + bossa) widoczne w embedzie
- [ ] Pobij tylko rekord bossa → pole pozycji bossa i snippet widoczne w embed
- [ ] Wrzuć wynik z nieznaną nazwą bossa → brak pól rankingowych bossa, widoczne pole `⚠️ Unverified Boss Name` z komunikatem weryfikacji
- [ ] Sprawdź komunikat na serwerze `eng` i `pol` — nagłówki i treść w odpowiednim języku

---
_Generated by [Claude Code](https://claude.ai/code/session_016VFS6p9LsXZ7wZBbCekjKY)_