### PR TITLE
Dodano komendę /test - analiza AI batch z dopasowaniem nicków klanu

### DIFF
--- a/Muteusz/config/all_commands.json
+++ b/Muteusz/config/all_commands.json
@@ -365,6 +365,12 @@
           "requiredPermission": "moderator"
         },
         {
+          "name": "/test",
+          "description": "TEST: analizuje wszystkie zdjęcia naraz przez AI i dopasowuje odczytane nicki do nicków członków roli klanowej z Discorda. Wynik z miejscami tylko w ephemeralu, BEZ zapisu do bazy (wymaga AI OCR)",
+          "usage": "/test → prześlij od 1 do 10 zdjęć → ephemeralna lista <nick Discord> - <wynik> z miejscami",
+          "requiredPermission": "moderator"
+        },
+        {
           "name": "/wyniki",
           "description": "Wyświetla wyniki wszystkich faz ekspedycji (tylko dla członków klanu)",
           "usage": "/wyniki",

--- a/Stalker/CLAUDE.md
+++ b/Stalker/CLAUDE.md
@@ -8,7 +8,8 @@
      - Domyślny model: `gemini-2.5-flash-preview-05-20` (nadpisywalny przez `STALKER_GOOGLE_AI_MODEL`)
      - Prompt: "Przeanalizuj zdjęcie z wynikami poszczególnych graczy oraz zwróć kompletne nicki oraz wyniki w następującym formacie: <nick> - <wynik>"
      - Automatyczny fallback na tradycyjny OCR gdy AI zawiedzie
-     - Dotyczy komend: `/punish`, `/remind`, `/faza1`, `/faza2`, Core Stock (skan ekwipunku)
+     - Dotyczy komend: `/punish`, `/remind`, `/faza1`, `/faza2`, `/test`, Core Stock (skan ekwipunku)
+     - **Tryb batch (`/test`):** `analyzeResultsImagesBatch(imagePaths, clanNicks)` - wysyła WSZYSTKIE zdjęcia naraz w jednym zapytaniu (oszczędność czasu/tokenów). Do promptu dołącza listę nicków z roli klanowej Discord i prosi AI o dopasowanie odczytanych nicków ze screenów do najbliższego nicku Discord. Zwraca format `<nick Discord> - <wynik>`. Wersja promptu: `extract-results-batch` v1
      - Walidacja wyników: 0–999999 (obsługuje wyniki 5-cyfrowe i wyższe)
      - Retry 3× z exponential backoff (1s/2s/4s) dla błędów 429/503/500/sieciowych
      - Weryfikacja wersji promptów przez `PROMPT_VERSIONS` (Langfuse telemetria)
@@ -28,6 +29,7 @@
    - Dane widoczne w `/player-status` w sekcji "### 🎒 EKWIPUNEK (Core Stock)"
    - Dane tymczasowe (pending) przechowywane w `client._equipmentPending` Map (wygasają po 5 min)
 6. **Fazy Lunar** - `phaseService.js`: `/faza1` (lista), `/faza2` (3 rundy damage), `/wyniki` (TOP30 z paginacją tygodni), `/progres`, `/clan-status`, `/clan-progres` (progres TOP30 klanu z wykresem), `/img` (dodaj zdjęcie tabeli do Fazy 2). Po każdym zatwierdzeniu `/faza1` (i przy starcie bota) wywołuje `clanThresholdsExportService.exportClanThresholds()` → zapisuje `shared_data/clan_thresholds.json` z minimalnym maxScore per klan, używanym przez Rekrutera do dynamicznej kwalifikacji.
+   - **`/test`** (`processTestImages()`): Tryb testowy - mirror `/faza1` (te same uprawnienia moderatora, ten sam kanał OCR `1437122516974829679`, ta sama kolejka OCR), ale: (1) przetwarza WSZYSTKIE zdjęcia naraz przez AI batch (`analyzeResultsImagesBatch`) zamiast pojedynczo; (2) do promptu AI dołącza listę nicków z roli klanowej użytkownika (pobrane przez `safeFetchMembers`), AI dopasowuje odczytane nicki do nicków Discord; (3) wynik (posortowana lista z miejscami `█████░░░░░ #1 nick - wynik` + suma TOP30) wyświetlany WYŁĄCZNIE w **ephemeralu** (`deferReply({ ephemeral: true })`); (4) **BEZ zapisu do bazy** - czysto diagnostyczny. Sesja oznaczona flagą `session.isTest = true`. Wymaga aktywnego AI OCR (`USE_STALKER_AI_OCR=true`).
 7. **AI Chat** - `aiChatService.js`: Mention @Stalker → rozmowa na dowolny temat, Anthropic API (Claude 3 Haiku), cooldown 5min, **bez pamięci kontekstu** (każde pytanie niezależne)
 8. **Broadcast Messages** - `broadcastMessageService.js`: `/msg` (admin) - wysyłanie wiadomości na wszystkie kanały tekstowe, rate limit protection (1s między kanałami), persistent storage messageId, `/msg` bez tekstu → usuwanie wszystkich poprzednich wiadomości
 9. **Kalkulator** - Auto-odpowiedź na słowo "kalkulator" w wiadomości → link do sio-tools.exp0.dev/?migrate=1, cooldown 1h per kanał (persistencja w `data/calculator_cooldowns.json`)
@@ -226,7 +228,7 @@
 - **Persistent cooldowns:** Cleanup starych danych (>2 dni) przy starcie
 - **ENV:** `ANTHROPIC_API_KEY` (opcjonalne), `STALKER_LME_AI_CHAT_MODEL` (opcjonalne, default: claude-3-haiku-20240307)
 
-**Komendy:** `/punish`, `/remind`, `/punishment`, `/points`, `/faza1`, `/faza2`, `/wyniki`, `/img`, `/progres`, `/player-status`, `/player-compare`, `/clan-status`, `/clan-progres`, `/player-raport`, `/core-ranking`, `/msg`, `/ocr-debug`
+**Komendy:** `/punish`, `/remind`, `/punishment`, `/points`, `/faza1`, `/faza2`, `/test`, `/wyniki`, `/img`, `/progres`, `/player-status`, `/player-compare`, `/clan-status`, `/clan-progres`, `/player-raport`, `/core-ranking`, `/msg`, `/ocr-debug`
 
 **Core Ranking** - `/core-ranking` (publiczna dla członków klanu):
 - Ephemeral z 6 przyciskami (jeden per typ cora, każdy z ikoną custom emoji)

--- a/Stalker/handlers/interactionHandlers.js
+++ b/Stalker/handlers/interactionHandlers.js
@@ -85,7 +85,7 @@ async function handleSlashCommand(interaction, sharedState) {
     }
 
     // Sprawdź kanał dla komend OCR i faz
-    const ocrCommands = ['punish', 'remind', 'faza1', 'faza2'];
+    const ocrCommands = ['punish', 'remind', 'faza1', 'faza2', 'test'];
     const allowedChannelId = '1437122516974829679';
     if (ocrCommands.includes(interaction.commandName) && interaction.channelId !== allowedChannelId) {
         await interaction.reply({
@@ -124,6 +124,9 @@ async function handleSlashCommand(interaction, sharedState) {
             break;
         case 'faza1':
             await handlePhase1Command(interaction, sharedState);
+            break;
+        case 'test':
+            await handleTestCommand(interaction, sharedState);
             break;
         case 'wyniki':
             await handleWynikiCommand(interaction, sharedState);
@@ -2744,6 +2747,10 @@ async function registerSlashCommands(client) {
             .setDescription('Zbierz i zapisz wyniki wszystkich graczy dla Fazy 1'),
 
         new SlashCommandBuilder()
+            .setName('test')
+            .setDescription('TEST: analiza AI wszystkich zdjęć naraz + dopasowanie do nicków Discord (bez zapisu)'),
+
+        new SlashCommandBuilder()
             .setName('wyniki')
             .setDescription('Wyświetl wyniki dla wszystkich faz'),
 
@@ -3667,6 +3674,127 @@ async function handleModalSubmit(interaction, sharedState) {
         await handlePhase1ManualModalSubmit(interaction, sharedState);
     } else if (interaction.customId.startsWith('phase2_manual_modal_')) {
         await handlePhase2ManualModalSubmit(interaction, sharedState);
+    }
+}
+
+/**
+ * Komenda /test - analiza AI wszystkich zdjęć naraz (batch) z dopasowaniem nicków
+ * ze screenów do nicków członków roli klanowej z Discorda. Wynik WYŁĄCZNIE w ephemeralu,
+ * BEZ zapisu do bazy. Korzysta z tej samej kolejki OCR co /faza1.
+ */
+async function handleTestCommand(interaction, sharedState) {
+    const { config, phaseService, ocrService } = sharedState;
+    const guildId = interaction.guild.id;
+    const userId = interaction.user.id;
+    const commandName = '/test';
+
+    // Sprawdź uprawnienia (admin lub allowedPunishRoles)
+    const isAdmin = interaction.member.permissions.has('Administrator');
+    const hasPunishRole = hasPermission(interaction.member, config.allowedPunishRoles);
+
+    if (!isAdmin && !hasPunishRole) {
+        await interaction.reply({
+            content: '❌ Nie masz uprawnień do używania tej komendy. Wymagane: **Administrator** lub rola moderatora.',
+            flags: MessageFlags.Ephemeral
+        });
+        return;
+    }
+
+    // /test wymaga aktywnego AI OCR (analiza batch przez Gemini Vision)
+    if (!ocrService.aiOcrService || !ocrService.aiOcrService.enabled) {
+        await interaction.reply({
+            content: '❌ Komenda `/test` wymaga aktywnego AI OCR (`USE_STALKER_AI_OCR=true`). Funkcja jest obecnie wyłączona.',
+            flags: MessageFlags.Ephemeral
+        });
+        return;
+    }
+
+    // ===== SPRAWDZENIE KOLEJKI OCR (przed deferReply) =====
+    const isOCRActive = ocrService.isOCRActive(guildId);
+    const isQueueEmpty = ocrService.isQueueEmpty(guildId);
+    const willBeQueued = isOCRActive || !isQueueEmpty;
+
+    // Ephemeral - wynik widoczny tylko dla wywołującego
+    await interaction.deferReply({ ephemeral: true });
+
+    try {
+        // Wykryj klan użytkownika
+        let userClan = null;
+        for (const [clanKey, roleId] of Object.entries(config.targetRoles)) {
+            if (interaction.member.roles.cache.has(roleId)) {
+                userClan = clanKey;
+                logger.info(`[TEST] 🎯 Wykryto klan użytkownika: ${clanKey} (${config.roleDisplayNames[clanKey]})`);
+                break;
+            }
+        }
+
+        if (!userClan) {
+            await interaction.editReply({
+                content: '❌ Nie wykryto Twojego klanu. Musisz mieć jedną z ról: ' +
+                    Object.values(config.roleDisplayNames).join(', ')
+            });
+            return;
+        }
+
+        const runSession = async (inter) => {
+            await ocrService.startOCRSession(guildId, userId, commandName);
+            logger.info(`[OCR-QUEUE] 🟢 ${inter.user.tag} rozpoczyna sesję OCR (${commandName})`);
+
+            const activeOCR = ocrService.activeProcessing.get(guildId);
+            const ocrExpiresAt = activeOCR ? activeOCR.expiresAt : null;
+
+            // Utwórz sesję (oznaczona jako testowa)
+            const sessionId = phaseService.createSession(
+                inter.user.id,
+                inter.guild.id,
+                inter.channelId,
+                1, // phase
+                ocrExpiresAt
+            );
+
+            const session = phaseService.getSession(sessionId);
+            session.publicInteraction = inter; // ephemeral interaction (editowalna)
+            session.clan = userClan;
+            session.isTest = true; // znacznik trybu testowego
+
+            // Pokaż embed z prośbą o zdjęcia (EPHEMERAL)
+            const awaitingEmbed = phaseService.createAwaitingImagesEmbed();
+            awaitingEmbed.embed.setTitle('🧪 TEST - Prześlij zdjęcia wyników')
+                .setColor('#9B59B6')
+                .setFooter({ text: 'TEST - wynik tylko dla Ciebie, dane NIE będą zapisane' });
+            await inter.editReply({
+                embeds: [awaitingEmbed.embed],
+                components: [awaitingEmbed.row]
+            });
+
+            logger.info(`[TEST] ✅ Sesja testowa utworzona, czekam na zdjęcia od ${inter.user.tag}`);
+        };
+
+        if (willBeQueued) {
+            const { position } = await ocrService.addToOCRQueue(guildId, userId, commandName, interaction, runSession);
+
+            const queueEmbed = new EmbedBuilder()
+                .setTitle('⏳ Kolejka OCR')
+                .setDescription(`System OCR jest obecnie zajęty przez innego użytkownika.\n\n` +
+                               `Zostałeś dodany do kolejki na pozycji **#${position}**.\n\n` +
+                               `⚡ Sesja zostanie **automatycznie uruchomiona** gdy będzie Twoja kolej.`)
+                .setColor('#ffa500')
+                .setTimestamp()
+                .setFooter({ text: `Komenda: ${commandName} | Pozycja w kolejce: ${position}` });
+
+            await interaction.editReply({ embeds: [queueEmbed] });
+            return;
+        }
+
+        await runSession(interaction);
+
+    } catch (error) {
+        logger.error('[TEST] ❌ Błąd komendy /test:', error);
+        await ocrService.endOCRSession(guildId, userId, true);
+        logger.info(`[OCR-QUEUE] 🔴 ${interaction.user.tag} zakończył sesję OCR (błąd)`);
+        await interaction.editReply({
+            content: '❌ Wystąpił błąd podczas inicjalizacji komendy /test.'
+        });
     }
 }
 

--- a/Stalker/index.js
+++ b/Stalker/index.js
@@ -651,6 +651,12 @@ client.on(Events.MessageCreate, async (message) => {
                     logger.error('[PHASE1] ❌ Błąd usuwania wiadomości:', deleteError);
                 }
 
+                // TEST: analiza wszystkich zdjęć naraz przez AI - wynik w ephemeralu, bez zapisu do bazy
+                if (session.isTest) {
+                    await phaseService.processTestImages(session, downloadedFiles, message.guild, message.member);
+                    return;
+                }
+
                 // KROK 3: Przetwarzaj zdjęcia z dysku
                 const results = await phaseService.processImagesFromDisk(
                     session.sessionId,

--- a/Stalker/services/aiOcrService.js
+++ b/Stalker/services/aiOcrService.js
@@ -11,8 +11,9 @@ const SAFETY_SETTINGS_OFF = [
 ];
 
 const PROMPT_VERSIONS = {
-    'extract-results':   'v1',
-    'extract-equipment': 'v1',
+    'extract-results':       'v1',
+    'extract-results-batch': 'v1',
+    'extract-equipment':     'v1',
 };
 
 const logger = createBotLogger('Stalker');
@@ -123,6 +124,71 @@ Jeśli nie możesz odczytać wyników lub zdjęcie nie zawiera wyników graczy, 
 
         } catch (error) {
             logger.error(`[AI OCR] Błąd analizy obrazu:`, error);
+            throw error;
+        }
+    }
+
+    /**
+     * Analizuje WSZYSTKIE zdjęcia naraz w jednym zapytaniu do Gemini Vision (batch).
+     * Dodatkowo otrzymuje listę nicków z roli klanowej Discord i prosi AI o dopasowanie
+     * odczytanych nicków ze screenów do najbliższego nicku Discord.
+     * @param {string[]} imagePaths - Ścieżki do obrazów
+     * @param {string[]} clanNicks - Lista nicków członków roli klanowej z Discorda
+     * @returns {Promise<{players: Array<{playerName: string, score: number}>, confidence: number, isValid: boolean, error?: string}>}
+     */
+    async analyzeResultsImagesBatch(imagePaths, clanNicks = []) {
+        if (!this.enabled) {
+            throw new Error('AI OCR nie jest włączony');
+        }
+
+        try {
+            logger.info(`[AI OCR - Batch] Rozpoczynam analizę ${imagePaths.length} zdjęć naraz (nicki klanu: ${clanNicks.length})`);
+
+            // Zbuduj części zapytania: najpierw wszystkie obrazy, potem prompt tekstowy
+            const parts = [];
+            for (const imagePath of imagePaths) {
+                const pngBuffer = await sharp(imagePath).png().toBuffer();
+                parts.push({ inlineData: { data: pngBuffer.toString('base64'), mimeType: 'image/png' } });
+            }
+
+            const nickListText = clanNicks.length > 0
+                ? clanNicks.map((n, i) => `${i + 1}. ${n}`).join('\n')
+                : '(brak listy)';
+
+            const prompt = `Przeanalizuj ${imagePaths.length} zdjęć z wynikami graczy z gry Survivor.io.
+Zdjęcia mogą się nakładać - ten sam gracz może pojawić się na kilku zdjęciach. Połącz wszystkie zdjęcia w jedną wspólną listę i usuń duplikaty (każdy gracz tylko raz, z jego wynikiem).
+
+Poniżej lista nicków graczy z roli klanowej na Discordzie:
+${nickListText}
+
+Dla każdego gracza odczytanego ze zdjęć dopasuj jego nick do NAJBARDZIEJ PODOBNEGO nicku z powyższej listy Discord. Nicki w grze mogą się nieznacznie różnić od nicków Discord (literówki, dodatkowe ozdobniki, inne znaki specjalne, emoji) - wybierz najbardziej prawdopodobne dopasowanie. W wyniku użyj DOKŁADNIE nicku z listy Discord.
+Jeśli żaden nick z listy nie pasuje, użyj nicku odczytanego bezpośrednio ze zdjęcia.
+
+Zwróć wynik w następującym formacie (jeden gracz na linię):
+<nick na discordzie> - <wynik>
+
+Jeśli nie możesz odczytać wyników lub zdjęcia nie zawierają wyników graczy, odpowiedz: "Nie wykryto wyników graczy".`;
+
+            parts.push({ text: prompt });
+
+            logger.info('[AI OCR - Batch] Wysyłam zapytanie zbiorcze do Gemini Vision...');
+
+            const res = await this._generateContent(parts, 4000, {
+                step:          'extract-results-batch',
+                promptName:    'extract-results-batch',
+                promptVersion: PROMPT_VERSIONS['extract-results-batch'],
+            });
+
+            logger.info('[AI OCR - Batch] Odpowiedź Gemini:');
+            logger.info(res.text);
+
+            const result = this.parseAIResponse(res.text);
+            logger.info(`[AI OCR - Batch] Wynik parsowania: ${result.players.length} graczy`);
+
+            return result;
+
+        } catch (error) {
+            logger.error('[AI OCR - Batch] Błąd analizy zbiorczej:', error);
             throw error;
         }
     }

--- a/Stalker/services/phaseService.js
+++ b/Stalker/services/phaseService.js
@@ -784,6 +784,147 @@ class PhaseService {
     }
 
     /**
+     * Przetwarza WSZYSTKIE zdjęcia naraz przez AI (batch) dla komendy /test.
+     * AI dostaje listę nicków z roli klanowej i dopasowuje odczytane nicki do Discord.
+     * Wynik prezentowany jest WYŁĄCZNIE w ephemeralu - BEZ zapisu do bazy.
+     */
+    async processTestImages(session, downloadedFiles, guild, member) {
+        const aiOcrService = this.ocrService.aiOcrService;
+        const inter = session.publicInteraction;
+
+        // Pomocnicza funkcja do aktualizacji ephemerala
+        const editEphemeral = async (payload) => {
+            if (!inter) return;
+            try {
+                if (inter.editReply) {
+                    await inter.editReply(payload);
+                } else {
+                    await inter.edit(payload);
+                }
+            } catch (err) {
+                logger.warn(`[TEST] ⚠️ Nie udało się zaktualizować ephemerala: ${err.message}`);
+            }
+        };
+
+        try {
+            // Wymagany aktywny AI OCR
+            if (!aiOcrService || !aiOcrService.enabled) {
+                await editEphemeral({
+                    content: '❌ Komenda `/test` wymaga aktywnego AI OCR (USE_STALKER_AI_OCR=true). Funkcja jest obecnie wyłączona.',
+                    embeds: [],
+                    components: []
+                });
+                return;
+            }
+
+            session.isProcessing = true;
+
+            // Pokaż embed "trwa przetwarzanie"
+            const totalImages = downloadedFiles.length;
+            await editEphemeral({
+                embeds: [new EmbedBuilder()
+                    .setTitle('🧪 TEST - Analiza AI (batch)')
+                    .setDescription(`🤖 Wysyłam **${totalImages}** ${totalImages === 1 ? 'zdjęcie' : 'zdjęć'} do AI w jednym zapytaniu...\n⏳ To może chwilę potrwać.`)
+                    .setColor('#9B59B6')
+                    .setTimestamp()],
+                components: []
+            });
+
+            // Pobierz listę nicków z roli klanowej
+            const clanRoleId = this.config.targetRoles[session.clan];
+            await safeFetchMembers(guild, logger);
+            const clanNicks = Array.from(guild.members.cache.values())
+                .filter(m => m.roles.cache.has(clanRoleId))
+                .map(m => m.displayName)
+                .sort((a, b) => a.localeCompare(b));
+
+            logger.info(`[TEST] 👥 Pobrano ${clanNicks.length} nicków z roli klanowej (${this.config.roleDisplayNames[session.clan]})`);
+
+            // Analiza zbiorcza przez AI
+            const filepaths = downloadedFiles.map(f => f.filepath);
+            const aiResult = await aiOcrService.analyzeResultsImagesBatch(filepaths, clanNicks);
+
+            session.isProcessing = false;
+
+            if (session.cancelled) {
+                logger.info('[TEST] ℹ️ Sesja anulowana podczas przetwarzania - pomijam wynik');
+                return;
+            }
+
+            if (!aiResult.isValid || aiResult.players.length === 0) {
+                await editEphemeral({
+                    embeds: [new EmbedBuilder()
+                        .setTitle('🧪 TEST - Brak wyników')
+                        .setDescription('❌ AI nie wykryło żadnych graczy na przesłanych zdjęciach.')
+                        .setColor('#FF0000')
+                        .setTimestamp()],
+                    components: []
+                });
+                return;
+            }
+
+            // Posortuj malejąco i przydziel miejsca (jak w Fazie 1)
+            const sortedPlayers = [...aiResult.players].sort((a, b) => b.score - a.score);
+            const maxScore = sortedPlayers[0]?.score || 1;
+            const top30Sum = sortedPlayers.slice(0, 30).reduce((sum, p) => sum + (p.score || 0), 0);
+            const aboveZero = sortedPlayers.filter(p => p.score > 0).length;
+            const zeroCount = sortedPlayers.filter(p => p.score === 0).length;
+
+            const resultsText = sortedPlayers.map((player, index) => {
+                const position = index + 1;
+                const barLength = 10;
+                const filledLength = player.score > 0
+                    ? Math.max(1, Math.round((player.score / maxScore) * barLength))
+                    : 0;
+                const progressBar = '█'.repeat(filledLength) + '░'.repeat(barLength - filledLength);
+                return `${progressBar} **#${position}** ${player.playerName} - ${player.score.toLocaleString('pl-PL')}`;
+            }).join('\n');
+
+            const clanName = this.config.roleDisplayNames[session.clan] || session.clan;
+            const weekInfo = this.getCurrentWeekInfo();
+
+            // Discord limit opisu embeda = 4096 znaków - przytnij jeśli trzeba
+            const header = `**Klan:** ${clanName}\n**Tydzień:** ${weekInfo.weekNumber}/${weekInfo.year}\n**Zdjęć:** ${totalImages} | **Graczy:** ${sortedPlayers.length}\n\n`;
+            let description = header + resultsText;
+            if (description.length > 4000) {
+                description = description.slice(0, 3990) + '\n…(lista przycięta)';
+            }
+
+            const summaryEmbed = new EmbedBuilder()
+                .setTitle(`🧪 TEST - Podsumowanie (AI batch) - Tydzień ${weekInfo.weekNumber}/${weekInfo.year}`)
+                .setDescription(description)
+                .setColor('#9B59B6')
+                .addFields(
+                    { name: '✅ Graczy', value: sortedPlayers.length.toString(), inline: true },
+                    { name: '📈 Wynik > 0', value: `${aboveZero} osób`, inline: true },
+                    { name: '⭕ Wynik = 0', value: `${zeroCount} osób`, inline: true },
+                    { name: '🏆 Suma TOP30', value: `${top30Sum.toLocaleString('pl-PL')} pkt`, inline: false }
+                )
+                .setTimestamp()
+                .setFooter({ text: 'TEST - dane NIE zostały zapisane do bazy' });
+
+            await editEphemeral({ embeds: [summaryEmbed], components: [] });
+
+            logger.info(`[TEST] ✅ Wyświetlono podsumowanie testowe (${sortedPlayers.length} graczy) - bez zapisu do bazy`);
+
+        } catch (error) {
+            logger.error('[TEST] ❌ Błąd przetwarzania testowego:', error);
+            session.isProcessing = false;
+            await editEphemeral({
+                embeds: [new EmbedBuilder()
+                    .setTitle('🧪 TEST - Błąd')
+                    .setDescription('❌ Wystąpił błąd podczas analizy AI. Spróbuj ponownie.')
+                    .setColor('#FF0000')
+                    .setTimestamp()],
+                components: []
+            });
+        } finally {
+            // Zawsze zwolnij kolejkę OCR i wyczyść sesję
+            await this.cleanupSession(session.sessionId);
+        }
+    }
+
+    /**
      * Aktualizuje postęp w publicznej wiadomości
      */
     async updateProgress(session, progress) {


### PR DESCRIPTION
## Cel

Nowa komenda `/test` w bocie Stalker do diagnostycznego testowania odczytu OCR — pokazuje **w ephemeralu** jak AI odczytało graczy i jak przyporządkowało ich do nicków na Discordzie, **bez zapisu do bazy**.

## Co robi `/test`

1. **Batch AI** — wysyła WSZYSTKIE zdjęcia naraz w jednym zapytaniu do Gemini Vision (zamiast pojedynczo jak `/faza1`) → szybciej i mniej powielania promptu.
2. **Dopasowanie nicków** — do promptu dołącza pełną listę nicków członków roli klanowej użytkownika (pobrane przez `safeFetchMembers`). AI dopasowuje nicki odczytane ze screenów do najbardziej podobnego nicku Discord i zwraca format `<nick Discord> - <wynik>`.
3. **Przydział miejsc** — wynik sortowany malejąco z miejscami i paskami postępu (jak `/faza1`): `█████░░░░░ #1 nick - wynik`, plus suma TOP30.
4. **Ephemeral, bez zapisu** — wynik widoczny tylko dla wywołującego, dane NIE trafiają do bazy.

## Szczegóły techniczne

- **`aiOcrService.js`** — nowa metoda `analyzeResultsImagesBatch(imagePaths, clanNicks)` (wszystkie obrazy + jeden prompt z listą nicków klanu). Reużywa `parseAIResponse`. Nowa wersja promptu `extract-results-batch` v1.
- **`phaseService.js`** — nowa metoda `processTestImages()` (pobranie nicków roli, batch AI, budowa ephemeralnego embeda, sprzątanie sesji + zwolnienie kolejki OCR).
- **`interactionHandlers.js`** — rejestracja `/test`, routing, dodanie do `ocrCommands` (ten sam kanał OCR co `/faza1`), handler `handleTestCommand` (mirror `/faza1`, ale `deferReply ephemeral`, flaga `session.isTest`, wczesny check `USE_STALKER_AI_OCR`).
- **`index.js`** — branch w message handlerze: dla `session.isTest` wywołuje `processTestImages` zamiast normalnego flow Fazy 1.

## Uprawnienia / ograniczenia

- Wymaga roli moderatora/admina (jak `/faza1`).
- Działa tylko na kanale OCR `1437122516974829679`.
- Wymaga aktywnego AI OCR (`USE_STALKER_AI_OCR=true`).
- Korzysta z tej samej kolejki OCR (jeden użytkownik OCR naraz).

## Dokumentacja

- Zaktualizowano `Stalker/CLAUDE.md` (sekcja Fazy Lunar + AI OCR + lista komend).
- Dodano wpis do `Muteusz/config/all_commands.json`.

https://claude.ai/code/session_01P9jvSsBTFy8Uzvu7NykeHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9jvSsBTFy8Uzvu7NykeHN)_