### PR TITLE
EndersEcho: Centrum Dowodzenia Head Admina (Live Dashboard)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -762,6 +762,8 @@ ENDERSECHO_ALLOWED_CHANNEL_ID=channel_id
 USE_ENDERSECHO_AI_OCR=false
 ENDERSECHO_GOOGLE_AI_API_KEY=AIzaSy-xxxxxxxxxxxxx
 ENDERSECHO_GOOGLE_AI_MODEL=gemini-2.5-flash-preview-05-20
+# Centrum Dowodzenia Head Admina — Live Dashboard (opcjonalne)
+ENDERSECHO_ADMIN_PANEL_CHANNEL_ID=id_kanalu_head_admina
 
 # ===== KONTROLER BOT =====
 KONTROLER_TOKEN=bot_token_here

--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -182,6 +182,7 @@
    - **Wyślij Info (head admin):** modal → podgląd PL+ENG → wyślij na wszystkie serwery. `_infoSessions` Map (RAM)
    - **Zbanuj serwer (head admin):** modal wyszukiwania nazwy → lista → potwierdzenie → bot wychodzi z serwera + ID zapisywane w `data/banned_guilds.json`. Odblokowanie przez listę zbanowanych. Check w `guildCreate` — bot natychmiast wychodzi, jeśli serwer jest na liście. `GuildBanService`.
    - **Konfiguracja bossów (head admin):** zarządzaj angielskimi nazwami bossów i ich aliasami w innych językach — patrz sekcja poniżej.
+   - **Centrum Dowodzenia (head admin):** panel 5 embedów na dedykowanym kanale, aktualizowany automatycznie po każdej analizie OCR i akcji admina — patrz sekcja poniżej.
 
 **Komendy slash:** `/achievements`, `/configure`, `/generate`, `/manage`, `/ranking`, `/subscribe`, `/test`, `/update`
 
@@ -189,7 +190,7 @@
 - Dostęp: Administrator Discord
 - **Układ rzędów — Główny panel (Admin i Head Admin):**
   - Rząd 1: `👥 Zarządzaj użytkownikami`, `🖥️ Zarządzaj serwerem`, `📊 Statystyki` (szare)
-  - Rząd 2 (tylko Head Admin): `📢 Wyślij Info`
+  - Rząd 2 (tylko Head Admin): `📢 Wyślij Info`, `📡 Centrum Dowodzenia`
 - **Sub-panel "Zarządzaj użytkownikami" (Admin):**
   - Rząd 1: `🗑️ Usuń gracza z rankingu`, `🔓 Odblokuj gracza`, `◀️ Wróć`
 - **Sub-panel "Zarządzaj użytkownikami" (Head Admin):**
@@ -285,6 +286,8 @@
 | `panel_unblock_select` | StringSelectMenu — wybór do odblokowania |
 | `panel_tokens` | Pokaż statystyki tokenów |
 | `panel_process_roles` | Pełny reset ról TOP: usuń wszystkie → przyznaj wg aktualnego rankingu (admin + head admin) |
+| `panel_cmd_center` | Otwórz widok Centrum Dowodzenia (head admin) |
+| `panel_cmd_center_refresh` | Wymuś natychmiastowy refresh panelu Centrum Dowodzenia (head admin) |
 | `panel_info` | Otwórz modal /info (head admin) |
 | `panel_tester` | Pokaż listę testerów + przyciski Dodaj/Usuń (head admin) |
 | `panel_tester_add` | Otwórz modal wpisania ID użytkownika |
@@ -714,3 +717,52 @@ Po **pierwszej** konfiguracji serwera (`!wasAlreadyConfigured`) pod embedem sukc
 - Thumbnail: ikona serwera Discord
 
 **Metody:** `_buildNewServerAnnouncementEmbeds(guild, serverNumber)`, `_enOrdinal(n)`, `_handleAnnounceNewServer()`, `_handleAnnounceNewServerSend()`
+
+---
+
+## Centrum Dowodzenia Head Admina (Admin Panel Live Dashboard)
+
+**Plik serwisu:** `services/adminPanelService.js`
+
+**Konfiguracja (zmienna env):**
+```env
+ENDERSECHO_ADMIN_PANEL_CHANNEL_ID=id_kanalu_head_admina
+```
+
+**Działanie:** Panel to jedna stała wiadomość z 5 embedami na kanale head admina. Edytowana automatycznie po każdym zdarzeniu — nie flood kanału nowymi wiadomościami.
+
+**5 embedów panelu:**
+
+| # | Embed | Kolor | Zawartość |
+|---|---|---|---|
+| 1 | 📡 Centrum Dowodzenia | `0xFF6B35` | Uptime, liczba serwerów, AI OCR on/off, następny Global TOP10 |
+| 2 | 📊 Statystyki OCR | `0x5865F2` | Łącznie analiz, od resetu, Success Rate, interwencje admina, oczekujące CV, ostatnia analiza |
+| 3 | 🌍 Gracze Globalnie | `0x57F287` | Łącznie graczy, aktywne cooldowny, zablokowanych, TOP 3 globalny |
+| 4 | 💰 Koszty AI — Dzisiaj | `0xFEE75C` | Requesty, tokeny IN/OUT, łącznie tokenów, szacowany koszt ($) |
+| 5 | 🖥️ Status Serwerów | `0xEB459E` | Per serwer: OCR on/off, liczba graczy, język, tag |
+
+**Triggery automatycznego refresh:**
+- ✅ Po każdym zapisie wyniku (`/update` — zarówno nowy rekord jak i brak rekordu, `!dryRun`)
+- ✅ Po analizie admina (`Analizuj` panel)
+- ✅ Po usunięciu gracza z rankingu (`panel_remove_confirm_*`)
+- ✅ Po zablokowaniu gracza (`panel_block_time_*`)
+- ✅ Po odblokowaniu gracza (`panel_unblock_select`)
+- ✅ Po akcji Community Verification (approve/remove/block)
+- ✅ Na żądanie: `/manage` → `📡 Centrum Dowodzenia` → `🔄 Odśwież Panel`
+- ✅ Przy starcie bota (jeśli kanał skonfigurowany)
+
+**Debouncing:** Maksymalnie 1 refresh naraz + 1 oczekujący (dodatkowe wywołania w trakcie odrzucane).
+
+**Persistencja:** `data/admin_panel.json` — `{ messageId, channelId }`. Jeśli wiadomość usunięta, serwis tworzy nową.
+
+**Klucz API serwisu:**
+```javascript
+adminPanelService.setLastRecord(userName, score, bossName, guildId); // przed refresh po OCR
+adminPanelService.refresh();   // fire-and-forget, debounced
+adminPanelService.setupChannel(channelId); // zmień kanał i wyślij nową wiadomość
+adminPanelService.isConfigured(); // czy ENDERSECHO_ADMIN_PANEL_CHANNEL_ID ustawione
+adminPanelService.getChannelId(); // ID aktualnego kanału
+adminPanelService.getMessageId(); // ID wiadomości panelu (null = jeszcze nie wysłana)
+```
+
+**Dostęp przez `/manage`:** Rząd 2 (tylko Head Admin) → `📡 Centrum Dowodzenia` → widok statusu + `🔄 Odśwież Panel`.

--- a/EndersEcho/config/config.js
+++ b/EndersEcho/config/config.js
@@ -106,6 +106,7 @@ module.exports = {
     rejectedChannelId: process.env.ENDERSECHO_REJECTED_CHANNEL_ID || null,
     communityChannelId: process.env.ENDERSECHO_COMMUNITY_CHANNEL_ID || null,
     appApiKey: process.env.ENDERSECHO_API_KEY || process.env.BOT_API_KEY || null,
+    adminPanelChannelId: process.env.ENDERSECHO_ADMIN_PANEL_CHANNEL_ID || null,
 
     // Lista serwerów z .env (fallback gdy guildConfigService niedostępny)
     guilds,

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -24,7 +24,7 @@ function buildGeminiUsage(aiResult) {
 }
 
 class InteractionHandler {
-    constructor(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService, roleRankingConfigService, usageLimitService, tokenUsageService, _botOps, guildConfigService, ocrBlockService, updateCooldownService, testerService, achievementService, communityVerificationService, scoreHistoryService = null, chartService = null, guildBanService = null, globalTop10Service = null, bossAliasService = null, ocrStatsService = null, bossRecordService = null) {
+    constructor(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService, roleRankingConfigService, usageLimitService, tokenUsageService, _botOps, guildConfigService, ocrBlockService, updateCooldownService, testerService, achievementService, communityVerificationService, scoreHistoryService = null, chartService = null, guildBanService = null, globalTop10Service = null, bossAliasService = null, ocrStatsService = null, bossRecordService = null, adminPanelService = null) {
         this.config = config;
         this.ocrService = ocrService;
         this.aiOcrService = aiOcrService;
@@ -49,6 +49,7 @@ class InteractionHandler {
         this.bossAliasService = bossAliasService;
         this.ocrStatsService = ocrStatsService;
         this.bossRecordService = bossRecordService;
+        this.adminPanelService = adminPanelService;
         // Tymczasowe sesje dla /info (userId -> { title, description, icon, image })
         // Każda sesja ma TTL 15 minut — timer usuwający ją automatycznie.
         this._infoSessions = new Map();
@@ -2162,6 +2163,7 @@ class InteractionHandler {
         ];
         if (isHeadAdmin) {
             descLines.push(`\n📢 **${t('Wyślij Info', 'Send Info')}** — ${t('skomponuj wiadomość i wyślij ją na kanały wszystkich skonfigurowanych serwerów.', 'compose a message and send it to all configured servers\' channels.')}`);
+            descLines.push(`📡 **${t('Centrum Dowodzenia', 'Command Center')}** — ${t('panel sterowania z live-statystykami OCR, graczy i kosztów AI, aktualizowany po każdej analizie.', 'control panel with live OCR, player and AI cost statistics, updated after each analysis.')}`);
         }
 
         const embed = new EmbedBuilder()
@@ -2181,9 +2183,10 @@ class InteractionHandler {
 
         const components = [row1];
         if (isHeadAdmin) {
-            // Rząd 2 Head Admin: Wyślij Info (zostaje w głównym panelu)
+            // Rząd 2 Head Admin: Wyślij Info + Centrum Dowodzenia
             components.push(new ActionRowBuilder().addComponents(
                 new ButtonBuilder().setCustomId('panel_info').setEmoji('📢').setLabel(t('Wyślij Info', 'Send Info')).setStyle(ButtonStyle.Primary),
+                new ButtonBuilder().setCustomId('panel_cmd_center').setEmoji('📡').setLabel(t('Centrum Dowodzenia', 'Command Center')).setStyle(ButtonStyle.Primary),
             ));
         }
 
@@ -2424,6 +2427,99 @@ class InteractionHandler {
         await interaction.update({ embeds: [embed], components });
     }
 
+    async _handlePanelCmdCenter(interaction) {
+        if (!this._isHeadAdmin(interaction.user.id)) {
+            await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+            return;
+        }
+        const t = this._panelT(interaction.guildId);
+        const svc = this.adminPanelService;
+        const isConfigured = svc?.isConfigured();
+        const channelId = svc?.getChannelId();
+        const messageId = svc?.getMessageId();
+
+        let statusLine;
+        if (!isConfigured) {
+            statusLine = t(
+                '⚠️ **Panel nie jest skonfigurowany.**\nUstaw `ENDERSECHO_ADMIN_PANEL_CHANNEL_ID` w pliku `.env` i zrestartuj bota.',
+                '⚠️ **Panel is not configured.**\nSet `ENDERSECHO_ADMIN_PANEL_CHANNEL_ID` in the `.env` file and restart the bot.'
+            );
+        } else if (messageId) {
+            statusLine = t(
+                `✅ **Panel aktywny** na kanale <#${channelId}>\n📩 ID wiadomości: \`${messageId}\``,
+                `✅ **Panel active** in channel <#${channelId}>\n📩 Message ID: \`${messageId}\``
+            );
+        } else {
+            statusLine = t(
+                `📬 Kanał ustawiony: <#${channelId}>\n⏳ Wiadomość zostanie wysłana przy najbliższym refresh.`,
+                `📬 Channel set: <#${channelId}>\n⏳ Message will be sent on next refresh.`
+            );
+        }
+
+        const embed = new EmbedBuilder()
+            .setColor(0xFF6B35)
+            .setTitle(t('📡 Centrum Dowodzenia', '📡 Command Center'))
+            .setDescription(
+                statusLine + '\n\n' +
+                t(
+                    '**Panel aktualizuje się automatycznie** po każdym nowym rekordzie, akcji admina i weryfikacji społeczności.\n\nUżyj przycisku poniżej aby wymusić natychmiastowy refresh.',
+                    '**The panel updates automatically** after every new record, admin action and community verification.\n\nUse the button below to force an immediate refresh.'
+                )
+            );
+
+        const back = new ButtonBuilder().setCustomId('panel_back').setEmoji('◀️').setLabel(t('Wróć', 'Back')).setStyle(ButtonStyle.Secondary);
+        const components = [new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId('panel_cmd_center_refresh')
+                .setEmoji('🔄')
+                .setLabel(t('Odśwież Panel', 'Refresh Panel'))
+                .setStyle(ButtonStyle.Primary)
+                .setDisabled(!isConfigured),
+            back,
+        )];
+
+        await interaction.update({ embeds: [embed], components });
+    }
+
+    async _handlePanelCmdCenterRefresh(interaction) {
+        if (!this._isHeadAdmin(interaction.user.id)) {
+            await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+            return;
+        }
+        const t = this._panelT(interaction.guildId);
+        await interaction.deferUpdate();
+
+        const svc = this.adminPanelService;
+        if (!svc?.isConfigured()) {
+            await interaction.editReply({
+                embeds: [new EmbedBuilder().setColor(0xFF4444)
+                    .setTitle(t('❌ Błąd', '❌ Error'))
+                    .setDescription(t('Panel nie jest skonfigurowany.', 'Panel is not configured.'))],
+                components: [new ActionRowBuilder().addComponents(
+                    new ButtonBuilder().setCustomId('panel_cmd_center').setEmoji('◀️').setLabel(t('Powrót', 'Back')).setStyle(ButtonStyle.Secondary)
+                )]
+            });
+            return;
+        }
+
+        await svc._doRefresh().catch(() => {});
+
+        const channelId = svc.getChannelId();
+        const messageId = svc.getMessageId();
+        const statusLine = messageId
+            ? t(`✅ Panel odświeżony — <#${channelId}>`, `✅ Panel refreshed — <#${channelId}>`)
+            : t(`⚠️ Nie udało się znaleźć wiadomości panelu.`, `⚠️ Panel message not found.`);
+
+        await interaction.editReply({
+            embeds: [new EmbedBuilder().setColor(0x57F287)
+                .setTitle(t('📡 Centrum Dowodzenia', '📡 Command Center'))
+                .setDescription(statusLine)],
+            components: [new ActionRowBuilder().addComponents(
+                new ButtonBuilder().setCustomId('panel_cmd_center').setEmoji('◀️').setLabel(t('Powrót', 'Back')).setStyle(ButtonStyle.Secondary)
+            )]
+        });
+    }
+
     async _handlePanelRemove(interaction) {
         const t = this._panelT(interaction.guildId);
         const modal = new ModalBuilder()
@@ -2572,6 +2668,7 @@ class InteractionHandler {
             } catch (roleError) {
                 logger.warn(`Błąd aktualizacji ról TOP po usunięciu (panel): ${roleError.message}`);
             }
+            this.adminPanelService?.refresh();
             const guildName = interaction.client.guilds.cache.get(targetGuildId)?.name;
             const serverNote = guildName ? ` (${guildName})` : '';
             await interaction.editReply({
@@ -3601,6 +3698,11 @@ class InteractionHandler {
                     guildId, userId, userName, bestScore, bossName
                 ));
                 await this.logService.logScoreUpdate(userName, bestScore, isNewRecord, guildId);
+                // Aktualizuj panel Centrum Dowodzenia po każdym zapisie (nowy rekord lub nie)
+                if (this.adminPanelService) {
+                    this.adminPanelService.setLastRecord(userName, bestScore, bossName, guildId);
+                    this.adminPanelService.refresh();
+                }
             }
 
             // Per-boss rekord (zawsze po pozytywnym OCR, niezależnie od isNewRecord)
@@ -4275,6 +4377,8 @@ class InteractionHandler {
 
     _describePanelButton(customId) {
         if (customId === 'panel_back' || customId === 'cfg_admin_panel') return 'Otwarto panel';
+        if (customId === 'panel_cmd_center') return 'Centrum Dowodzenia';
+        if (customId === 'panel_cmd_center_refresh') return 'Odśwież Centrum Dowodzenia';
         if (customId === 'panel_cat_users') return 'Zarządzaj użytkownikami';
         if (customId === 'panel_cat_server') return 'Zarządzaj serwerem';
         if (customId === 'panel_cat_stats') return 'Statystyki';
@@ -4643,6 +4747,14 @@ class InteractionHandler {
                 }
                 const { embed, rows } = this._buildWizardDashboard(state, interaction.guildId);
                 await interaction.update({ embeds: [embed], components: rows });
+                return;
+            }
+            if (customId === 'panel_cmd_center') {
+                await this._handlePanelCmdCenter(interaction);
+                return;
+            }
+            if (customId === 'panel_cmd_center_refresh') {
+                await this._handlePanelCmdCenterRefresh(interaction);
                 return;
             }
             if (customId === 'panel_remove') {
@@ -5409,6 +5521,7 @@ class InteractionHandler {
             await this._updateAllCvReportMsgs(interaction.client, session,
                 msgs.cvAdminBlocked.replace('{adminName}', adminName), []);
         }
+        this.adminPanelService?.refresh();
     }
 
     async _updateOriginalRecordButton(client, session, action) {
@@ -6278,6 +6391,7 @@ class InteractionHandler {
                 }
                 const success = await this.userBlockService.unblockUser(targetUserId, isHeadAdmin);
                 const username = entry?.username || targetUserId;
+                if (success === true) this.adminPanelService?.refresh();
                 await interaction.update({
                     embeds: [new EmbedBuilder().setColor(success === true ? 0x57F287 : 0xFF4444)
                         .setTitle(success === true ? t('✅ Odblokowano', '✅ Unblocked') : t('⚠️ Nie znaleziono', '⚠️ Not Found'))
@@ -7227,6 +7341,7 @@ class InteractionHandler {
         });
 
         logger.info(`🔒 Zablokowano ${targetUsername} (${targetUserId}) ${blockedUntil ? `do ${new Date(blockedUntil).toISOString()}` : 'permanentnie'} przez ${adminName}`);
+        this.adminPanelService?.refresh();
 
         if (crossUpdateGlobalMsgId) {
             await this._updateGlobalReportMsg(interaction.client, crossUpdateGlobalMsgId, targetGuildId, 'blocked', adminName, durationLabel);
@@ -7634,6 +7749,10 @@ class InteractionHandler {
             await this.logService.logScoreUpdate(userName, aiResult.score, isNewRecord, targetGuildId, { adminName });
             gl.info(`🎯 [Analizuj] Wynik zapisany — isNewRecord: ${isNewRecord}`);
             if (this.ocrStatsService) this.ocrStatsService.recordAnalyze().catch(() => {});
+            if (this.adminPanelService) {
+                this.adminPanelService.setLastRecord(userName, aiResult.score, aiResult.bossName, targetGuildId);
+                this.adminPanelService.refresh();
+            }
 
             let newAchievements = [];
             if (this.achievementService) {

--- a/EndersEcho/index.js
+++ b/EndersEcho/index.js
@@ -40,6 +40,7 @@ const { createBotLogger } = require('../utils/consoleLogger');
 const KingBumChatService = require('./services/kingBumChatService');
 const { createLlmAdapter } = require('../utils/llmAdapter');
 const cron = require('node-cron');
+const AdminPanelService = require('./services/adminPanelService');
 
 const logger = createBotLogger('EndersEcho');
 
@@ -113,7 +114,17 @@ const globalTop10Service = new GlobalTop10Service(config.ranking.dataDir, rankin
 const ocrStatsService = new OcrStatsService(config.ranking.dataDir, logger);
 const bossRecordService = new BossRecordService(config.ranking.dataDir);
 const kingBumChatService = new KingBumChatService(config, rankingService);
-const interactionHandler = new InteractionHandler(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService, roleRankingConfigService, usageLimitService, tokenUsageService, null, guildConfigService, ocrBlockService, updateCooldownService, testerService, achievementService, communityVerificationService, scoreHistoryService, chartService, guildBanService, globalTop10Service, bossAliasService, ocrStatsService, bossRecordService);
+const adminPanelService = new AdminPanelService(config.ranking.dataDir, config, {
+    rankingService,
+    ocrStatsService,
+    tokenUsageService,
+    userBlockService,
+    updateCooldownService,
+    communityVerificationService,
+    guildConfigService,
+    globalTop10Service,
+});
+const interactionHandler = new InteractionHandler(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService, roleRankingConfigService, usageLimitService, tokenUsageService, null, guildConfigService, ocrBlockService, updateCooldownService, testerService, achievementService, communityVerificationService, scoreHistoryService, chartService, guildBanService, globalTop10Service, bossAliasService, ocrStatsService, bossRecordService, adminPanelService);
 
 /**
  * Inicjalizuje bota EndersEcho
@@ -147,6 +158,13 @@ async function initializeBot() {
         // Uruchom scheduler cyklicznych raportów TOP10 globalnego
         globalTop10Service.setClient(client);
         globalTop10Service.start();
+
+        // Wczytaj i uruchom Panel Centrum Dowodzenia Head Admina
+        adminPanelService.setClient(client);
+        await adminPanelService.load();
+        if (adminPanelService.isConfigured()) {
+            adminPanelService.refresh();
+        }
 
         // Dzienna wiadomość na nieskonfigurowanych serwerach (co dzień o 10:00 UTC)
         cron.schedule('0 10 * * *', async () => {

--- a/EndersEcho/services/adminPanelService.js
+++ b/EndersEcho/services/adminPanelService.js
@@ -1,0 +1,391 @@
+const fs = require('fs').promises;
+const path = require('path');
+const { EmbedBuilder } = require('discord.js');
+const { createBotLogger } = require('../../utils/consoleLogger');
+
+const logger = createBotLogger('EndersEcho');
+
+function fmtCost(usd) {
+    if (usd === 0) return '$0.0000';
+    if (usd < 0.0001) return `<$0.0001`;
+    return `$${usd.toFixed(4)}`;
+}
+
+function fmtTokens(n) {
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+    return n.toString();
+}
+
+function fmtUptime(ms) {
+    const totalSec = Math.floor(ms / 1000);
+    const d = Math.floor(totalSec / 86400);
+    const h = Math.floor((totalSec % 86400) / 3600);
+    const m = Math.floor((totalSec % 3600) / 60);
+    if (d > 0) return `${d}d ${h}h ${m}m`;
+    if (h > 0) return `${h}h ${m}m`;
+    return `${m}m ${totalSec % 60}s`;
+}
+
+function fmtTs(isoStr) {
+    if (!isoStr) return '—';
+    try {
+        return new Date(isoStr).toLocaleString('pl-PL', {
+            timeZone: 'Europe/Warsaw',
+            day: '2-digit', month: '2-digit', year: 'numeric',
+            hour: '2-digit', minute: '2-digit'
+        });
+    } catch { return isoStr.slice(0, 16).replace('T', ' '); }
+}
+
+function timeSince(isoStr) {
+    if (!isoStr) return '—';
+    const diff = Date.now() - new Date(isoStr).getTime();
+    const m = Math.floor(diff / 60000);
+    if (m < 1) return 'przed chwilą';
+    if (m < 60) return `${m} min temu`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}h temu`;
+    return `${Math.floor(h / 24)}d temu`;
+}
+
+function todayKey() {
+    return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Zarządza wiadomością Centrum Dowodzenia Head Admina.
+ * Panel jest wiadomością na kanale ENDERSECHO_ADMIN_PANEL_CHANNEL_ID,
+ * automatycznie edytowaną po każdym nowym rekordzie lub akcji admina.
+ */
+class AdminPanelService {
+    constructor(dataDir, config, services) {
+        this._dataFile = path.join(dataDir, 'admin_panel.json');
+        this._config = config;
+        this._services = services;
+        this._messageId = null;
+        this._channelId = config.adminPanelChannelId || null;
+        this._client = null;
+        this._startTime = Date.now();
+        // { userName, score, bossName, guildId, timestamp }
+        this._lastRecord = null;
+        this._refreshing = false;
+        this._pendingRefresh = false;
+    }
+
+    setClient(client) {
+        this._client = client;
+    }
+
+    async load() {
+        try {
+            const raw = await fs.readFile(this._dataFile, 'utf8');
+            const data = JSON.parse(raw);
+            this._messageId = data.messageId || null;
+            if (!this._channelId && data.channelId) {
+                this._channelId = data.channelId;
+            }
+        } catch {
+            // Brak pliku — pierwszy start
+        }
+    }
+
+    async _persist() {
+        await fs.mkdir(path.dirname(this._dataFile), { recursive: true });
+        await fs.writeFile(this._dataFile, JSON.stringify({
+            messageId: this._messageId,
+            channelId: this._channelId,
+        }, null, 2), 'utf8');
+    }
+
+    setLastRecord(userName, score, bossName, guildId) {
+        this._lastRecord = { userName, score, bossName, guildId, timestamp: new Date().toISOString() };
+    }
+
+    isConfigured() {
+        return Boolean(this._channelId);
+    }
+
+    getChannelId() {
+        return this._channelId;
+    }
+
+    getMessageId() {
+        return this._messageId;
+    }
+
+    // Ustaw kanał panelu (używane przez komendę /manage → Centrum Dowodzenia → Skonfiguruj)
+    async setupChannel(channelId) {
+        this._channelId = channelId;
+        this._messageId = null;
+        await this._persist();
+        await this._doRefresh();
+    }
+
+    // Debounced refresh — maksymalnie jeden pending na raz
+    refresh() {
+        if (this._refreshing) {
+            this._pendingRefresh = true;
+            return;
+        }
+        this._refreshing = true;
+        this._doRefresh()
+            .catch(err => logger.error(`Panel Centrum Dowodzenia — błąd refresh: ${err.message}`))
+            .finally(() => {
+                this._refreshing = false;
+                if (this._pendingRefresh) {
+                    this._pendingRefresh = false;
+                    this.refresh();
+                }
+            });
+    }
+
+    async _doRefresh() {
+        if (!this._client || !this._channelId) return;
+
+        const embeds = await this._buildEmbeds();
+
+        const channel = await this._client.channels.fetch(this._channelId).catch(() => null);
+        if (!channel) {
+            logger.warn(`Panel Centrum Dowodzenia: kanał ${this._channelId} niedostępny`);
+            return;
+        }
+
+        if (this._messageId) {
+            const msg = await channel.messages.fetch(this._messageId).catch(() => null);
+            if (msg) {
+                await msg.edit({ embeds });
+                return;
+            }
+            // Wiadomość usunięta — wyczyść ID, wyślij nową
+            this._messageId = null;
+        }
+
+        const newMsg = await channel.send({ embeds });
+        this._messageId = newMsg.id;
+        await this._persist();
+        logger.info(`Panel Centrum Dowodzenia: nowa wiadomość ${this._messageId} na kanale ${this._channelId}`);
+    }
+
+    _getActiveGuildIds() {
+        if (this._services.guildConfigService) {
+            return new Set(this._services.guildConfigService.getAllConfiguredGuildIds());
+        }
+        return new Set((this._config.guilds || []).map(g => g.id));
+    }
+
+    async _buildEmbeds() {
+        const guildIds = this._getActiveGuildIds();
+        const now = new Date();
+
+        const [globalRanking, blockedUsersArr, serverStats] = await Promise.all([
+            this._services.rankingService?.getGlobalRanking(guildIds).catch(() => []) ?? Promise.resolve([]),
+            this._services.userBlockService?.getBlockedUsers().catch(() => []) ?? Promise.resolve([]),
+            this._getServerStats([...guildIds]),
+        ]);
+
+        const ocrStats = this._services.ocrStatsService?.getStats() || null;
+        const activeCooldownCount = this._getActiveCooldownCount();
+        const pendingCvCount = this._getPendingCvCount();
+        const todayTokens = this._getTodayTokens([...guildIds]);
+
+        const lastUpdated = now.toLocaleString('pl-PL', {
+            timeZone: 'Europe/Warsaw',
+            day: '2-digit', month: '2-digit', year: 'numeric',
+            hour: '2-digit', minute: '2-digit', second: '2-digit'
+        });
+
+        return [
+            this._buildStatusEmbed(serverStats, lastUpdated),
+            this._buildOcrEmbed(ocrStats, pendingCvCount),
+            this._buildPlayersEmbed(globalRanking, blockedUsersArr, activeCooldownCount),
+            this._buildCostEmbed(todayTokens),
+            this._buildServersEmbed(serverStats),
+        ];
+    }
+
+    _getActiveCooldownCount() {
+        const svc = this._services.updateCooldownService;
+        if (!svc?._cooldowns) return 0;
+        const now = Date.now();
+        let count = 0;
+        for (const [, entry] of svc._cooldowns) {
+            if (entry.expiresAt > now) count++;
+        }
+        return count;
+    }
+
+    _getPendingCvCount() {
+        const svc = this._services.communityVerificationService;
+        if (!svc?._sessions) return 0;
+        return Object.values(svc._sessions).filter(s => s.status === 'pending').length;
+    }
+
+    _getTodayTokens(guildIds) {
+        const svc = this._services.tokenUsageService;
+        if (!svc?.data?.guilds) return { promptTokens: 0, outputTokens: 0, requests: 0, cost: 0 };
+        const today = todayKey();
+        let promptTokens = 0, outputTokens = 0, requests = 0;
+        for (const guildId of guildIds) {
+            const d = svc.data.guilds[guildId]?.[today];
+            if (!d) continue;
+            promptTokens += d.promptTokens || 0;
+            outputTokens += d.outputTokens || 0;
+            requests += d.requests || 0;
+        }
+        const cost = (promptTokens / 1_000_000) * 0.10 + (outputTokens / 1_000_000) * 0.40;
+        return { promptTokens, outputTokens, requests, cost };
+    }
+
+    async _getServerStats(guildIds) {
+        const stats = [];
+        const cfgSvc = this._services.guildConfigService;
+        for (const guildId of guildIds) {
+            const cfg = cfgSvc?.getConfig(guildId);
+            if (!cfg?.configured) continue;
+            let playerCount = 0;
+            try {
+                const ranking = await this._services.rankingService?.loadRanking(guildId).catch(() => ({})) ?? {};
+                playerCount = Object.keys(ranking).length;
+            } catch { /* pomiń */ }
+            const ocrBlocked = cfg.ocrBlocked || [];
+            stats.push({
+                guildId,
+                guildName: cfg.guildName || guildId,
+                playerCount,
+                updateBlocked: ocrBlocked.includes('update'),
+                testBlocked: ocrBlocked.includes('test'),
+                lang: cfg.lang || 'pol',
+                tag: cfg.tag || null,
+            });
+        }
+        return stats;
+    }
+
+    _buildStatusEmbed(serverStats, lastUpdated) {
+        const uptime = fmtUptime(Date.now() - this._startTime);
+        const configuredCount = serverStats.length;
+
+        // Następny Global TOP10
+        let nextTop10 = '—';
+        const g10 = this._services.globalTop10Service;
+        try {
+            if (g10?._cfg?.nextTrigger && g10?._cfg?.enabled) {
+                nextTop10 = fmtTs(g10._cfg.nextTrigger);
+            }
+        } catch { /* pomiń */ }
+
+        const aiEnabled = this._config.ocr?.useAI !== false;
+
+        return new EmbedBuilder()
+            .setColor(0xFF6B35)
+            .setTitle('📡 Centrum Dowodzenia — EndersEcho')
+            .addFields(
+                { name: '⏱️ Uptime', value: uptime, inline: true },
+                { name: '🖥️ Serwery', value: `${configuredCount}`, inline: true },
+                { name: '🌐 AI OCR', value: aiEnabled ? '✅ Włączone' : '❌ Wyłączone', inline: true },
+                { name: '📅 Następny Global TOP10', value: nextTop10, inline: false },
+            )
+            .setFooter({ text: `Ostatnia aktualizacja: ${lastUpdated}` });
+    }
+
+    _buildOcrEmbed(ocrStats, pendingCvCount) {
+        const at = ocrStats?.allTime ?? { total: 0, success: 0, adminFixed: 0 };
+        const rs = ocrStats?.resettable ?? { total: 0, success: 0, adminFixed: 0 };
+
+        const atFixed = at.adminFixed || 0;
+        const rsFixed = rs.adminFixed || 0;
+        const atRate = at.total > 0 ? `${(((at.total - atFixed) / at.total) * 100).toFixed(1)}%` : '—';
+        const rsRate = rs.total > 0 ? `${(((rs.total - rsFixed) / rs.total) * 100).toFixed(1)}%` : '—';
+
+        let lastAnalysis = '—';
+        if (this._lastRecord) {
+            const lr = this._lastRecord;
+            const boss = lr.bossName ? ` (${lr.bossName})` : '';
+            lastAnalysis = `**${lr.userName}** — ${lr.score}${boss} • ${timeSince(lr.timestamp)}`;
+        }
+
+        return new EmbedBuilder()
+            .setColor(0x5865F2)
+            .setTitle('📊 Statystyki OCR')
+            .addFields(
+                { name: '📈 Łącznie analiz', value: `${at.total}`, inline: true },
+                { name: '🔄 Od ostatniego resetu', value: `${rs.total}`, inline: true },
+                { name: '✅ Success Rate', value: `${atRate} (reset: ${rsRate})`, inline: true },
+                { name: '🔧 Interwencje admina', value: `Łącznie: **${atFixed}** | Reset: **${rsFixed}**`, inline: true },
+                { name: '🗳️ Oczekujące CV', value: `${pendingCvCount}`, inline: true },
+                { name: '📸 Ostatnia analiza', value: lastAnalysis, inline: false },
+            );
+    }
+
+    _buildPlayersEmbed(globalRanking, blockedUsersArr, activeCooldownCount) {
+        const totalPlayers = globalRanking.length;
+        const blockedCount = Array.isArray(blockedUsersArr) ? blockedUsersArr.length : 0;
+        const medals = ['🥇', '🥈', '🥉'];
+
+        const fields = [
+            { name: '👥 Łącznie graczy', value: `${totalPlayers}`, inline: true },
+            { name: '⏳ Aktywne cooldowny', value: `${activeCooldownCount}`, inline: true },
+            { name: '🔒 Zablokowanych', value: `${blockedCount}`, inline: true },
+        ];
+
+        const top3 = (globalRanking || []).slice(0, 3);
+        for (let i = 0; i < top3.length; i++) {
+            const p = top3[i];
+            const boss = p.bossName ? ` • ${p.bossName}` : '';
+            fields.push({
+                name: `${medals[i]} #${i + 1} — ${p.username || p.userId}`,
+                value: `${p.score}${boss}`,
+                inline: true,
+            });
+        }
+
+        // Dopełnij do wielokrotności 3 (Discord wymaga równych rzędów inline)
+        while (fields.length % 3 !== 0 && top3.length > 0) {
+            fields.push({ name: '​', value: '​', inline: true });
+        }
+
+        return new EmbedBuilder()
+            .setColor(0x57F287)
+            .setTitle('🌍 Gracze Globalnie')
+            .addFields(fields);
+    }
+
+    _buildCostEmbed(todayTokens) {
+        const { promptTokens, outputTokens, requests, cost } = todayTokens;
+        return new EmbedBuilder()
+            .setColor(0xFEE75C)
+            .setTitle('💰 Koszty AI — Dzisiaj')
+            .addFields(
+                { name: '📤 Requesty', value: `${requests}`, inline: true },
+                { name: '🔤 Tokeny IN', value: fmtTokens(promptTokens), inline: true },
+                { name: '🔤 Tokeny OUT', value: fmtTokens(outputTokens), inline: true },
+                { name: '💵 Szacowany koszt', value: fmtCost(cost), inline: true },
+                { name: '🔢 Łącznie tokenów', value: fmtTokens(promptTokens + outputTokens), inline: true },
+                { name: '​', value: '​', inline: true },
+            );
+    }
+
+    _buildServersEmbed(serverStats) {
+        if (serverStats.length === 0) {
+            return new EmbedBuilder()
+                .setColor(0xEB459E)
+                .setTitle('🖥️ Status Serwerów')
+                .setDescription('Brak skonfigurowanych serwerów.');
+        }
+
+        const lines = serverStats.map(s => {
+            const ocrIcon = s.updateBlocked ? '❌' : '✅';
+            const tag = s.tag ? ` \`${s.tag}\`` : '';
+            const lang = s.lang.toUpperCase();
+            return `${ocrIcon} **${s.guildName}**${tag} — ${s.playerCount} graczy | OCR: ${ocrIcon} | ${lang}`;
+        });
+
+        return new EmbedBuilder()
+            .setColor(0xEB459E)
+            .setTitle('🖥️ Status Serwerów')
+            .setDescription(lines.join('\n'));
+    }
+}
+
+module.exports = AdminPanelService;


### PR DESCRIPTION
## Summary

- Nowy serwis `adminPanelService.js` — zarządza wiadomością Centrum Dowodzenia
- Nowa zmienna env `ENDERSECHO_ADMIN_PANEL_CHANNEL_ID` — kanał gdzie bot wysyła panel
- Nowy przycisk `📡 Centrum Dowodzenia` w `/manage` (tylko Head Admin)
- 5 live-embedów automatycznie edytowanych po każdym zdarzeniu

## Panel — 5 Embedów

| Embed | Zawartość |
|---|---|
| 📡 Status systemu | Uptime, liczba serwerów, AI OCR on/off, następny Global TOP10 |
| 📊 Statystyki OCR | Łącznie analiz, od resetu, Success Rate, interwencje admina, oczekujące CV, ostatnia analiza |
| 🌍 Gracze Globalnie | Łącznie graczy, aktywne cooldowny, zablokowanych, TOP 3 globalny |
| 💰 Koszty AI (Dzisiaj) | Requesty, tokeny IN/OUT, łącznie, koszt ($) |
| 🖥️ Status Serwerów | Per serwer: OCR on/off, gracze, język, tag |

## Triggery Auto-Refresh

- Po każdym `/update` (nowy rekord lub nie, `!dryRun`)
- Po analizie admina (Analizuj panel)
- Po usunięciu gracza z rankingu
- Po zablokowaniu/odblokowaniu gracza
- Po akcji Community Verification (approve/remove/block)
- Przy starcie bota
- Na żądanie przez `/manage` → `📡 Centrum Dowodzenia` → `🔄 Odśwież Panel`

## Konfiguracja

Dodaj do `.env`:
```
ENDERSECHO_ADMIN_PANEL_CHANNEL_ID=id_kanalu_head_admina
```

## Test plan

- [ ] Dodać `ENDERSECHO_ADMIN_PANEL_CHANNEL_ID` w `.env` na serwerze
- [ ] Zrestartować bota — panel powinien pojawić się na kanale
- [ ] Przesłać wynik przez `/update` — panel powinien się zaktualizować
- [ ] Sprawdzić `/manage` → `📡 Centrum Dowodzenia` → `🔄 Odśwież Panel`
- [ ] Zablokować gracza → sprawdzić czy licznik Zablokowanych się zaktualizował
- [ ] Sprawdzić czy po restarcie bota panel zostaje edytowany (nie wysyłana nowa wiadomość)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQwK96XD35wqSJMB43Yu1g)_