### PR TITLE
EndersEcho: rankingi bossów — pozycja, ikona, nieznany boss

### DIFF
--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -78,7 +78,7 @@ const pol = {
     recordNewScore: '🏆 Wynik',
     recordProgress: '📈 Progres',
     recordRanking: '🏅 Pozycja',
-    recordBossRanking: '🎯 Pozycja (boss)',
+    recordBossRanking: '👾 Pozycja (boss)',
     recordPromotionBy: 'awans o',
     recordNewEntry: 'nowy w rankingu',
     recordDateLabel: '📅 Data',
@@ -122,7 +122,7 @@ const pol = {
 
     // Global TOP snippet (pod wynikiem)
     globalSnippetTitle: '🌐 Zmiana w globalnym rankingu',
-    bossSnippetTitle: '🎯 Zmiana w rankingu bossa',
+    bossSnippetTitle: '👾 Zmiana w rankingu bossa',
 
     // Global TOP10 cykliczny raport
     globalTop10ReportTitle: '🌐 TOP 10 Globalny',
@@ -325,20 +325,20 @@ const pol = {
     cvBtnStatusRemoved: '🗑️ Usunięte przez admina',
 
     // Per-boss rekord (w embedzie ogłoszenia + w embedzie braku rekordu)
-    bossRecordField: '🎯 Rekord na bossie',
+    bossRecordField: '👾 Rekord na bossie',
     bossRecordFirst: 'pierwszy wynik na tym bossie!',
-    bossRecordUpdated: '🎯 Nowy rekord na bossie',
-    bossRecordOnlyStatus: '🎯 Pobito rekord na bossie! Rekord globalny bez zmian (obecny: {currentScore})',
+    bossRecordUpdated: '👾 Nowy rekord na bossie',
+    bossRecordOnlyStatus: '👾 Pobito rekord na bossie! Rekord globalny bez zmian (obecny: {currentScore})',
     unknownBossAccepted: '⚠️ Wynik zapamiętany — nazwa bossa nierozpoznana. Po weryfikacji przez admina wpis zostanie zaktualizowany lub usunięty z rankingu.',
     unknownBossRankingNotice: '⚠️ Wykryto **nową nazwę bossa**: *{bossName}*\nWynik **nie pojawi się w rankingu bossów** do czasu weryfikacji przez admina.\nPo weryfikacji: nazwa zostanie dodana jako alias lub wynik zostanie cofnięty do poprzedniego stanu.',
     unknownBossRankingField: '⚠️ Niezweryfikowana nazwa bossa',
-    bossRecordOnlyConfirmed: '✅ **Nowy rekord na bossie ogłoszony!** 🎯 Twój wynik na tym bossie został opublikowany.',
-    bossRecordPublicTitle: '🎯 Nowy Rekord Bossa!',
+    bossRecordOnlyConfirmed: '✅ **Nowy rekord na bossie ogłoszony!** 👾 Twój wynik na tym bossie został opublikowany.',
+    bossRecordPublicTitle: '👾 Nowy Rekord Bossa!',
 
     // Ranking bossów
     buttonBossRanking: 'Ranking Bossów',
-    bossRankingTitle: '🎯 Ranking',
-    bossRankingSelectTitle: '🎯 Wybierz bossa',
+    bossRankingTitle: '👾 Ranking',
+    bossRankingSelectTitle: '👾 Wybierz bossa',
     bossRankingSelectDesc: 'Wybierz bossa z listy aby zobaczyć globalny ranking.',
     bossRankingSelectPlaceholder: 'Wybierz bossa...',
     bossRankingNoBosses: '📭 Brak wyników bossów do wyświetlenia.\nGracze muszą wysyłać screeny przez `/update` aby pojawili się w rankingu.',
@@ -436,7 +436,7 @@ const eng = {
     recordNewScore: '🏆 Score',
     recordProgress: '📈 Progress',
     recordRanking: '🏅 Position',
-    recordBossRanking: '🎯 Position (boss)',
+    recordBossRanking: '👾 Position (boss)',
     recordPromotionBy: 'promoted by',
     recordNewEntry: 'new entry',
     recordDateLabel: '📅 Date',
@@ -480,7 +480,7 @@ const eng = {
 
     // Global TOP snippet (under result)
     globalSnippetTitle: '🌐 Global Ranking Change',
-    bossSnippetTitle: '🎯 Boss Ranking Change',
+    bossSnippetTitle: '👾 Boss Ranking Change',
 
     // Global TOP10 periodic report
     globalTop10ReportTitle: '🌐 Global TOP 10',
@@ -683,20 +683,20 @@ const eng = {
     cvBtnStatusRemoved: '🗑️ Removed by admin',
 
     // Per-boss record (in announcement embed + no-record embed)
-    bossRecordField: '🎯 Boss Record',
+    bossRecordField: '👾 Boss Record',
     bossRecordFirst: 'first score on this boss!',
-    bossRecordUpdated: '🎯 New Boss Record',
-    bossRecordOnlyStatus: '🎯 Boss record beaten! Global record unchanged (current: {currentScore})',
+    bossRecordUpdated: '👾 New Boss Record',
+    bossRecordOnlyStatus: '👾 Boss record beaten! Global record unchanged (current: {currentScore})',
     unknownBossAccepted: '⚠️ Score noted — boss name unrecognized. After admin verification, the entry will be updated or removed from the ranking.',
     unknownBossRankingNotice: '⚠️ **New boss name** detected: *{bossName}*\nThe score **won\'t appear in the boss ranking** until verified by an admin.\nAfter verification: the name will be added as an alias or the score will be reverted.',
     unknownBossRankingField: '⚠️ Unverified Boss Name',
-    bossRecordOnlyConfirmed: '✅ **New boss record announced!** 🎯 Your score on this boss has been published.',
-    bossRecordPublicTitle: '🎯 New Boss Record!',
+    bossRecordOnlyConfirmed: '✅ **New boss record announced!** 👾 Your score on this boss has been published.',
+    bossRecordPublicTitle: '👾 New Boss Record!',
 
     // Boss rankings
     buttonBossRanking: 'Boss Rankings',
-    bossRankingTitle: '🎯 Ranking',
-    bossRankingSelectTitle: '🎯 Select a Boss',
+    bossRankingTitle: '👾 Ranking',
+    bossRankingSelectTitle: '👾 Select a Boss',
     bossRankingSelectDesc: 'Choose a boss from the list to view the global ranking.',
     bossRankingSelectPlaceholder: 'Choose a boss...',
     bossRankingNoBosses: '📭 No boss records to display yet.\nPlayers need to submit screenshots via `/update` to appear in the ranking.',

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -2229,7 +2229,7 @@ class InteractionHandler {
                     new ButtonBuilder().setCustomId('panel_process_roles').setEmoji('🔁').setLabel(t('Przetwórz role', 'Process Roles')).setStyle(ButtonStyle.Primary),
                 ),
                 new ActionRowBuilder().addComponents(
-                    new ButtonBuilder().setCustomId('panel_boss_cfg').setEmoji('🎯').setLabel(t('Konfiguracja bossów', 'Boss Configuration')).setStyle(ButtonStyle.Primary),
+                    new ButtonBuilder().setCustomId('panel_boss_cfg').setEmoji('👾').setLabel(t('Konfiguracja bossów', 'Boss Configuration')).setStyle(ButtonStyle.Primary),
                     new ButtonBuilder().setCustomId('panel_ban_server').setEmoji('🚫').setLabel(t('Zbanuj serwer', 'Ban Server')).setStyle(ButtonStyle.Danger),
                     back,
                 ),
@@ -2302,8 +2302,8 @@ class InteractionHandler {
                   '🧪 **Testers** — manage the list of testers authorized to use `/test`.'),
                 t('📅 **Interwał TOP10** — ustaw datę i godzinę pierwszego raportu TOP10 globalnego (potem co ~3 dni automatycznie).',
                   '📅 **TOP10 Interval** — set the date and time of the first global TOP10 report (then automatically every ~3 days).'),
-                t('🎯 **Konfiguracja bossów** — zarządzaj angielskimi nazwami bossów i ich aliasami w innych językach (automatyczna normalizacja OCR).',
-                  '🎯 **Boss Configuration** — manage English boss names and their aliases in other languages (automatic OCR normalization).'),
+                t('👾 **Konfiguracja bossów** — zarządzaj angielskimi nazwami bossów i ich aliasami w innych językach (automatyczna normalizacja OCR).',
+                  '👾 **Boss Configuration** — manage English boss names and their aliases in other languages (automatic OCR normalization).'),
                 t('🚫 **Zbanuj serwer** — wyrzuć bota z wybranego serwera i zablokuj możliwość ponownego dodania go do tego serwera.',
                   '🚫 **Ban Server** — remove the bot from a selected server and prevent it from being re-added to that server.'),
             );
@@ -10068,7 +10068,7 @@ class InteractionHandler {
 
         const embed = new EmbedBuilder()
             .setColor(0x5865F2)
-            .setTitle(t('🎯 Konfiguracja Bossów', '🎯 Boss Configuration'))
+            .setTitle(t('👾 Konfiguracja Bossów', '👾 Boss Configuration'))
             .setDescription(
                 t(
                     'Aliasy w innych językach są automatycznie normalizowane do angielskiej nazwy przy analizie OCR.\nNazwa angielska jest kluczem — jeden boss = jeden rekord w osiągnięciach.',
@@ -10243,7 +10243,7 @@ class InteractionHandler {
         const lang = interaction.values[0];
         const addResult = await this.bossAliasService.addAlias(session.pendingBoss, session.pendingAlias, lang);
         const backRow = [new ActionRowBuilder().addComponents(
-            new ButtonBuilder().setCustomId('panel_boss_cfg').setEmoji('🎯').setLabel(t('Powrót do konfiguracji bossów', 'Back to Boss Config')).setStyle(ButtonStyle.Primary),
+            new ButtonBuilder().setCustomId('panel_boss_cfg').setEmoji('👾').setLabel(t('Powrót do konfiguracji bossów', 'Back to Boss Config')).setStyle(ButtonStyle.Primary),
         )];
         if (!addResult.added) {
             const { englishName: conflictBoss, language: conflictLang } = addResult.conflict;
@@ -10366,7 +10366,7 @@ class InteractionHandler {
                     `Removed alias **${alias}** (${lang}) for boss **${session.pendingBoss}**.`
                 ))],
             components: [new ActionRowBuilder().addComponents(
-                new ButtonBuilder().setCustomId('panel_boss_cfg').setEmoji('🎯').setLabel(t('Powrót do konfiguracji bossów', 'Back to Boss Config')).setStyle(ButtonStyle.Primary),
+                new ButtonBuilder().setCustomId('panel_boss_cfg').setEmoji('👾').setLabel(t('Powrót do konfiguracji bossów', 'Back to Boss Config')).setStyle(ButtonStyle.Primary),
             )],
         });
     }
@@ -10645,7 +10645,7 @@ class InteractionHandler {
             .setTimestamp();
         if (userAvatarUrl) embed.setThumbnail(userAvatarUrl);
         embed.addFields(
-            { name: '🎯 Nazwa bossa (OCR)', value: `\`${rawBoss}\``, inline: false },
+            { name: '👾 Nazwa bossa (OCR)', value: `\`${rawBoss}\``, inline: false },
             { name: '👤 Gracz', value: `[${userName}](https://discord.com/users/${userId})`, inline: true },
             { name: '⌨️ Komenda', value: `/${commandName}`, inline: true },
             { name: '🏠 Serwer', value: guildName, inline: true },

--- a/EndersEcho/services/logService.js
+++ b/EndersEcho/services/logService.js
@@ -5,7 +5,7 @@ const { createBotLogger } = require('../../utils/consoleLogger');
 const OCR_EMBED_TYPES = {
     new_record:              { color: 0x57F287, emoji: '🏆', label: 'NOWY REKORD' },
     new_player:              { color: 0x57F287, emoji: '🆕', label: 'NOWY GRACZ' },
-    boss_record:             { color: 0x1ABC9C, emoji: '🎯', label: 'POBITO REKORD BOSSA' },
+    boss_record:             { color: 0x1ABC9C, emoji: '👾', label: 'POBITO REKORD BOSSA' },
     role_error:              { color: 0xFEE75C, emoji: '⚠️', label: 'NOWY REKORD — błąd uprawnień ról' },
     role_error_new_player:   { color: 0xFEE75C, emoji: '⚠️', label: 'NOWY GRACZ — błąd uprawnień ról' },
     rejected:                { color: 0xED4245, emoji: '🚫', label: 'ANALIZA ODRZUCONA' },

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -1014,18 +1014,6 @@ class RankingService {
             descLines.push(posLine);
         }
 
-        if (rankingOverride?.position) {
-            const overrideMedal = this.getPositionMedal(rankingOverride.position);
-            const rankingLabel = rankingOverride.label || msgs.recordRanking;
-            let posLine = `**${rankingLabel}:** ${overrideMedal} #${rankingOverride.position}`;
-            if (rankingOverride.positionChange > 0) {
-                posLine += `  *(${msgs.recordPromotionBy} +${rankingOverride.positionChange})*`;
-            } else if (rankingOverride.isNewEntry) {
-                posLine += `  *(${msgs.recordNewEntry})*`;
-            }
-            descLines.push(posLine);
-        }
-
         if (rolePositions?.length > 0) {
             for (const rp of rolePositions) {
                 descLines.push(`🎖️ **${rp.roleName}:** #${rp.position}`);
@@ -1080,7 +1068,17 @@ class RankingService {
             } else {
                 bossFieldVal = `**${bossRecordData.bossName}:** ${bestScore} *(${msgs.bossRecordFirst || 'pierwszy wynik na tym bossie!'})*`;
             }
-            embed.addFields({ name: msgs.bossRecordField || '🎯 Rekord na bossie', value: bossFieldVal, inline: false });
+            if (rankingOverride?.position) {
+                const overrideMedal = this.getPositionMedal(rankingOverride.position);
+                let posLine = `${overrideMedal} #${rankingOverride.position}`;
+                if (rankingOverride.positionChange > 0) {
+                    posLine += `  *(${msgs.recordPromotionBy} +${rankingOverride.positionChange})*`;
+                } else if (rankingOverride.isNewEntry) {
+                    posLine += `  *(${msgs.recordNewEntry})*`;
+                }
+                bossFieldVal += `\n${posLine}`;
+            }
+            embed.addFields({ name: msgs.bossRecordField || '👾 Rekord na bossie', value: bossFieldVal, inline: false });
         }
 
         if (achievementsFieldValue) {

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -593,7 +593,7 @@ class RankingService {
             ...(mode === 'global' ? [
                 new ButtonBuilder()
                     .setCustomId('ranking_boss_list')
-                    .setEmoji('🎯')
+                    .setEmoji('👾')
                     .setLabel(msgs.buttonBossRanking || 'Ranking Bossów')
                     .setStyle(ButtonStyle.Secondary)
                     .setDisabled(disabled)


### PR DESCRIPTION
## Zmiany

- **Pozycja bossa w polu Boss Record** — pozycja w rankingu bossa (`🏅 #7 *(awans o +5)*`) przeniesiona z opisu embeda do pola „👾 Rekord na bossie", tuż pod zmianą wyniku
- **Pozycja bossa przy globalnym rekordzie** — pozycja bossa pokazuje się poprawnie również gdy gracz pobija globalny rekord (wcześniej brak)
- **Log snippeta bossa** — format logu zmieniony na `👾 Snippet bossa "Name": 8 → #7` (poprzednia pozycja → nowa)
- **Ikona bossa 🎯 → 👾** — zmieniona we wszystkich miejscach: messages.js, logService.js, rankingService.js, interactionHandlers.js (przyciski, tytuły, opisy panelu, pola embedów)
- **Nieznany boss** — gdy OCR wykryje nazwę bossa spoza bazy: brak informacji o rankingach bossa, zamiast tego pole informacyjne „⚠️ Niezweryfikowana nazwa bossa / ⚠️ Unverified Boss Name" z opisem procesu weryfikacji (dwujęzyczne)
- **Embed rekordu bossa** — używa `createRecordEmbed` tak jak rekord globalny (spójny wygląd)
- **Snippet zmiany w rankingu bossa** — dodany do embeda ogłoszenia rekordu bossa (kontekst graczy wokół nowej pozycji)

## Test plan

- [ ] Pobij rekord bossa → pole „👾 Rekord na bossie" pokazuje wynik + pozycję w rankingu bossa
- [ ] Pobij globalny rekord + rekord bossa → oba pola (globalny i bossa) widoczne z poprawnymi pozycjami
- [ ] Wyślij screen z nieznaną nazwą bossa → pole „⚠️ Niezweryfikowana nazwa bossa" bez rankingów
- [ ] Sprawdź ikonę 👾 w panelu admina (Konfiguracja bossów), rankingu bossów i logach OCR

---
_Generated by [Claude Code](https://claude.ai/code/session_016VFS6p9LsXZ7wZBbCekjKY)_