### PR TITLE
EndersEcho: formatowanie nagłówków snippetów rankingu

### DIFF
--- a/EndersEcho/services/globalTop10Service.js
+++ b/EndersEcho/services/globalTop10Service.js
@@ -384,8 +384,8 @@ class GlobalTop10Service {
         }
 
         return {
-            title: `${title} ${direction} ${prevLabel} → #${newGlobalPosition}`,
-            description: lines.join('\n\n')
+            title,
+            description: `${direction} ${prevLabel} → #${newGlobalPosition}\n\n${lines.join('\n\n')}`
         };
     }
 
@@ -428,8 +428,7 @@ class GlobalTop10Service {
 
         const prevLabel = prevBossPosition ? `#${prevBossPosition}` : '—';
         const direction = !prevBossPosition || prevBossPosition > newBossPosition ? '↑' : '↓';
-        const snippetTitle = msgs.bossSnippetTitle || '🎯 Zmiana w rankingu bossa';
-        const title = `${snippetTitle} ${bossName} ${direction} ${prevLabel} → #${newBossPosition}`;
+        const title = msgs.bossSnippetTitle || '🎯 Zmiana w rankingu bossa';
 
         const lines = [];
         const above   = bossRanking[newBossIndex - 1];
@@ -446,7 +445,7 @@ class GlobalTop10Service {
             lines.push(`${belowDir} ${await buildLine(below, newBossPosition + 1)}`);
         }
 
-        return { title, description: lines.join('\n\n') };
+        return { title, description: `\`${bossName}:\` ${direction} ${prevLabel} → #${newBossPosition}\n\n${lines.join('\n\n')}` };
     }
 
     /**


### PR DESCRIPTION
## Zmiany

- **Snippet globalny** — zmiana pozycji (`↑ — → #143`) przeniesiona z nagłówka pola do pierwszej linii wartości; nagłówek to teraz samo `🌐 Zmiana w globalnym rankingu`
- **Snippet bossa** — nazwa bossa i zmiana pozycji (`` `Ancient Megalodon:` ↑ — → #24 ``) przeniesione do wartości pola; nagłówek to teraz samo `👾 Zmiana w rankingu bossa`

**Przed:**
```
🌐 Zmiana w globalnym rankingu ↑ — → #143
👾 Zmiana w rankingu bossa Ancient Megalodon ↑ — → #24
```

**Po:**
```
🌐 Zmiana w globalnym rankingu
↑ — → #143

👾 Zmiana w rankingu bossa
`Ancient Megalodon:` ↑ — → #24
```

## Test plan

- [ ] Pobij globalny rekord → nagłówek snippeta globalnego bez info o pozycji, info w pierwszej linii wartości
- [ ] Pobij rekord bossa → nagłówek snippeta bossa bez nazwy bossa/pozycji, nazwa bossa w code block w pierwszej linii wartości

---
_Generated by [Claude Code](https://claude.ai/code/session_016VFS6p9LsXZ7wZBbCekjKY)_