### PR TITLE
EndersEcho: Rozbudowa Centrum Dowodzenia — alerty, przyciski panelu, deep-dive serwerów

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -287,8 +287,17 @@
 | `panel_unblock_select` | StringSelectMenu — wybór do odblokowania |
 | `panel_tokens` | Pokaż statystyki tokenów |
 | `panel_process_roles` | Pełny reset ról TOP: usuń wszystkie → przyznaj wg aktualnego rankingu (admin + head admin) |
-| `panel_cmd_center` | Otwórz widok Centrum Dowodzenia (head admin) |
+| `panel_cmd_center` | Otwórz widok Centrum Dowodzenia z zakładkami (head admin) |
 | `panel_cmd_center_refresh` | Wymuś natychmiastowy refresh panelu Centrum Dowodzenia (head admin) |
+| `cc_refresh` | Odśwież wiadomość panelu (panel message → ephemeral) |
+| `cc_quick` | Szybki Podgląd — live snapshot OCR/koszty/CV (panel message → ephemeral) |
+| `cc_alerts` | Zarządzanie alertami (panel message → ephemeral) |
+| `cc_alert_ack_all` | Potwierdź wszystkie aktywne alerty |
+| `cc_alert_ack_{type}` | Potwierdź konkretny alert (ocrRate/pendingCv/dailyCost) |
+| `cc_thresh_set_{type}` | Otwórz modal zmiany progu alertu |
+| `cc_thresh_modal_{type}` | Modal zmiany progu (pole `cc_thresh_value`) |
+| `cc_tab_sel` | StringSelectMenu — zmiana zakładki w widoku CC (overview/quick/alert_cfg) |
+| `cc_server_sel` | StringSelectMenu — deep-dive serwera (panel message → ephemeral z TOP5 i paskami postępu) |
 | `panel_info` | Otwórz modal /info (head admin) |
 | `panel_tester` | Pokaż listę testerów + przyciski Dodaj/Usuń (head admin) |
 | `panel_tester_add` | Otwórz modal wpisania ID użytkownika |
@@ -739,14 +748,14 @@ Po **pierwszej** konfiguracji serwera (`!wasAlreadyConfigured`) pod embedem sukc
 
 ## Centrum Dowodzenia Head Admina (Admin Panel Live Dashboard)
 
-**Plik serwisu:** `services/adminPanelService.js`
+**Pliki serwisów:** `services/adminPanelService.js`, `services/alertService.js`
 
 **Konfiguracja (zmienna env):**
 ```env
 ENDERSECHO_ADMIN_PANEL_CHANNEL_ID=id_kanalu_head_admina
 ```
 
-**Działanie:** Panel to jedna stała wiadomość z 5 embedami na kanale head admina. Edytowana automatycznie po każdym zdarzeniu — nie flood kanału nowymi wiadomościami.
+**Działanie:** Panel to jedna stała wiadomość z 5 embedami + komponenty (przyciski + select menu) na kanale head admina. Edytowana automatycznie po każdym zdarzeniu.
 
 **5 embedów panelu:**
 
@@ -757,6 +766,26 @@ ENDERSECHO_ADMIN_PANEL_CHANNEL_ID=id_kanalu_head_admina
 | 3 | 🌍 Gracze Globalnie | `0x57F287` | Łącznie graczy, aktywne cooldowny, zablokowanych, TOP 3 globalny |
 | 4 | 💰 Koszty AI — Dzisiaj | `0xFEE75C` | Requesty, tokeny IN/OUT, łącznie tokenów, szacowany koszt ($) |
 | 5 | 🖥️ Status Serwerów | `0xEB459E` | Per serwer: OCR on/off, liczba graczy, język, tag |
+
+**Komponenty na wiadomości panelu (Rząd 1 — przyciski):**
+- `🔄 cc_refresh` — wymuś refresh (odpowiada ephemeral)
+- `🚨 cc_alerts (N)` — zarządzaj alertami (czerwony gdy N>0, szary gdy brak; ephemeral)
+- `⚡ cc_quick` — Szybki Podgląd z live statystykami (ephemeral)
+
+**Komponenty na wiadomości panelu (Rząd 2 — select menu):**
+- `cc_server_sel` — deep-dive wybranego serwera: TOP5 z paskami postępu `█░`, koszty AI, OCR status (ephemeral)
+
+**Widok `/manage → 📡 Centrum Dowodzenia` (zakładki via select menu):**
+- `📡 Przegląd` — status panelu + instrukcje obsługi
+- `⚡ Szybki Podgląd` — live OCR rate z paskiem, koszty z paskiem, CV, cooldowny, serwery
+- `⚙️ Konfiguracja Alertów` — stan alertów, potwierdzanie, zmiana progów przez modal
+
+**AlertService (`services/alertService.js`):**
+- Trzy typy alertów: `ocrRate` (min %), `pendingCv` (max count), `dailyCost` (max $)
+- Domyślne progi: OCR <80%, CV >3, koszt >$5.00
+- Debounce: alert wysyłany max raz na godzinę tego samego typu
+- Persistencja: `data/alert_config.json` — `{ thresholds, active }`
+- Po przekroczeniu progu: oddzielna wiadomość `🚨 Centrum Dowodzenia — Nowy Alert!` na kanale panelu
 
 **Triggery automatycznego refresh:**
 - ✅ Po każdym zapisie wyniku (`/update` — zarówno nowy rekord jak i brak rekordu, `!dryRun`)
@@ -780,6 +809,8 @@ adminPanelService.setupChannel(channelId); // zmień kanał i wyślij nową wiad
 adminPanelService.isConfigured(); // czy ENDERSECHO_ADMIN_PANEL_CHANNEL_ID ustawione
 adminPanelService.getChannelId(); // ID aktualnego kanału
 adminPanelService.getMessageId(); // ID wiadomości panelu (null = jeszcze nie wysłana)
+adminPanelService.alertService;  // getter do AlertService (sprawdź alerty)
+adminPanelService.buildServerDeepDive(guildId); // embed z TOP5 + paski postępu dla serwera
 ```
 
-**Dostęp przez `/manage`:** Rząd 2 (tylko Head Admin) → `📡 Centrum Dowodzenia` → widok statusu + `🔄 Odśwież Panel`.
+**Dostęp przez `/manage`:** Rząd 2 (tylko Head Admin) → `📡 Centrum Dowodzenia` → zakładki: Przegląd / Szybki Podgląd / Konfiguracja Alertów.

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -379,6 +379,14 @@ class InteractionHandler {
                 await this._handlePanelBlockModal(interaction, parts[0], parts[1]);
                 return;
             }
+            if (interaction.customId.startsWith('cc_thresh_modal_')) {
+                if (!this._isHeadAdmin(interaction.user.id)) {
+                    await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+                    return;
+                }
+                await this._handleCcThreshModal(interaction);
+                return;
+            }
             if (interaction.customId === 'cfg_tag_modal') {
                 await this._handleConfigureTagModal(interaction);
                 return;
@@ -2454,53 +2462,262 @@ class InteractionHandler {
             await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
             return;
         }
-        const t = this._panelT(interaction.guildId);
-        const svc = this.adminPanelService;
+        await this._showCcTab(interaction, 'overview', 'update');
+    }
+
+    // ─── Centrum Dowodzenia — wspólny renderer zakładek ──────────────────────
+
+    _buildCcTabRows(activeTab, svc, alertCount) {
+        const t = this._panelT();
+        const tabSel = new StringSelectMenuBuilder()
+            .setCustomId('cc_tab_sel')
+            .setPlaceholder('📂 Wybierz zakładkę...')
+            .addOptions([
+                new StringSelectMenuOptionBuilder()
+                    .setLabel('📡 Przegląd')
+                    .setValue('overview')
+                    .setDescription('Status panelu i szybkie akcje')
+                    .setDefault(activeTab === 'overview'),
+                new StringSelectMenuOptionBuilder()
+                    .setLabel('⚡ Szybki Podgląd')
+                    .setValue('quick')
+                    .setDescription('Live snapshot: OCR, gracze, koszty')
+                    .setDefault(activeTab === 'quick'),
+                new StringSelectMenuOptionBuilder()
+                    .setLabel('⚙️ Konfiguracja Alertów')
+                    .setValue('alert_cfg')
+                    .setDescription(`Aktywne alerty: ${alertCount}`)
+                    .setDefault(activeTab === 'alert_cfg'),
+            ]);
+
+        const isConfigured = svc?.isConfigured() ?? false;
+        const btnRow = new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId('panel_back')
+                .setEmoji('◀️')
+                .setLabel('Wróć')
+                .setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder()
+                .setCustomId('cc_refresh')
+                .setEmoji('🔄')
+                .setLabel('Odśwież Panel')
+                .setStyle(ButtonStyle.Primary)
+                .setDisabled(!isConfigured),
+            alertCount > 0
+                ? new ButtonBuilder().setCustomId('cc_alerts').setEmoji('🚨').setLabel(`Alerty (${alertCount})`).setStyle(ButtonStyle.Danger)
+                : new ButtonBuilder().setCustomId('cc_alerts').setEmoji('🚨').setLabel('Alerty').setStyle(ButtonStyle.Secondary).setDisabled(true),
+        );
+
+        return [
+            new ActionRowBuilder().addComponents(tabSel),
+            btnRow,
+        ];
+    }
+
+    _buildCcOverviewEmbed(svc) {
         const isConfigured = svc?.isConfigured();
         const channelId = svc?.getChannelId();
         const messageId = svc?.getMessageId();
 
         let statusLine;
         if (!isConfigured) {
-            statusLine = t(
-                '⚠️ **Panel nie jest skonfigurowany.**\nUstaw `ENDERSECHO_ADMIN_PANEL_CHANNEL_ID` w pliku `.env` i zrestartuj bota.',
-                '⚠️ **Panel is not configured.**\nSet `ENDERSECHO_ADMIN_PANEL_CHANNEL_ID` in the `.env` file and restart the bot.'
-            );
+            statusLine = '⚠️ **Panel nie jest skonfigurowany.**\nUstaw `ENDERSECHO_ADMIN_PANEL_CHANNEL_ID` w `.env` i zrestartuj bota.';
         } else if (messageId) {
-            statusLine = t(
-                `✅ **Panel aktywny** na kanale <#${channelId}>\n📩 ID wiadomości: \`${messageId}\``,
-                `✅ **Panel active** in channel <#${channelId}>\n📩 Message ID: \`${messageId}\``
-            );
+            statusLine = `✅ **Panel aktywny** na kanale <#${channelId}>\n📩 ID wiadomości: \`${messageId}\``;
         } else {
-            statusLine = t(
-                `📬 Kanał ustawiony: <#${channelId}>\n⏳ Wiadomość zostanie wysłana przy najbliższym refresh.`,
-                `📬 Channel set: <#${channelId}>\n⏳ Message will be sent on next refresh.`
+            statusLine = `📬 Kanał ustawiony: <#${channelId}>\n⏳ Wiadomość zostanie wysłana przy najbliższym refresh.`;
+        }
+
+        return new EmbedBuilder()
+            .setColor(0xFF6B35)
+            .setTitle('📡 Centrum Dowodzenia — Przegląd')
+            .setDescription(
+                statusLine + '\n\n' +
+                '**Panel aktualizuje się automatycznie** po każdym nowym rekordzie, akcji admina i weryfikacji społeczności.\n\n' +
+                '• `🔄 Odśwież Panel` — wymuś natychmiastowe odświeżenie wiadomości panelu\n' +
+                '• `🚨 Alerty` — zarządzaj aktywnymi alertami i progami\n' +
+                '• Zakładka **⚡ Szybki Podgląd** — live snapshot statystyk\n' +
+                '• Zakładka **⚙️ Konfiguracja Alertów** — ustaw progi alertów'
             );
+    }
+
+    async _buildCcQuickEmbed() {
+        const fmtCost = (usd) => {
+            if (usd === 0) return '$0.0000';
+            if (usd < 0.0001) return '<$0.0001';
+            return `$${usd.toFixed(4)}`;
+        };
+        const fmtTokens = (n) => {
+            if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+            if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+            return n.toString();
+        };
+        const svc = this.adminPanelService;
+        if (!svc) return new EmbedBuilder().setColor(0xFF4444).setDescription('Brak serwisu panelu.');
+
+        const guildIds = [...svc._getActiveGuildIds()];
+        const ocrStats = svc._services?.ocrStatsService?.getStats() || null;
+        const pendingCv = svc._getPendingCvCount();
+        const { promptTokens, outputTokens, requests, cost } = svc._getTodayTokens(guildIds);
+        const activeCooldowns = svc._getActiveCooldownCount();
+
+        const at = ocrStats?.allTime ?? { total: 0, success: 0, adminFixed: 0 };
+        const ocrRate = at.total > 0
+            ? ((at.total - (at.adminFixed || 0)) / at.total * 100).toFixed(1)
+            : '—';
+        const ocrBar = at.total > 0
+            ? svc._buildProgressBar(parseFloat(ocrRate), 100, 12)
+            : '░'.repeat(12);
+
+        const costBar = svc._buildProgressBar(cost, 5.0, 12);
+
+        const now = new Date().toLocaleString('pl-PL', {
+            timeZone: 'Europe/Warsaw',
+            hour: '2-digit', minute: '2-digit', second: '2-digit',
+        });
+
+        return new EmbedBuilder()
+            .setColor(0x57F287)
+            .setTitle('⚡ Centrum Dowodzenia — Szybki Podgląd')
+            .addFields(
+                {
+                    name: '📸 OCR',
+                    value: `Skuteczność: **${ocrRate}%**\n\`${ocrBar}\`\nŁącznie: ${at.total} | Interwencje: ${at.adminFixed || 0}`,
+                    inline: true,
+                },
+                {
+                    name: '💰 Koszt AI (dziś)',
+                    value: `**${fmtCost(cost)}** / $5.00\n\`${costBar}\`\nTokeny IN: ${fmtTokens(promptTokens)} | OUT: ${fmtTokens(outputTokens)}\nRequesty: ${requests}`,
+                    inline: true,
+                },
+                {
+                    name: '🗳️ Weryfikacje CV',
+                    value: `Oczekujących: **${pendingCv}**`,
+                    inline: true,
+                },
+                {
+                    name: '⏳ Cooldowny',
+                    value: `Aktywnych: **${activeCooldowns}**`,
+                    inline: true,
+                },
+                {
+                    name: '🖥️ Serwery',
+                    value: `Skonfigurowanych: **${guildIds.length}**`,
+                    inline: true,
+                },
+            )
+            .setFooter({ text: `Live snapshot • ${now}` });
+    }
+
+    _buildCcAlertCfgEmbed(alertSvc) {
+        if (!alertSvc) {
+            return new EmbedBuilder()
+                .setColor(0xFEE75C)
+                .setTitle('⚙️ Centrum Dowodzenia — Konfiguracja Alertów')
+                .setDescription('⚠️ AlertService nie jest zainicjalizowany.');
+        }
+
+        const thresholds = alertSvc.getThresholds();
+        const active = alertSvc.getActiveAlerts();
+        const alertCount = alertSvc.getActiveAlertCount();
+
+        const threshLines = [
+            `• **OCR Rate**: alert gdy skuteczność < **${thresholds.ocrRate}%**`,
+            `• **Oczekujące CV**: alert gdy > **${thresholds.pendingCv}**`,
+            `• **Koszt AI/dzień**: alert gdy > **$${thresholds.dailyCost}**`,
+        ];
+
+        const activeLines = [];
+        for (const [type, alert] of Object.entries(active)) {
+            if (!alert) continue;
+            const ackIcon = alert.acknowledged ? '✅' : '🔴';
+            const desc = alertSvc.describeAlert(type, alert.value);
+            const since = new Date(alert.triggeredAt).toLocaleString('pl-PL', {
+                timeZone: 'Europe/Warsaw', hour: '2-digit', minute: '2-digit',
+            });
+            activeLines.push(`${ackIcon} ${desc}\n*od ${since}*`);
         }
 
         const embed = new EmbedBuilder()
-            .setColor(0xFF6B35)
-            .setTitle(t('📡 Centrum Dowodzenia', '📡 Command Center'))
-            .setDescription(
-                statusLine + '\n\n' +
-                t(
-                    '**Panel aktualizuje się automatycznie** po każdym nowym rekordzie, akcji admina i weryfikacji społeczności.\n\nUżyj przycisku poniżej aby wymusić natychmiastowy refresh.',
-                    '**The panel updates automatically** after every new record, admin action and community verification.\n\nUse the button below to force an immediate refresh.'
-                )
+            .setColor(alertCount > 0 ? 0xFF4444 : 0x57F287)
+            .setTitle('⚙️ Centrum Dowodzenia — Konfiguracja Alertów')
+            .addFields({
+                name: '📏 Aktualne progi',
+                value: threshLines.join('\n'),
+                inline: false,
+            });
+
+        if (activeLines.length > 0) {
+            embed.addFields({
+                name: `🚨 Aktywne alerty (${alertCount})`,
+                value: activeLines.join('\n\n'),
+                inline: false,
+            });
+
+            const ackAllRow = new ActionRowBuilder().addComponents(
+                new ButtonBuilder()
+                    .setCustomId('cc_alert_ack_all')
+                    .setEmoji('✅')
+                    .setLabel('Potwierdź wszystkie')
+                    .setStyle(ButtonStyle.Success),
             );
+            embed.setDescription('Użyj przycisków poniżej, aby potwierdzić alerty lub zmienić progi.');
+            return { embed, extraRows: [ackAllRow] };
+        } else {
+            embed.addFields({
+                name: '✅ Brak aktywnych alertów',
+                value: 'Wszystkie metryki w normie.',
+                inline: false,
+            });
+        }
 
-        const back = new ButtonBuilder().setCustomId('panel_back').setEmoji('◀️').setLabel(t('Wróć', 'Back')).setStyle(ButtonStyle.Secondary);
-        const components = [new ActionRowBuilder().addComponents(
-            new ButtonBuilder()
-                .setCustomId('panel_cmd_center_refresh')
-                .setEmoji('🔄')
-                .setLabel(t('Odśwież Panel', 'Refresh Panel'))
-                .setStyle(ButtonStyle.Primary)
-                .setDisabled(!isConfigured),
-            back,
-        )];
+        embed.addFields({
+            name: '🔧 Zmiana progów',
+            value: 'Użyj przycisków poniżej, aby zmienić progi alertów.',
+            inline: false,
+        });
 
-        await interaction.update({ embeds: [embed], components });
+        return { embed, extraRows: [] };
+    }
+
+    async _showCcTab(interaction, tab, method = 'update') {
+        const svc = this.adminPanelService;
+        const alertSvc = svc?.alertService;
+        const alertCount = alertSvc?.getActiveAlertCount() ?? 0;
+
+        let embed;
+        let extraRows = [];
+
+        if (tab === 'overview') {
+            embed = this._buildCcOverviewEmbed(svc);
+        } else if (tab === 'quick') {
+            embed = await this._buildCcQuickEmbed();
+        } else if (tab === 'alert_cfg') {
+            const result = this._buildCcAlertCfgEmbed(alertSvc);
+            embed = result.embed;
+            extraRows = result.extraRows || [];
+
+            // Dodaj przyciski progów (tylko dla admina)
+            const threshBtns = new ActionRowBuilder().addComponents(
+                new ButtonBuilder().setCustomId('cc_thresh_set_ocrRate').setEmoji('📊').setLabel('Próg OCR %').setStyle(ButtonStyle.Secondary),
+                new ButtonBuilder().setCustomId('cc_thresh_set_pendingCv').setEmoji('🗳️').setLabel('Próg CV').setStyle(ButtonStyle.Secondary),
+                new ButtonBuilder().setCustomId('cc_thresh_set_dailyCost').setEmoji('💰').setLabel('Próg kosztu').setStyle(ButtonStyle.Secondary),
+            );
+            extraRows.push(threshBtns);
+        } else {
+            embed = this._buildCcOverviewEmbed(svc);
+        }
+
+        const tabRows = this._buildCcTabRows(tab, svc, alertCount);
+        const components = [...tabRows, ...extraRows];
+
+        if (method === 'update') {
+            await interaction.update({ embeds: [embed], components });
+        } else if (method === 'editReply') {
+            await interaction.editReply({ embeds: [embed], components });
+        } else {
+            await interaction.reply({ embeds: [embed], components, flags: ['Ephemeral'] });
+        }
     }
 
     async _handlePanelCmdCenterRefresh(interaction) {
@@ -2539,6 +2756,179 @@ class InteractionHandler {
             components: [new ActionRowBuilder().addComponents(
                 new ButtonBuilder().setCustomId('panel_cmd_center').setEmoji('◀️').setLabel(t('Powrót', 'Back')).setStyle(ButtonStyle.Secondary)
             )]
+        });
+    }
+
+    // ─── Panel message CC handlers (ephemeral) ───────────────────────────────
+
+    async _handleCcRefresh(interaction) {
+        if (!this._isHeadAdmin(interaction.user.id)) {
+            await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+            return;
+        }
+        const svc = this.adminPanelService;
+        if (!svc?.isConfigured()) {
+            await interaction.reply({ embeds: [new EmbedBuilder().setColor(0xFF4444).setDescription('❌ Panel nie jest skonfigurowany.')], flags: ['Ephemeral'] });
+            return;
+        }
+        await interaction.deferReply({ flags: ['Ephemeral'] });
+        await svc._doRefresh().catch(() => {});
+        const channelId = svc.getChannelId();
+        await interaction.editReply({
+            embeds: [new EmbedBuilder().setColor(0x57F287)
+                .setTitle('✅ Panel odświeżony')
+                .setDescription(`Panel Centrum Dowodzenia na <#${channelId}> został zaktualizowany.`)
+            ]
+        });
+    }
+
+    async _handleCcQuick(interaction) {
+        if (!this._isHeadAdmin(interaction.user.id)) {
+            await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+            return;
+        }
+        await interaction.deferReply({ flags: ['Ephemeral'] });
+        const embed = await this._buildCcQuickEmbed();
+        await interaction.editReply({ embeds: [embed] });
+    }
+
+    async _handleCcAlerts(interaction) {
+        if (!this._isHeadAdmin(interaction.user.id)) {
+            await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+            return;
+        }
+        const alertSvc = this.adminPanelService?.alertService;
+        const { embed, extraRows } = this._buildCcAlertCfgEmbed(alertSvc);
+
+        const threshBtns = new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId('cc_thresh_set_ocrRate').setEmoji('📊').setLabel('Próg OCR %').setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('cc_thresh_set_pendingCv').setEmoji('🗳️').setLabel('Próg CV').setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('cc_thresh_set_dailyCost').setEmoji('💰').setLabel('Próg kosztu').setStyle(ButtonStyle.Secondary),
+        );
+
+        const components = [...(extraRows || []), threshBtns];
+        await interaction.reply({ embeds: [embed], components, flags: ['Ephemeral'] });
+    }
+
+    async _handleCcAlertAck(interaction, alertType) {
+        if (!this._isHeadAdmin(interaction.user.id)) {
+            await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+            return;
+        }
+        const alertSvc = this.adminPanelService?.alertService;
+        if (!alertSvc) {
+            await interaction.reply({ embeds: [new EmbedBuilder().setColor(0xFF4444).setDescription('❌ AlertService niedostępny.')], flags: ['Ephemeral'] });
+            return;
+        }
+
+        if (alertType === 'all') {
+            await alertSvc.acknowledgeAll();
+        } else {
+            await alertSvc.acknowledgeAlert(alertType);
+        }
+
+        // Odśwież panel żeby zaktualizować licznik przycisków
+        this.adminPanelService?.refresh();
+
+        const { embed, extraRows } = this._buildCcAlertCfgEmbed(alertSvc);
+        const threshBtns = new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId('cc_thresh_set_ocrRate').setEmoji('📊').setLabel('Próg OCR %').setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('cc_thresh_set_pendingCv').setEmoji('🗳️').setLabel('Próg CV').setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('cc_thresh_set_dailyCost').setEmoji('💰').setLabel('Próg kosztu').setStyle(ButtonStyle.Secondary),
+        );
+        await interaction.update({ embeds: [embed], components: [...(extraRows || []), threshBtns] });
+    }
+
+    async _handleCcThreshSet(interaction, alertType) {
+        if (!this._isHeadAdmin(interaction.user.id)) {
+            await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+            return;
+        }
+        const alertSvc = this.adminPanelService?.alertService;
+        if (!alertSvc) {
+            await interaction.reply({ embeds: [new EmbedBuilder().setColor(0xFF4444).setDescription('❌ AlertService niedostępny.')], flags: ['Ephemeral'] });
+            return;
+        }
+        const info = alertSvc.describeThreshold(alertType);
+        const modal = new ModalBuilder()
+            .setCustomId(`cc_thresh_modal_${alertType}`)
+            .setTitle(`Zmień próg: ${info.label}`);
+        modal.addComponents(new ActionRowBuilder().addComponents(
+            new TextInputBuilder()
+                .setCustomId('cc_thresh_value')
+                .setLabel(`${info.label} (obecny: ${info.current})`)
+                .setStyle(TextInputStyle.Short)
+                .setPlaceholder(info.unit ? `Podaj wartość (${info.unit})` : 'Podaj wartość liczbową')
+                .setRequired(true)
+                .setMinLength(1)
+                .setMaxLength(10)
+        ));
+        await interaction.showModal(modal);
+    }
+
+    async _handleCcServerSel(interaction) {
+        if (!this._isHeadAdmin(interaction.user.id)) {
+            await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+            return;
+        }
+        const guildId = interaction.values?.[0];
+        if (!guildId) {
+            await interaction.reply({ embeds: [new EmbedBuilder().setColor(0xFF4444).setDescription('❌ Nie wybrano serwera.')], flags: ['Ephemeral'] });
+            return;
+        }
+        await interaction.deferReply({ flags: ['Ephemeral'] });
+        const svc = this.adminPanelService;
+        const embed = await svc?.buildServerDeepDive(guildId);
+        if (!embed) {
+            await interaction.editReply({ embeds: [new EmbedBuilder().setColor(0xFF4444).setDescription(`❌ Brak danych dla serwera \`${guildId}\`.`)] });
+            return;
+        }
+        await interaction.editReply({ embeds: [embed] });
+    }
+
+    async _handleCcTabSel(interaction) {
+        if (!this._isHeadAdmin(interaction.user.id)) {
+            await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+            return;
+        }
+        const tab = interaction.values?.[0] || 'overview';
+        await this._showCcTab(interaction, tab, 'update');
+    }
+
+    async _handleCcThreshModal(interaction) {
+        const alertType = interaction.customId.replace('cc_thresh_modal_', '');
+        const alertSvc = this.adminPanelService?.alertService;
+        if (!alertSvc) {
+            await interaction.reply({ embeds: [new EmbedBuilder().setColor(0xFF4444).setDescription('❌ AlertService niedostępny.')], flags: ['Ephemeral'] });
+            return;
+        }
+        const raw = interaction.fields.getTextInputValue('cc_thresh_value');
+        const num = parseFloat(raw.replace(',', '.'));
+        if (isNaN(num) || num < 0) {
+            await interaction.reply({ embeds: [new EmbedBuilder().setColor(0xFF4444).setDescription(`❌ Nieprawidłowa wartość: \`${raw}\`. Podaj dodatnią liczbę.`)], flags: ['Ephemeral'] });
+            return;
+        }
+        const ok = await alertSvc.setThreshold(alertType, num);
+        if (!ok) {
+            await interaction.reply({ embeds: [new EmbedBuilder().setColor(0xFF4444).setDescription(`❌ Nieznany typ alertu: \`${alertType}\``)], flags: ['Ephemeral'] });
+            return;
+        }
+        const info = alertSvc.describeThreshold(alertType);
+        // Odśwież panel żeby odzwierciedlić nowe progi
+        this.adminPanelService?.refresh();
+        const { embed, extraRows } = this._buildCcAlertCfgEmbed(alertSvc);
+        const threshBtns = new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId('cc_thresh_set_ocrRate').setEmoji('📊').setLabel('Próg OCR %').setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('cc_thresh_set_pendingCv').setEmoji('🗳️').setLabel('Próg CV').setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('cc_thresh_set_dailyCost').setEmoji('💰').setLabel('Próg kosztu').setStyle(ButtonStyle.Secondary),
+        );
+        await interaction.reply({
+            embeds: [
+                new EmbedBuilder().setColor(0x57F287).setDescription(`✅ Próg **${info.label}** ustawiony na **${info.current}**.`),
+                embed,
+            ],
+            components: [...(extraRows || []), threshBtns],
+            flags: ['Ephemeral'],
         });
     }
 
@@ -4440,6 +4830,14 @@ class InteractionHandler {
         if (customId === 'panel_delete_server_data') return 'Usuń dane serwera (panel)';
         if (customId === 'panel_delete_server_sel') return 'Usuń dane serwera (wybór)';
         if (customId.startsWith('panel_delete_server_ok_')) return `Usuń dane serwera (potwierdź: ${customId.replace('panel_delete_server_ok_', '')})`;
+        if (customId === 'cc_refresh') return 'CC: Odśwież Panel';
+        if (customId === 'cc_quick') return 'CC: Szybki Podgląd';
+        if (customId === 'cc_alerts') return 'CC: Zarządzaj Alertami';
+        if (customId === 'cc_alert_ack_all') return 'CC: Potwierdź wszystkie alerty';
+        if (customId.startsWith('cc_alert_ack_')) return `CC: Potwierdź alert ${customId.replace('cc_alert_ack_', '')}`;
+        if (customId.startsWith('cc_thresh_set_')) return `CC: Zmień próg ${customId.replace('cc_thresh_set_', '')}`;
+        if (customId === 'cc_tab_sel') return 'CC: Zmiana zakładki';
+        if (customId === 'cc_server_sel') return 'CC: Deep-dive serwer';
         return `panel: ${customId}`;
     }
 
@@ -4789,6 +5187,31 @@ class InteractionHandler {
             }
             if (customId === 'panel_cmd_center_refresh') {
                 await this._handlePanelCmdCenterRefresh(interaction);
+                return;
+            }
+            // Centrum Dowodzenia — przyciski na wiadomości panelu lub w zakładce CC
+            if (customId === 'cc_refresh') {
+                await this._handleCcRefresh(interaction);
+                return;
+            }
+            if (customId === 'cc_quick') {
+                await this._handleCcQuick(interaction);
+                return;
+            }
+            if (customId === 'cc_alerts') {
+                await this._handleCcAlerts(interaction);
+                return;
+            }
+            if (customId === 'cc_alert_ack_all') {
+                await this._handleCcAlertAck(interaction, 'all');
+                return;
+            }
+            if (customId.startsWith('cc_alert_ack_')) {
+                await this._handleCcAlertAck(interaction, customId.replace('cc_alert_ack_', ''));
+                return;
+            }
+            if (customId.startsWith('cc_thresh_set_')) {
+                await this._handleCcThreshSet(interaction, customId.replace('cc_thresh_set_', ''));
                 return;
             }
             if (customId === 'panel_remove') {
@@ -6718,6 +7141,14 @@ class InteractionHandler {
                 return;
             }
 
+            if (customId === 'cc_tab_sel') {
+                await this._handleCcTabSel(interaction);
+                return;
+            }
+            if (customId === 'cc_server_sel') {
+                await this._handleCcServerSel(interaction);
+                return;
+            }
             if (customId === 'panel_ocr_guild_select') {
                 await this._handlePanelOcrGuildSelect(interaction);
                 return;

--- a/EndersEcho/index.js
+++ b/EndersEcho/index.js
@@ -41,6 +41,7 @@ const KingBumChatService = require('./services/kingBumChatService');
 const { createLlmAdapter } = require('../utils/llmAdapter');
 const cron = require('node-cron');
 const AdminPanelService = require('./services/adminPanelService');
+const AlertService = require('./services/alertService');
 
 const logger = createBotLogger('EndersEcho');
 
@@ -114,6 +115,7 @@ const globalTop10Service = new GlobalTop10Service(config.ranking.dataDir, rankin
 const ocrStatsService = new OcrStatsService(config.ranking.dataDir, logger);
 const bossRecordService = new BossRecordService(config.ranking.dataDir);
 const kingBumChatService = new KingBumChatService(config, rankingService);
+const alertService = new AlertService(config.ranking.dataDir);
 const adminPanelService = new AdminPanelService(config.ranking.dataDir, config, {
     rankingService,
     ocrStatsService,
@@ -123,6 +125,7 @@ const adminPanelService = new AdminPanelService(config.ranking.dataDir, config, 
     communityVerificationService,
     guildConfigService,
     globalTop10Service,
+    alertService,
 });
 const interactionHandler = new InteractionHandler(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService, roleRankingConfigService, usageLimitService, tokenUsageService, null, guildConfigService, ocrBlockService, updateCooldownService, testerService, achievementService, communityVerificationService, scoreHistoryService, chartService, guildBanService, globalTop10Service, bossAliasService, ocrStatsService, bossRecordService, adminPanelService);
 
@@ -160,6 +163,7 @@ async function initializeBot() {
         globalTop10Service.start();
 
         // Wczytaj i uruchom Panel Centrum Dowodzenia Head Admina
+        await alertService.load();
         adminPanelService.setClient(client);
         await adminPanelService.load();
         if (adminPanelService.isConfigured()) {

--- a/EndersEcho/services/adminPanelService.js
+++ b/EndersEcho/services/adminPanelService.js
@@ -1,6 +1,6 @@
 const fs = require('fs').promises;
 const path = require('path');
-const { EmbedBuilder } = require('discord.js');
+const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, StringSelectMenuBuilder, StringSelectMenuOptionBuilder } = require('discord.js');
 const { createBotLogger } = require('../../utils/consoleLogger');
 
 const logger = createBotLogger('EndersEcho');
@@ -71,6 +71,8 @@ class AdminPanelService {
         this._lastRecord = null;
         this._refreshing = false;
         this._pendingRefresh = false;
+        this._alertService = services.alertService || null;
+        this._lastServerData = null;
     }
 
     setClient(client) {
@@ -114,6 +116,10 @@ class AdminPanelService {
         return this._messageId;
     }
 
+    get alertService() {
+        return this._alertService;
+    }
+
     // Ustaw kanał panelu (używane przez komendę /manage → Centrum Dowodzenia → Skonfiguruj)
     async setupChannel(channelId) {
         this._channelId = channelId;
@@ -143,7 +149,9 @@ class AdminPanelService {
     async _doRefresh() {
         if (!this._client || !this._channelId) return;
 
-        const embeds = await this._buildEmbeds();
+        const embeds = await this._buildEmbeds(); // ustawia this._lastServerData
+        const alertCount = this._alertService?.getActiveAlertCount() ?? 0;
+        const components = this._buildComponents(this._lastServerData, alertCount);
 
         const channel = await this._client.channels.fetch(this._channelId).catch(() => null);
         if (!channel) {
@@ -154,17 +162,20 @@ class AdminPanelService {
         if (this._messageId) {
             const msg = await channel.messages.fetch(this._messageId).catch(() => null);
             if (msg) {
-                await msg.edit({ embeds });
+                await msg.edit({ embeds, components });
+                // Sprawdź alerty po refresh (może wysłać alert jako osobna wiadomość)
+                await this._checkAlerts(channel).catch(() => {});
                 return;
             }
             // Wiadomość usunięta — wyczyść ID, wyślij nową
             this._messageId = null;
         }
 
-        const newMsg = await channel.send({ embeds });
+        const newMsg = await channel.send({ embeds, components });
         this._messageId = newMsg.id;
         await this._persist();
         logger.info(`Panel Centrum Dowodzenia: nowa wiadomość ${this._messageId} na kanale ${this._channelId}`);
+        await this._checkAlerts(channel).catch(() => {});
     }
 
     _getActiveGuildIds() {
@@ -278,7 +289,136 @@ class AdminPanelService {
             unconfigured.push({ guildId, guildName: guild.name });
         }
 
-        return { configured, unconfigured, absent };
+        const result = { configured, unconfigured, absent };
+        this._lastServerData = result;
+        return result;
+    }
+
+    _buildProgressBar(value, max, length = 10) {
+        if (!max || max <= 0) return '░'.repeat(length);
+        const filled = Math.min(length, Math.round((value / max) * length));
+        return '█'.repeat(filled) + '░'.repeat(length - filled);
+    }
+
+    _buildComponents(serverData, alertCount) {
+        const components = [];
+
+        const row1 = new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId('cc_refresh')
+                .setEmoji('🔄')
+                .setLabel('Odśwież')
+                .setStyle(ButtonStyle.Primary),
+            new ButtonBuilder()
+                .setCustomId('cc_alerts')
+                .setEmoji('🚨')
+                .setLabel(alertCount > 0 ? `Alerty (${alertCount})` : 'Alerty')
+                .setStyle(alertCount > 0 ? ButtonStyle.Danger : ButtonStyle.Secondary)
+                .setDisabled(alertCount === 0),
+            new ButtonBuilder()
+                .setCustomId('cc_quick')
+                .setEmoji('⚡')
+                .setLabel('Podsumowanie')
+                .setStyle(ButtonStyle.Secondary),
+        );
+        components.push(row1);
+
+        const configured = serverData?.configured || [];
+        if (configured.length > 0) {
+            const options = configured.slice(0, 25).map(s =>
+                new StringSelectMenuOptionBuilder()
+                    .setLabel((s.tag || s.guildId).slice(0, 100))
+                    .setDescription(`${s.playerCount} graczy | OCR: ${s.updateBlocked ? 'zablokowany' : 'aktywny'} | ${s.lang.toUpperCase()}`.slice(0, 100))
+                    .setValue(s.guildId)
+                    .setEmoji('🖥️')
+            );
+            const serverSel = new StringSelectMenuBuilder()
+                .setCustomId('cc_server_sel')
+                .setPlaceholder('🔍 Deep-dive: wybierz serwer...')
+                .addOptions(options);
+            components.push(new ActionRowBuilder().addComponents(serverSel));
+        }
+
+        return components;
+    }
+
+    async buildServerDeepDive(guildId) {
+        const cfg = this._services.guildConfigService?.getConfig(guildId);
+        if (!cfg) return null;
+
+        const rankingService = this._services.rankingService;
+        const tokenSvc = this._services.tokenUsageService;
+        const ocrStats = this._services.ocrStatsService?.getStats();
+
+        let ranking = {};
+        try {
+            ranking = await rankingService?.loadRanking(guildId).catch(() => ({})) ?? {};
+        } catch { /* pomiń */ }
+
+        const players = Object.values(ranking).sort((a, b) => (b.score || 0) - (a.score || 0));
+        const top5 = players.slice(0, 5);
+        const maxScore = top5[0]?.score || 1;
+
+        const today = new Date().toISOString().slice(0, 10);
+        const tokenData = tokenSvc?.data?.guilds?.[guildId]?.[today];
+        const todayCost = tokenData
+            ? (tokenData.promptTokens / 1_000_000) * 0.10 + (tokenData.outputTokens / 1_000_000) * 0.40
+            : 0;
+
+        const ocrBlocked = cfg.ocrBlocked || [];
+        const ocrStatus = ocrBlocked.length > 0 ? `❌ Zablokowane: \`${ocrBlocked.join(', ')}\`` : '✅ Aktywne';
+
+        const medals = ['🥇', '🥈', '🥉', '4️⃣', '5️⃣'];
+        const playerLines = top5.map((p, i) => {
+            const bar = this._buildProgressBar(p.score, maxScore, 12);
+            return `${medals[i]} **${(p.username || p.userId).slice(0, 20)}** — ${p.score}\n\`${bar}\``;
+        });
+        if (playerLines.length === 0) playerLines.push('Brak graczy w rankingu.');
+
+        return new EmbedBuilder()
+            .setColor(0x5865F2)
+            .setTitle(`🖥️ Deep-Dive: ${(cfg.tag || guildId).slice(0, 50)}`)
+            .addFields(
+                { name: '👥 Graczy', value: `${players.length}`, inline: true },
+                { name: '🌐 Język', value: (cfg.lang || 'pol').toUpperCase(), inline: true },
+                { name: '📸 OCR', value: ocrStatus, inline: true },
+                { name: '💰 Koszt AI (dziś)', value: fmtCost(todayCost), inline: true },
+                { name: '​', value: '​', inline: true },
+                { name: '​', value: '​', inline: true },
+                { name: '🏆 TOP 5 (z paskami postępu)', value: playerLines.join('\n'), inline: false },
+            )
+            .setFooter({ text: `ID serwera: ${guildId}` });
+    }
+
+    async _checkAlerts(channel) {
+        if (!this._alertService) return;
+
+        const ocrStats = this._services.ocrStatsService?.getStats() || null;
+        const pendingCv = this._getPendingCvCount();
+        const guildIds = [...this._getActiveGuildIds()];
+        const { cost } = this._getTodayTokens(guildIds);
+
+        const at = ocrStats?.allTime ?? { total: 0, adminFixed: 0 };
+        const ocrRate = at.total > 0
+            ? ((at.total - (at.adminFixed || 0)) / at.total) * 100
+            : 100;
+
+        const newAlerts = await this._alertService.check(ocrRate, pendingCv, cost);
+
+        if (newAlerts.length > 0 && channel) {
+            const active = this._alertService.getActiveAlerts();
+            const lines = newAlerts.map(type =>
+                this._alertService.describeAlert(type, active[type]?.value)
+            );
+            await channel.send({
+                embeds: [new EmbedBuilder()
+                    .setColor(0xFF4444)
+                    .setTitle('🚨 Centrum Dowodzenia — Nowy Alert!')
+                    .setDescription(lines.join('\n\n'))
+                    .setFooter({ text: 'Kliknij przycisk 🚨 Alerty na panelu, aby zarządzać' })
+                ]
+            }).catch(() => {});
+        }
     }
 
     _buildStatusEmbed(configuredServers, lastUpdated) {

--- a/EndersEcho/services/alertService.js
+++ b/EndersEcho/services/alertService.js
@@ -1,0 +1,154 @@
+const fs = require('fs').promises;
+const path = require('path');
+const { createBotLogger } = require('../../utils/consoleLogger');
+
+const logger = createBotLogger('EndersEcho');
+
+const ALERT_TYPES = ['ocrRate', 'pendingCv', 'dailyCost'];
+const ALERT_DEBOUNCE_MS = 60 * 60 * 1000; // 1 godzina
+
+class AlertService {
+    constructor(dataDir) {
+        this._dataFile = path.join(dataDir, 'alert_config.json');
+        this._thresholds = {
+            ocrRate: 80,    // min % — alert gdy poniżej
+            pendingCv: 3,   // max   — alert gdy powyżej
+            dailyCost: 5.0, // max $ — alert gdy powyżej
+        };
+        this._active = {}; // type → { triggeredAt, value, acknowledged }
+        this._lastSent = {}; // type → timestamp (debounce wysyłki)
+    }
+
+    async load() {
+        try {
+            const raw = await fs.readFile(this._dataFile, 'utf8');
+            const data = JSON.parse(raw);
+            if (data.thresholds) {
+                this._thresholds = { ...this._thresholds, ...data.thresholds };
+            }
+            if (data.active) {
+                this._active = data.active;
+            }
+            logger.info(`AlertService: wczytano progi — OCR<${this._thresholds.ocrRate}% / CV>${this._thresholds.pendingCv} / koszt>$${this._thresholds.dailyCost}`);
+        } catch {
+            // Brak pliku — domyślne wartości
+        }
+    }
+
+    async _persist() {
+        await fs.mkdir(path.dirname(this._dataFile), { recursive: true });
+        await fs.writeFile(this._dataFile, JSON.stringify({
+            thresholds: this._thresholds,
+            active: this._active,
+        }, null, 2), 'utf8');
+    }
+
+    getThresholds() {
+        return { ...this._thresholds };
+    }
+
+    async setThreshold(type, value) {
+        if (!ALERT_TYPES.includes(type)) return false;
+        this._thresholds[type] = value;
+        await this._persist();
+        logger.info(`AlertService: próg "${type}" ustawiony na ${value}`);
+        return true;
+    }
+
+    getActiveAlerts() {
+        return { ...this._active };
+    }
+
+    getActiveAlertCount() {
+        return Object.values(this._active).filter(a => a && !a.acknowledged).length;
+    }
+
+    async acknowledgeAlert(type) {
+        if (this._active[type]) {
+            this._active[type].acknowledged = true;
+            await this._persist();
+            return true;
+        }
+        return false;
+    }
+
+    async acknowledgeAll() {
+        let changed = false;
+        for (const type of Object.keys(this._active)) {
+            if (!this._active[type].acknowledged) {
+                this._active[type].acknowledged = true;
+                changed = true;
+            }
+        }
+        if (changed) await this._persist();
+        return changed;
+    }
+
+    /**
+     * Sprawdza wartości, aktualizuje aktywne alerty.
+     * @returns {string[]} typy nowych alertów (do wysłania powiadomień)
+     */
+    async check(ocrRate, pendingCv, dailyCost) {
+        const newAlerts = [];
+        const now = Date.now();
+
+        const checks = [
+            { type: 'ocrRate',   value: ocrRate,   triggered: ocrRate > 0 && ocrRate < this._thresholds.ocrRate },
+            { type: 'pendingCv', value: pendingCv,  triggered: pendingCv > this._thresholds.pendingCv },
+            { type: 'dailyCost', value: dailyCost,  triggered: dailyCost > this._thresholds.dailyCost },
+        ];
+
+        let changed = false;
+        for (const { type, value, triggered } of checks) {
+            if (triggered) {
+                const lastSent = this._lastSent[type] || 0;
+                const existing = this._active[type];
+                const isNewOrAcked = !existing || existing.acknowledged;
+                const canSend = now - lastSent > ALERT_DEBOUNCE_MS;
+
+                if (isNewOrAcked) {
+                    this._active[type] = { triggeredAt: new Date().toISOString(), value, acknowledged: false };
+                    if (canSend) {
+                        this._lastSent[type] = now;
+                        newAlerts.push(type);
+                    }
+                    changed = true;
+                }
+            } else {
+                if (this._active[type]) {
+                    delete this._active[type];
+                    changed = true;
+                }
+            }
+        }
+
+        if (changed) await this._persist();
+        return newAlerts;
+    }
+
+    describeAlert(type, value) {
+        const t = this._thresholds;
+        switch (type) {
+            case 'ocrRate':
+                return `🔴 **OCR Rate** poniżej progu: **${typeof value === 'number' ? value.toFixed(1) : '?'}%** *(próg: <${t.ocrRate}%)*`;
+            case 'pendingCv':
+                return `🟡 **Oczekujące weryfikacje CV**: **${value ?? '?'}** *(próg: >${t.pendingCv})*`;
+            case 'dailyCost':
+                return `💸 **Koszt AI** przekroczył limit: **$${typeof value === 'number' ? value.toFixed(4) : '?'}** *(próg: >$${t.dailyCost})*`;
+            default:
+                return `⚠️ Alert: ${type} = ${value}`;
+        }
+    }
+
+    describeThreshold(type) {
+        const t = this._thresholds;
+        switch (type) {
+            case 'ocrRate':   return { label: 'Min. OCR Rate (%)',       current: `${t.ocrRate}%`,  unit: '%',  direction: 'min' };
+            case 'pendingCv': return { label: 'Max oczekujących CV',      current: `${t.pendingCv}`, unit: '',   direction: 'max' };
+            case 'dailyCost': return { label: 'Max koszt AI/dzień (USD)', current: `$${t.dailyCost}`,unit: '$',  direction: 'max' };
+            default:          return { label: type, current: String(t[type] ?? '?'), unit: '', direction: 'max' };
+        }
+    }
+}
+
+module.exports = AlertService;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Nowy `AlertService`** (`services/alertService.js`) — zarządza progami alertów i ich stanem:
  - 3 typy alertów: OCR Rate (<80%), Oczekujące CV (>3), Koszt AI/dzień (>$5)
  - Debounce 1h per typ, persistencja w `data/alert_config.json`
  - Progi konfigurowalne przez modal bezpośrednio z panelu

- **Komponenty na wiadomości panelu** (`adminPanelService.js`) — panel zyskał interaktywne przyciski i select menu:
  - `🔄 Odśwież` — wymuś refresh (ephemeral potwierdzenie)
  - `🚨 Alerty (N)` — czerwony gdy aktywne alerty; zarządzanie + potwierdzanie alertów
  - `⚡ Podsumowanie` — live snapshot: OCR rate z paskiem `█░`, koszt z paskiem, CV, cooldowny
  - Select menu serwerów — deep-dive wybranego serwera: TOP5 z paskami postępu, koszty AI, status OCR

- **Zakładki w `/manage → Centrum Dowodzenia`** — 3 zakładki via StringSelectMenu:
  - `📡 Przegląd` — status panelu + instrukcje
  - `⚡ Szybki Podgląd` — live snapshot statystyk
  - `⚙️ Konfiguracja Alertów` — lista aktywnych alertów, przyciski potwierdzenia, zmiana progów

- **System alertów** — po przekroczeniu progu: oddzielna wiadomość `🚨` na kanale panelu (raz/godzinę per typ)

## Test plan

- [ ] Panel na kanale admina wyświetla przyciski i select menu po restarcie bota
- [ ] `🔄 Odśwież` — aktualizuje panel i odpowiada ephemeral potwierdzeniem
- [ ] `⚡ Podsumowanie` — pokazuje live stats z paskami postępu `█░`
- [ ] `🚨 Alerty` — szary i wyłączony gdy brak alertów; czerwony gdy są aktywne
- [ ] Select menu serwerów — deep-dive z TOP5 i paskami postępu
- [ ] `/manage → Centrum Dowodzenia` — zakładki działają prawidłowo
- [ ] Zakładka Konfiguracja Alertów — zmiana progu przez modal, potwierdzanie alertów
- [ ] `data/alert_config.json` tworzony przy starcie bota

https://claude.ai/code/session_01PJu6JZuq8fZES8cBDtKxbg
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJu6JZuq8fZES8cBDtKxbg)_