### PR TITLE
EndersEcho: top odrzucani w Centrum Dowodzenia z linkiem i tagiem serwera

### DIFF
--- a/EndersEcho/services/adminPanelService.js
+++ b/EndersEcho/services/adminPanelService.js
@@ -248,7 +248,7 @@ class AdminPanelService {
                 components: [this._buildUsersRow()],
             },
             {
-                embed: this._buildOcrEmbed(ocrStats),
+                embed: this._buildOcrEmbed(ocrStats, [...guildIds], globalRanking),
                 components: [this._buildOcrRow()],
             },
             {
@@ -449,7 +449,7 @@ class AdminPanelService {
     }
 
     // ─── EMBED 3: OCR & Analizy ──────────────────────────────────────────────
-    _buildOcrEmbed(ocrStats) {
+    _buildOcrEmbed(ocrStats, guildIds = [], globalRanking = []) {
         const at = ocrStats?.allTime ?? { total: 0, success: 0, adminFixed: 0 };
         const rs = ocrStats?.resettable ?? { total: 0, success: 0, adminFixed: 0 };
 
@@ -473,9 +473,19 @@ class AdminPanelService {
 
         const currentMonth = new Date().toISOString().slice(0, 7);
         const ocrSvc = this._services.ocrStatsService;
+        const cfgSvc = this._services.guildConfigService;
         const topRejected = ocrSvc?.getMonthlyTopRejectedUsers?.(currentMonth, 'all') ?? [];
+        const rejUsernameMap = new Map(globalRanking.map(p => [p.userId, p.username]));
         const rejectedUsersValue = topRejected.length > 0
-            ? topRejected.map((u, i) => `${i + 1}. <@${u.userId}>: **${u.count}**`).join('\n')
+            ? topRejected.map((u, i) => {
+                const username = rejUsernameMap.get(u.userId) || `<@${u.userId}>`;
+                const link = rejUsernameMap.has(u.userId)
+                    ? `[${username}](https://discord.com/users/${u.userId})`
+                    : username;
+                const serverTag = this._getRejectedUserPrimaryGuildTag(u.userId, currentMonth, guildIds, ocrSvc, cfgSvc);
+                const tagStr = serverTag ? ` \`${serverTag}\`` : '';
+                return `${i + 1}. ${link}${tagStr} — **${u.count}** odrzuc.`;
+            }).join('\n')
             : '—';
 
         return new EmbedBuilder()
@@ -629,6 +639,20 @@ class AdminPanelService {
             }
             if (gReq > maxReq) {
                 maxReq = gReq;
+                const cfg = cfgSvc?.getConfig(gId);
+                bestTag = cfg?.tag || cfg?.guildName || null;
+            }
+        }
+        return bestTag;
+    }
+
+    _getRejectedUserPrimaryGuildTag(userId, month, guildIds, ocrSvc, cfgSvc) {
+        const rejData = ocrSvc?.data?.userRejections || ocrSvc?._data?.userRejections || {};
+        let maxCount = 0, bestTag = null;
+        for (const gId of guildIds) {
+            const count = rejData[gId]?.[userId]?.[month] || 0;
+            if (count > maxCount) {
+                maxCount = count;
                 const cfg = cfgSvc?.getConfig(gId);
                 bestTag = cfg?.tag || cfg?.guildName || null;
             }


### PR DESCRIPTION
## Problem

W embedzie `📊 OCR & Analizy` Centrum Dowodzenia sekcja `🚫 Top odrzucani` wyświetlała użytkowników jako zwykłe wzmianki `<@userId>: **N**`, podczas gdy sekcja `👤 Top 5 użytkowników (req.)` w embedzie `💰 Koszty AI` pokazuje klikalny link do profilu i tag serwera.

## Rozwiązanie

Sekcja `🚫 Top odrzucani` formatuje teraz tak samo jak `👤 Top 5 użytkowników`:

```
1. [NickGracza](https://discord.com/users/...) `PS🔥` — **7** odrzuc.
```

## Zmiany

### `adminPanelService.js`
- `_buildOcrEmbed(ocrStats, guildIds, globalRanking)` — rozszerzona sygnatura o `guildIds` i `globalRanking`
- `_buildSections()` — przekazuje `guildIds` i `globalRanking` do `_buildOcrEmbed` (już dostępne w tym miejscu)
- `rejectedUsersValue` — budowany z `usernameMap` (z globalRanking) + link do profilu Discord + tag serwera z `_getRejectedUserPrimaryGuildTag`
- `_getRejectedUserPrimaryGuildTag(userId, month, guildIds, ocrSvc, cfgSvc)` — nowa metoda pomocnicza analogiczna do `_getUserPrimaryGuildTag`; szuka guildy z największą liczbą odrzuceń dla użytkownika w danym miesiącu z `ocrStatsService._data.userRejections`

https://claude.ai/code/session_0169i9XjRgWST33KiZ61fwGa

---
_Generated by [Claude Code](https://claude.ai/code/session_0169i9XjRgWST33KiZ61fwGa)_