### PR TITLE
EndersEcho: dwujęzyczne notki + poprawka statystyk OCR

### DIFF
--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -12017,7 +12017,9 @@ class InteractionHandler {
         }
         const lang = interaction.values[0];
         const addResult = await this.bossAliasService.addAlias(session.englishBoss, session.adjustedBoss, lang);
-        const langLabel = this.bossAliasService.getSupportedLanguages().find(l => l.code === lang)?.label || lang;
+        const _langEntry = this.bossAliasService.getSupportedLanguages().find(l => l.code === lang);
+        const langLabel = _langEntry?.label || lang;
+        const langLabelEn = _langEntry?.labelEn || _langEntry?.label || lang;
         if (!addResult.added) {
             const { englishName: conflictBoss, language: conflictLang } = addResult.conflict;
             await interaction.update({
@@ -12095,7 +12097,7 @@ class InteractionHandler {
                         const _tPub = this._panelT(ubSession?.guildId || interaction.guildId);
                         const noteText = _tPub(
                             `📋 Administrator **${adminName}** ustawił nazwę **${session.adjustedBoss}** (${langLabel}) jako alias do angielskiej nazwy bossa **${session.englishBoss}**`,
-                            `📋 Administrator **${adminName}** set **${session.adjustedBoss}** (${langLabel}) as an alias for English boss name **${session.englishBoss}**`
+                            `📋 Administrator **${adminName}** set **${session.adjustedBoss}** (${langLabelEn}) as an alias for English boss name **${session.englishBoss}**`
                         );
                         const existingContent = pubMsg.content ? `${pubMsg.content}\n` : '';
                         await pubMsg.edit({ content: `${existingContent}${noteText}` }).catch(() => null);

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -5093,7 +5093,7 @@ class InteractionHandler {
                                     `↩️ Administrator **${adminName}** reverted the score and all achievements to the state before this record was set due to a rules violation.`
                                 );
                                 const _existingContent = _pubMsg.content ? `${_pubMsg.content}\n` : '';
-                                await _pubMsg.edit({ content: `${_existingContent}${_noteText}`, embeds: _pubMsg.embeds }).catch(() => null);
+                                await _pubMsg.edit({ content: `${_existingContent}${_noteText}` }).catch(() => null);
                             }
                         }
                     } catch {}
@@ -9005,7 +9005,7 @@ class InteractionHandler {
                                 `↩️ Administrator **${reverterName}** reverted the score and all achievements to the state before this record was set due to a rules violation.`
                             );
                             const _existingContent = _pubMsg.content ? `${_pubMsg.content}\n` : '';
-                            await _pubMsg.edit({ content: `${_existingContent}${_noteText}`, embeds: _pubMsg.embeds }).catch(() => null);
+                            await _pubMsg.edit({ content: `${_existingContent}${_noteText}` }).catch(() => null);
                         }
                     }
                 } catch {}
@@ -12098,7 +12098,7 @@ class InteractionHandler {
                             `📋 Administrator **${adminName}** set **${session.adjustedBoss}** (${langLabel}) as an alias for English boss name **${session.englishBoss}**`
                         );
                         const existingContent = pubMsg.content ? `${pubMsg.content}\n` : '';
-                        await pubMsg.edit({ content: `${existingContent}${noteText}`, embeds: pubMsg.embeds }).catch(() => null);
+                        await pubMsg.edit({ content: `${existingContent}${noteText}` }).catch(() => null);
                     }
                 }
             } catch {}

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -5087,7 +5087,11 @@ class InteractionHandler {
                         if (_pubChan) {
                             const _pubMsg = await _pubChan.messages.fetch(session.publicMsgId).catch(() => null);
                             if (_pubMsg) {
-                                const _noteText = `↩️ Administrator **${adminName}** cofnął wynik oraz wszystkie osiągnięcia do stanu sprzed pobicia tego rekordu z powodu naruszenia zasad.`;
+                                const _t = this._panelT(targetGuildId);
+                                const _noteText = _t(
+                                    `↩️ Administrator **${adminName}** cofnął wynik oraz wszystkie osiągnięcia do stanu sprzed pobicia tego rekordu z powodu naruszenia zasad.`,
+                                    `↩️ Administrator **${adminName}** reverted the score and all achievements to the state before this record was set due to a rules violation.`
+                                );
                                 const _existingContent = _pubMsg.content ? `${_pubMsg.content}\n` : '';
                                 await _pubMsg.edit({ content: `${_existingContent}${_noteText}`, embeds: _pubMsg.embeds }).catch(() => null);
                             }
@@ -8995,7 +8999,11 @@ class InteractionHandler {
                     if (_pubChan) {
                         const _pubMsg = await _pubChan.messages.fetch(session.publicMsgId).catch(() => null);
                         if (_pubMsg) {
-                            const _noteText = `↩️ Administrator **${reverterName}** cofnął wynik oraz wszystkie osiągnięcia do stanu sprzed pobicia tego rekordu z powodu naruszenia zasad.`;
+                            const _t = this._panelT(targetGuildId);
+                            const _noteText = _t(
+                                `↩️ Administrator **${reverterName}** cofnął wynik oraz wszystkie osiągnięcia do stanu sprzed pobicia tego rekordu z powodu naruszenia zasad.`,
+                                `↩️ Administrator **${reverterName}** reverted the score and all achievements to the state before this record was set due to a rules violation.`
+                            );
                             const _existingContent = _pubMsg.content ? `${_pubMsg.content}\n` : '';
                             await _pubMsg.edit({ content: `${_existingContent}${_noteText}`, embeds: _pubMsg.embeds }).catch(() => null);
                         }
@@ -12084,7 +12092,11 @@ class InteractionHandler {
                 if (pubChan) {
                     const pubMsg = await pubChan.messages.fetch(ubPublicMsgId).catch(() => null);
                     if (pubMsg) {
-                        const noteText = `📋 Administrator **${adminName}** ustawił nazwę **${session.adjustedBoss}** (${langLabel}) jako alias do angielskiej nazwy bossa **${session.englishBoss}**`;
+                        const _tPub = this._panelT(ubSession?.guildId || interaction.guildId);
+                        const noteText = _tPub(
+                            `📋 Administrator **${adminName}** ustawił nazwę **${session.adjustedBoss}** (${langLabel}) jako alias do angielskiej nazwy bossa **${session.englishBoss}**`,
+                            `📋 Administrator **${adminName}** set **${session.adjustedBoss}** (${langLabel}) as an alias for English boss name **${session.englishBoss}**`
+                        );
                         const existingContent = pubMsg.content ? `${pubMsg.content}\n` : '';
                         await pubMsg.edit({ content: `${existingContent}${noteText}`, embeds: pubMsg.embeds }).catch(() => null);
                     }

--- a/EndersEcho/services/bossAliasService.js
+++ b/EndersEcho/services/bossAliasService.js
@@ -7,18 +7,18 @@ const DATA_PATH = path.join(__dirname, '../data/boss_aliases.json');
 
 // Obsługiwane języki (kod → etykieta)
 const SUPPORTED_LANGUAGES = [
-    { code: 'pl', label: '🇵🇱 Polski' },
-    { code: 'de', label: '🇩🇪 Deutsch' },
-    { code: 'fr', label: '🇫🇷 Français' },
-    { code: 'es', label: '🇪🇸 Español' },
-    { code: 'pt', label: '🇵🇹 Português' },
-    { code: 'ru', label: '🇷🇺 Русский' },
-    { code: 'it', label: '🇮🇹 Italiano' },
-    { code: 'tr', label: '🇹🇷 Türkçe' },
-    { code: 'ja', label: '🇯🇵 日本語' },
-    { code: 'zh', label: '🇨🇳 中文' },
-    { code: 'vi', label: '🇻🇳 Tiếng Việt' },
-    { code: 'ko', label: '🇰🇷 한국어' },
+    { code: 'pl', label: '🇵🇱 Polski',      labelEn: '🇵🇱 Polish' },
+    { code: 'de', label: '🇩🇪 Deutsch',     labelEn: '🇩🇪 German' },
+    { code: 'fr', label: '🇫🇷 Français',    labelEn: '🇫🇷 French' },
+    { code: 'es', label: '🇪🇸 Español',     labelEn: '🇪🇸 Spanish' },
+    { code: 'pt', label: '🇵🇹 Português',   labelEn: '🇵🇹 Portuguese' },
+    { code: 'ru', label: '🇷🇺 Русский',     labelEn: '🇷🇺 Russian' },
+    { code: 'it', label: '🇮🇹 Italiano',    labelEn: '🇮🇹 Italian' },
+    { code: 'tr', label: '🇹🇷 Türkçe',      labelEn: '🇹🇷 Turkish' },
+    { code: 'ja', label: '🇯🇵 日本語',       labelEn: '🇯🇵 Japanese' },
+    { code: 'zh', label: '🇨🇳 中文',         labelEn: '🇨🇳 Chinese' },
+    { code: 'vi', label: '🇻🇳 Tiếng Việt',  labelEn: '🇻🇳 Vietnamese' },
+    { code: 'ko', label: '🇰🇷 한국어',       labelEn: '🇰🇷 Korean' },
 ];
 
 class BossAliasService {


### PR DESCRIPTION
## Podsumowanie

**Dwujęzyczność notek (`pol`/`eng` per serwer):**
- Notka po dodaniu aliasu bossa w ogłoszeniu rekordu — `_handleBossMapLangSel`
- Notka po cofnięciu wyniku w ogłoszeniu rekordu — `ocr_revert_` i `ee_analyze_revert`
- Język pobierany z konfiguracji serwera docelowego przez `_panelT(targetGuildId)`, nie z serwera admina

**Poprawka statystyk OCR (`ocrStatsService`):**
- `/test` (`dryRun`) — nie liczy się do success rate
- Head admin cofa **własny** wynik → nie wpływa na statystyki (testowanie)
- Head admin cofa **wynik kogoś innego** → liczy się normalnie
- CV `remove`/`block` → liczy się normalnie (przywrócono)

---
_Generated by [Claude Code](https://claude.ai/code/session_013THER41TvTwHoSt4N5TPWt)_