### PR TITLE
EndersEcho: nick admina jako link w embedach konfiguracji

### DIFF
--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -2045,7 +2045,7 @@ class InteractionHandler {
                         .setThumbnail(interaction.guild.iconURL({ dynamic: true, size: 128 }))
                         .addFields(
                             { name: tCfg('Serwer', 'Server'), value: interaction.guild.name },
-                            { name: tCfg('Administrator', 'Administrator'), value: interaction.member?.displayName || interaction.user.username },
+                            { name: tCfg('Administrator', 'Administrator'), value: `[${interaction.member?.displayName || interaction.user.username}](https://discord.com/users/${interaction.user.id})` },
                             { name: tCfg('Kanał bota', 'Bot channel'), value: `<#${newData.allowedChannelId}>` },
                             { name: tCfg('Język', 'Language'), value: newData.lang || 'pol' },
                             { name: 'Tag', value: newData.tag || '—' },
@@ -2115,7 +2115,7 @@ class InteractionHandler {
                         .setThumbnail(interaction.guild.iconURL({ dynamic: true, size: 128 }))
                         .addFields(
                             { name: tCfg('Serwer', 'Server'), value: interaction.guild.name, inline: true },
-                            { name: tCfg('Administrator', 'Administrator'), value: interaction.member?.displayName || interaction.user.username, inline: true },
+                            { name: tCfg('Administrator', 'Administrator'), value: `[${interaction.member?.displayName || interaction.user.username}](https://discord.com/users/${interaction.user.id})`, inline: true },
                             ...diffFields
                         )
                         .setTimestamp();


### PR DESCRIPTION
## Zmiany

Pole **Administrator** w embedach konfiguracji serwera (`cfg_accept`) zmienione z czystego tekstu na klikalne łącze Discord.

**Przed:** `Thashar`
**Po:** `[Thashar](https://discord.com/users/398983446812295168)`

Dotyczy obu przypadków:
- Pierwsza konfiguracja (niebieski embed `⚙️ Nowy serwer skonfigurowany`)
- Rekonfiguracja (żółty embed `⚙️ Zmiana konfiguracji serwera`)

## Test plan

- [ ] Użyj `/configure` na nowym serwerze → embed na `ENDERSECHO_SERVER_LOG_CHANNEL_ID` zawiera klikalny link admina
- [ ] Zmień konfigurację istniejącego serwera → embed rekonfiguracji zawiera klikalny link admina

---
_Generated by [Claude Code](https://claude.ai/code/session_016VFS6p9LsXZ7wZBbCekjKY)_