### PR TITLE
Muteusz: przywrócono okno naruszeń 15 minut

### DIFF
--- a/Muteusz/config/config.js
+++ b/Muteusz/config/config.js
@@ -91,7 +91,7 @@ module.exports = {
     
     autoModeration: {
         enabled: true,
-        violationWindow: 5, // okno czasowe w minutach
+        violationWindow: 15, // okno czasowe w minutach
         violationsBeforeWarn: 3, // ilość wyzwisk przed warnem
         warningsBeforeMute: 3, // ilość warnów przed mute
         muteTime: 60, // czas mute w minutach


### PR DESCRIPTION
Przywrócono `violationWindow: 15` w `config/config.js` (cofnięcie wcześniejszej zmiany na 5 minut).

---
_Generated by [Claude Code](https://claude.ai/code/session_01966SZPSSDr7QJyKfBvQRMb)_