### PR TITLE
EndersEcho: usunięto pozycję bossa z pola Boss Record

### DIFF
--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -1065,16 +1065,6 @@ class RankingService {
             } else {
                 bossFieldVal = `${bestScore} *(${msgs.bossRecordFirst || 'pierwszy wynik na tym bossie!'})*`;
             }
-            if (rankingOverride?.position) {
-                const overrideMedal = this.getPositionMedal(rankingOverride.position);
-                let posLine = `${overrideMedal} #${rankingOverride.position}`;
-                if (rankingOverride.positionChange > 0) {
-                    posLine += `  *(${msgs.recordPromotionBy} +${rankingOverride.positionChange})*`;
-                } else if (rankingOverride.isNewEntry) {
-                    posLine += `  *(${msgs.recordNewEntry})*`;
-                }
-                bossFieldVal += `\n${posLine}`;
-            }
             embed.addFields({ name: fieldName, value: bossFieldVal, inline: false });
         }
 


### PR DESCRIPTION
## Summary

- Usunięto blok `rankingOverride` z pola Boss Record w `createRecordEmbed` — pozycja bossa (`🏅 #6  *(promoted by +1)*`) nie jest już wyświetlana w tym polu

## Test plan

- [ ] Sprawdź że po pobiciu rekordu bossa pole Boss Record zawiera tylko wynik (np. `149Sx ➜ 201Sx`) bez linii z pozycją

---
_Generated by [Claude Code](https://claude.ai/code/session_016VFS6p9LsXZ7wZBbCekjKY)_