### PR TITLE
Poprawiono strefę czasową w dacie zapisu fazy2

### DIFF
--- a/Stalker/services/phaseService.js
+++ b/Stalker/services/phaseService.js
@@ -1409,7 +1409,7 @@ class PhaseService {
         }
 
         const createdDate = new Date(existingData.createdAt);
-        const dateStr = createdDate.toLocaleString('pl-PL');
+        const dateStr = createdDate.toLocaleString('pl-PL', { timeZone: this.config.timezone });
 
         const clanName = this.config.roleDisplayNames[clan] || clan;
 


### PR DESCRIPTION
## Opis problemu

Przy kliknięciu przycisku w Stalkerze (faza2) data i godzina zapisu była wyświetlana z przesunięciem o kilka godzin.

## Przyczyna

W `phaseService.js` linia 1412, wywołanie `toLocaleString('pl-PL')` nie przekazywało opcji `timeZone`, przez co używana była domyślna strefa czasowa serwera (UTC). Serwer działa w UTC, więc data była przesunięta o +1h (zima) lub +2h (lato) względem polskiego czasu.

## Poprawka

Dodano `{ timeZone: this.config.timezone }` (wartość: `'Europe/Warsaw'`) do wywołania `toLocaleString`, tak samo jak zrobiono w innych miejscach kodu (np. `reminderUsageService.js`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xnc3fYCR8sfSFQ93wbXN12)_