### PR TITLE
EndersEcho Tokeny: sortowanie serwerów i fix paginacji

### DIFF
--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -9206,13 +9206,11 @@ class InteractionHandler {
         const hasPrev   = idx > 0;
         const hasNext   = idx < available.length - 1;
 
-        const prevMonthRaw = hasPrev ? available[idx - 1].replace('-', '') : monthStr;
-        const nextMonthRaw = hasNext ? available[idx + 1].replace('-', '') : monthStr;
-
+        // Przyciski kodują BIEŻĄCY miesiąc — handler sam oblicza prev/next
         // Wiersz 1: ◀ | [Miesiąc → per user] | ▶ | 🌐 Wszystkie (superUser) | Zbiorczo (superUser)
         const row1Buttons = [
             new ButtonBuilder()
-                .setCustomId(`tk_p_${prevMonthRaw}_${guildFilter}_${userId}`)
+                .setCustomId(`tk_p_${monthStr}_${guildFilter}_${userId}`)
                 .setEmoji('◀️')
                 .setStyle(ButtonStyle.Secondary)
                 .setDisabled(!hasPrev),
@@ -9221,7 +9219,7 @@ class InteractionHandler {
                 .setLabel(monthLabel)
                 .setStyle(ButtonStyle.Primary),
             new ButtonBuilder()
-                .setCustomId(`tk_n_${nextMonthRaw}_${guildFilter}_${userId}`)
+                .setCustomId(`tk_n_${monthStr}_${guildFilter}_${userId}`)
                 .setEmoji('▶️')
                 .setStyle(ButtonStyle.Secondary)
                 .setDisabled(!hasNext),

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -9309,20 +9309,21 @@ class InteractionHandler {
         const leftLines   = [];
         let totalCost = 0;
 
+        const guildEntries = [];
         for (const guildId of tokenGuildIds) {
             const stats = this.tokenUsageService.getMonthlyStats(guildId, month);
             if (stats.requests === 0) continue;
-            const cost = stats.cost;
-            totalCost += cost;
+            totalCost += stats.cost;
             const liveName   = interaction.client.guilds.cache.get(guildId)?.name;
             const storedName = this.guildConfigService.getConfig(guildId)?.guildName;
             const name       = (liveName || storedName || guildId).slice(0, 24);
-            const line = `**${name}** — ${fmtCost(cost)} (${stats.requests} req)`;
-            if (liveName) {
-                activeLines.push(line);
-            } else {
-                leftLines.push(line);
-            }
+            guildEntries.push({ name, cost: stats.cost, requests: stats.requests, isActive: !!liveName });
+        }
+        guildEntries.sort((a, b) => b.requests - a.requests);
+        for (const entry of guildEntries) {
+            const line = `**${entry.name}** — ${fmtCost(entry.cost)} (${entry.requests} req)`;
+            if (entry.isActive) activeLines.push(line);
+            else leftLines.push(line);
         }
 
         activeLines.push('');
@@ -9391,6 +9392,7 @@ class InteractionHandler {
         const leftLines   = [];
         let totalCost = 0;
 
+        const guildEntries = [];
         for (const guildId of tokenGuildIds) {
             let promptTokens = 0, outputTokens = 0, requests = 0;
             for (const month of allMonths) {
@@ -9405,12 +9407,13 @@ class InteractionHandler {
             const liveName   = interaction.client.guilds.cache.get(guildId)?.name;
             const storedName = this.guildConfigService.getConfig(guildId)?.guildName;
             const name       = (liveName || storedName || guildId).slice(0, 24);
-            const line = `**${name}** — ${fmtCost(cost)} (${requests} req)`;
-            if (liveName) {
-                activeLines.push(line);
-            } else {
-                leftLines.push(line);
-            }
+            guildEntries.push({ name, cost, requests, isActive: !!liveName });
+        }
+        guildEntries.sort((a, b) => b.requests - a.requests);
+        for (const entry of guildEntries) {
+            const line = `**${entry.name}** — ${fmtCost(entry.cost)} (${entry.requests} req)`;
+            if (entry.isActive) activeLines.push(line);
+            else leftLines.push(line);
         }
 
         activeLines.push('');


### PR DESCRIPTION
## Podsumowanie

Poprawki w widoku **Tokeny AI**.

## Zmiany

### 🔢 Sortowanie serwerów od największej liczby req
- `_buildTokensMonthBreakdown` — lista serwerów za dany miesiąc sortowana malejąco po liczbie requestów
- `_buildTokensTotalBreakdown` — lista serwerów za całe czasy sortowana malejąco po liczbie requestów

### 🔧 Fix paginacji (double-step)
- Przyciski ◀️/▶️ w widoku wykresu kodują teraz **bieżący miesiąc** zamiast docelowego
- Wcześniej: kliknięcie ▶️ przeskakiwało o 2 miesiące zamiast 1

https://claude.ai/code/session_0169i9XjRgWST33KiZ61fwGa

---
_Generated by [Claude Code](https://claude.ai/code/session_0169i9XjRgWST33KiZ61fwGa)_