### PR TITLE
EndersEcho: format nagłówka pola Boss Record

### DIFF
--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -1058,7 +1058,7 @@ class RankingService {
 
         // Per-boss rekord (przed snippetem bossa)
         if (bossRecordData?.isNewBossRecord && bossRecordData.bossName) {
-            const fieldName = `${msgs.bossRecordField || '👾 Rekord na bossie'} \`${bossRecordData.bossName}\``;
+            const fieldName = `${msgs.bossRecordField || '👾 Rekord na bossie'}: \`\`${bossRecordData.bossName}\`\``;
             let bossFieldVal;
             if (bossRecordData.previousBossRecord) {
                 bossFieldVal = `${bossRecordData.previousBossRecord.score} ➜ ${bestScore}`;


### PR DESCRIPTION
## Zmiany

Zmiana formatu nagłówka pola Boss Record:

**Przed:** `👾 Rekord na bossie \`Ancient Megalodon\``
**Po:** `👾 Boss Record: \`\`Ancient Megalodon\`\``

Dodano dwukropek po etykiecie i podwójne backticki wokół nazwy bossa.

## Test plan

- [ ] Pobij rekord bossa → nagłówek pola w formacie `👾 Boss Record: \`\`NazwaBossa\`\``

---
_Generated by [Claude Code](https://claude.ai/code/session_016VFS6p9LsXZ7wZBbCekjKY)_