### PR TITLE
EndersEcho: dopracowanie wyświetlania Boss Record i snippetów

### DIFF
--- a/EndersEcho/services/globalTop10Service.js
+++ b/EndersEcho/services/globalTop10Service.js
@@ -445,7 +445,7 @@ class GlobalTop10Service {
             lines.push(`${belowDir} ${await buildLine(below, newBossPosition + 1)}`);
         }
 
-        return { title, description: `\`${bossName}:\` ${direction} ${prevLabel} → #${newBossPosition}\n\n${lines.join('\n\n')}` };
+        return { title, description: `${direction} ${prevLabel} → #${newBossPosition}\n\n${lines.join('\n\n')}` };
     }
 
     /**

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -1062,11 +1062,12 @@ class RankingService {
 
         // Per-boss rekord (tuż przed osiągnięciami)
         if (bossRecordData?.isNewBossRecord && bossRecordData.bossName) {
+            const fieldName = `${msgs.bossRecordField || '👾 Rekord na bossie'} \`${bossRecordData.bossName}\``;
             let bossFieldVal;
             if (bossRecordData.previousBossRecord) {
-                bossFieldVal = `**${bossRecordData.bossName}:** ${bossRecordData.previousBossRecord.score} ➜ ${bestScore}`;
+                bossFieldVal = `${bossRecordData.previousBossRecord.score} ➜ ${bestScore}`;
             } else {
-                bossFieldVal = `**${bossRecordData.bossName}:** ${bestScore} *(${msgs.bossRecordFirst || 'pierwszy wynik na tym bossie!'})*`;
+                bossFieldVal = `${bestScore} *(${msgs.bossRecordFirst || 'pierwszy wynik na tym bossie!'})*`;
             }
             if (rankingOverride?.position) {
                 const overrideMedal = this.getPositionMedal(rankingOverride.position);
@@ -1078,7 +1079,7 @@ class RankingService {
                 }
                 bossFieldVal += `\n${posLine}`;
             }
-            embed.addFields({ name: msgs.bossRecordField || '👾 Rekord na bossie', value: bossFieldVal, inline: false });
+            embed.addFields({ name: fieldName, value: bossFieldVal, inline: false });
         }
 
         if (achievementsFieldValue) {

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -1056,11 +1056,7 @@ class RankingService {
             embed.addFields({ name: globalSnippetData.title, value: globalSnippetData.description, inline: false });
         }
 
-        if (bossSnippetData) {
-            embed.addFields({ name: bossSnippetData.title, value: bossSnippetData.description, inline: false });
-        }
-
-        // Per-boss rekord (tuż przed osiągnięciami)
+        // Per-boss rekord (przed snippetem bossa)
         if (bossRecordData?.isNewBossRecord && bossRecordData.bossName) {
             const fieldName = `${msgs.bossRecordField || '👾 Rekord na bossie'} \`${bossRecordData.bossName}\``;
             let bossFieldVal;
@@ -1080,6 +1076,10 @@ class RankingService {
                 bossFieldVal += `\n${posLine}`;
             }
             embed.addFields({ name: fieldName, value: bossFieldVal, inline: false });
+        }
+
+        if (bossSnippetData) {
+            embed.addFields({ name: bossSnippetData.title, value: bossSnippetData.description, inline: false });
         }
 
         if (achievementsFieldValue) {


### PR DESCRIPTION
## Zmiany

- **Kolejność pól** — Boss Record wyświetlany przed Boss Ranking Change (snippet)
- **Nazwa bossa w nagłówku pola** — pole `👾 Rekord na bossie \`Ancient Megalodon\`` zamiast nazwy w wartości
- **Snippet bossa** — usunięta nazwa bossa z pierwszej linii opisu (była: `` `Ancient Megalodon:` ↑ — → #24 ``, teraz: `↑ — → #24`)
- **Snippety globalne i bossa** — zmiana pozycji (`↑ — → #143`) przeniesiona z nagłówka pola do pierwszej linii wartości; nagłówek jest teraz samym tytułem (`🌐 Zmiana w globalnym rankingu` / `👾 Zmiana w rankingu bossa`)

**Nowy układ pól w embedzie rekordu:**
```
🌐 Zmiana w globalnym rankingu
↑ — → #143
[ranking globalny]

👾 Rekord na bossie `Ancient Megalodon`
149Sx *(first score on this boss!)*
🏅 #6  *(new entry)*

👾 Zmiana w rankingu bossa
↑ — → #24
[ranking bossa]

🎉 Nowe osiągnięcia
```

## Test plan

- [ ] Pobij globalny rekord + rekord bossa → pola w kolejności: Global snippet → Boss Record → Boss snippet → Achievements
- [ ] Sprawdź nagłówek pola Boss Record — zawiera nazwę bossa w backtickach
- [ ] Sprawdź snippety — zmiana pozycji w pierwszej linii wartości, nie w nagłówku

---
_Generated by [Claude Code](https://claude.ai/code/session_016VFS6p9LsXZ7wZBbCekjKY)_