### PR TITLE
Stalker batch AI (faza/remind/punish) + usunięcie /test; Kontroler na czasie polskim

### DIFF
--- a/Kontroler/CLAUDE.md
+++ b/Kontroler/CLAUDE.md
@@ -3,7 +3,8 @@
 **4 Systemy:**
 1. **OCR Dwukanałowy** - `ocrService.js`: CX (1500min, 0-2800/100, skip1, rola 2800+), Daily (910min, 0-1050/10, skip3, 2x nick), normalizacja znaków (o→0, z→2, l→1, sg→9)
    - **Zapis CX do shared_data:** Po udanym OCR na kanale CX, wynik jest zapisywany do `shared_data/cx_history.json` (klucz: userId, historia max 20 wyników). Używane przez Stalker Bot w `/player-status` i `/player-compare`
-2. **Loteria** - `lotteryService.js`: Daty (dd.mm.yyyy HH:MM), DST auto, multi-klan (server/main/0/1/2), cykle (0-365dni, max 24d), ostrzeżenia (90/30min), historia+przelosowanie, ban filter
+2. **Loteria** - `lotteryService.js`: Daty (dd.mm.yyyy HH:MM) w **czasie polskim** (Europe/Warsaw, niezależnie od strefy serwera), DST auto, multi-klan (server/main/0/1/2), cykle (0-365dni, max 24d), ostrzeżenia (90/30min), historia+przelosowanie, ban filter
+   - **Czas polski (`utils/timezone.js`):** Bot operuje w strefie Europe/Warsaw niezależnie od strefy czasowej serwera (np. UTC). `polandWallClockToUTC(y,m,d,h,min)` przelicza polski zegar ścienny na poprawny moment UTC (DST przez `Intl`), `getPolandParts()` zwraca komponenty czasu polskiego "teraz" (walidacja dat, klucze ostrzeżeń), `formatPolandDateTime/Date/Time()` formatują do wyświetlenia. Tworzenie loterii, obliczanie kolejnych losowań, walidacja daty i wszystkie wyświetlane daty używają czasu polskiego.
 3. **Dywersja w klanie** - `votingService.js`:
    - Trigger: Fraza "działasz na szkodę klanu" w odpowiedzi do użytkownika
    - Głosowanie: 15 minut (przyciski Tak/Nie), ping roli klanowej

--- a/Kontroler/handlers/interactionHandlers.js
+++ b/Kontroler/handlers/interactionHandlers.js
@@ -6,6 +6,7 @@ const {
 const fs = require('fs').promises;
 const OligopolyService = require('../services/oligopolyService');
 const { createBotLogger } = require('../../utils/consoleLogger');
+const { getPolandParts } = require('../utils/timezone');
 
 const logger = createBotLogger('Kontroler');
 
@@ -240,24 +241,24 @@ async function handleLotteryCommand(interaction, config, lotteryService) {
         return;
     }
     
-    // Sprawdź czy data nie jest w przeszłości i nie przekracza limitu 365 dni
-    const now = new Date();
-    now.setHours(0, 0, 0, 0);
-    drawDate.setHours(0, 0, 0, 0);
-    
-    if (drawDate < now) {
+    // Sprawdź czy data nie jest w przeszłości i nie przekracza limitu 365 dni (względem POLSKIEJ daty "dziś")
+    const plNow = getPolandParts();
+    const today = new Date(Date.UTC(plNow.year, plNow.month - 1, plNow.day));
+    const drawDay = new Date(Date.UTC(year, month - 1, day));
+
+    if (drawDay < today) {
         await interaction.reply({
             content: '❌ Data następnego losowania nie może być w przeszłości.',
             ephemeral: true
         });
         return;
     }
-    
-    // Sprawdź czy data nie przekracza limitu 365 dni
-    const maxDate = new Date(now);
-    maxDate.setDate(now.getDate() + 365);
 
-    if (drawDate > maxDate) {
+    // Sprawdź czy data nie przekracza limitu 365 dni
+    const maxDate = new Date(today);
+    maxDate.setUTCDate(today.getUTCDate() + 365);
+
+    if (drawDay > maxDate) {
         await interaction.reply({
             content: '❌ Data następnego losowania nie może być dalej niż 365 dni w przyszłości.',
             ephemeral: true
@@ -394,8 +395,8 @@ async function handleLotteryRerollCommand(interaction, config, lotteryService) {
         const recentHistory = history.slice(-20); // Ostatnie 20 loterii
         const selectOptions = recentHistory.map((result, index) => {
             const originalIndex = history.length - recentHistory.length + index;
-            const date = new Date(result.date).toLocaleDateString('pl-PL');
-            const time = new Date(result.date).toLocaleTimeString('pl-PL', {hour: '2-digit', minute: '2-digit'});
+            const date = new Date(result.date).toLocaleDateString('pl-PL', { timeZone: 'Europe/Warsaw' });
+            const time = new Date(result.date).toLocaleTimeString('pl-PL', {hour: '2-digit', minute: '2-digit', timeZone: 'Europe/Warsaw'});
             
             return {
                 label: `${result.lotteryName}`,
@@ -490,7 +491,7 @@ async function handlePlannedLotteryRemove(interaction, config, lotteryService) {
     const selectOptions = activeLotteries.map(lottery => {
         // Użyj nextDraw zamiast daty z ID loterii
         const nextDrawDate = lottery.nextDraw ? new Date(lottery.nextDraw) : null;
-        const formattedDate = nextDrawDate ? nextDrawDate.toLocaleDateString('pl-PL') : 'Jednorazowa - wykonana';
+        const formattedDate = nextDrawDate ? nextDrawDate.toLocaleDateString('pl-PL', { timeZone: 'Europe/Warsaw' }) : 'Jednorazowa - wykonana';
         const clan = config.lottery.clans[lottery.clanKey];
         
         return {
@@ -547,8 +548,8 @@ async function handleHistoricalLotteryRemove(interaction, config, lotteryService
     const recentHistory = history.slice(-20); // Ostatnie 20 loterii
     const selectOptions = recentHistory.map((result, index) => {
         const originalIndex = history.length - recentHistory.length + index;
-        const date = new Date(result.originalDate || result.date).toLocaleDateString('pl-PL');
-        const time = new Date(result.originalDate || result.date).toLocaleTimeString('pl-PL', {hour: '2-digit', minute: '2-digit'});
+        const date = new Date(result.originalDate || result.date).toLocaleDateString('pl-PL', { timeZone: 'Europe/Warsaw' });
+        const time = new Date(result.originalDate || result.date).toLocaleTimeString('pl-PL', {hour: '2-digit', minute: '2-digit', timeZone: 'Europe/Warsaw'});
         
         return {
             label: `${result.lotteryName}`,
@@ -638,8 +639,8 @@ async function handleLotteryRemovePlannedSelect(interaction, config, lotteryServ
             // Przygotuj listę historycznych wyników z datami
             let historyList = '';
             relatedResults.forEach((result, index) => {
-                const date = new Date(result.originalDate || result.date).toLocaleDateString('pl-PL');
-                const time = new Date(result.originalDate || result.date).toLocaleTimeString('pl-PL', {hour: '2-digit', minute: '2-digit'});
+                const date = new Date(result.originalDate || result.date).toLocaleDateString('pl-PL', { timeZone: 'Europe/Warsaw' });
+                const time = new Date(result.originalDate || result.date).toLocaleTimeString('pl-PL', {hour: '2-digit', minute: '2-digit', timeZone: 'Europe/Warsaw'});
                 const isReroll = result.lotteryId && result.lotteryId.includes('_reroll');
                 const type = isReroll ? '🔄 Reroll' : '🎲 Losowanie';
                 const winnersCount = (result.winners || result.newWinners || []).length;
@@ -670,7 +671,7 @@ async function handleLotteryRemovePlannedSelect(interaction, config, lotteryServ
                     },
                     {
                         name: '📅 Harmonogram',
-                        value: `${lottery.nextDraw ? new Date(lottery.nextDraw).toLocaleDateString('pl-PL') : 'Jednorazowa'} o ${lottery.hour}:${lottery.minute.toString().padStart(2, '0')}`,
+                        value: `${lottery.nextDraw ? new Date(lottery.nextDraw).toLocaleDateString('pl-PL', { timeZone: 'Europe/Warsaw' }) : 'Jednorazowa'} o ${lottery.hour}:${lottery.minute.toString().padStart(2, '0')}`,
                         inline: true
                     },
                     {
@@ -722,7 +723,7 @@ async function handleLotteryRemovePlannedSelect(interaction, config, lotteryServ
                     },
                     {
                         name: '📅 Harmonogram',
-                        value: `${lottery.nextDraw ? new Date(lottery.nextDraw).toLocaleDateString('pl-PL') : 'Jednorazowa'} o ${lottery.hour}:${lottery.minute.toString().padStart(2, '0')}`,
+                        value: `${lottery.nextDraw ? new Date(lottery.nextDraw).toLocaleDateString('pl-PL', { timeZone: 'Europe/Warsaw' }) : 'Jednorazowa'} o ${lottery.hour}:${lottery.minute.toString().padStart(2, '0')}`,
                         inline: true
                     },
                     {
@@ -847,7 +848,7 @@ async function handleLotteryRemovePlannedConfirm(interaction, config, lotterySer
                     },
                     {
                         name: '📅 Harmonogram',
-                        value: `${lottery.nextDraw ? new Date(lottery.nextDraw).toLocaleDateString('pl-PL') : 'Jednorazowa'} o ${lottery.hour}:${lottery.minute.toString().padStart(2, '0')}`,
+                        value: `${lottery.nextDraw ? new Date(lottery.nextDraw).toLocaleDateString('pl-PL', { timeZone: 'Europe/Warsaw' }) : 'Jednorazowa'} o ${lottery.hour}:${lottery.minute.toString().padStart(2, '0')}`,
                         inline: true
                     },
                     {
@@ -899,7 +900,7 @@ async function handleLotteryRemovePlannedConfirm(interaction, config, lotterySer
                     },
                     {
                         name: '📅 Harmonogram',
-                        value: `${lottery.nextDraw ? new Date(lottery.nextDraw).toLocaleDateString('pl-PL') : 'Jednorazowa'} o ${lottery.hour}:${lottery.minute.toString().padStart(2, '0')}`,
+                        value: `${lottery.nextDraw ? new Date(lottery.nextDraw).toLocaleDateString('pl-PL', { timeZone: 'Europe/Warsaw' }) : 'Jednorazowa'} o ${lottery.hour}:${lottery.minute.toString().padStart(2, '0')}`,
                         inline: true
                     },
                     {
@@ -994,7 +995,7 @@ async function handleLotteryRemoveHistoricalSelect(interaction, config, lotteryS
                 },
                 {
                     name: '📅 Data',
-                    value: new Date(lotteryToRemove.originalDate || lotteryToRemove.date).toLocaleDateString('pl-PL'),
+                    value: new Date(lotteryToRemove.originalDate || lotteryToRemove.date).toLocaleDateString('pl-PL', { timeZone: 'Europe/Warsaw' }),
                     inline: true
                 },
                 {
@@ -1489,8 +1490,8 @@ async function generateHistoryEmbed(history, currentPage, config, guild = null) 
         pageItems.forEach((result, index) => {
             try {
                 const globalIndex = startIndex + index + 1;
-                const date = new Date(result.originalDate || result.date).toLocaleDateString('pl-PL');
-                const time = new Date(result.originalDate || result.date).toLocaleTimeString('pl-PL', {hour: '2-digit', minute: '2-digit'});
+                const date = new Date(result.originalDate || result.date).toLocaleDateString('pl-PL', { timeZone: 'Europe/Warsaw' });
+                const time = new Date(result.originalDate || result.date).toLocaleTimeString('pl-PL', {hour: '2-digit', minute: '2-digit', timeZone: 'Europe/Warsaw'});
             
             // Znajdź nazwę klanu
             let clanName = 'Nieznany';

--- a/Kontroler/handlers/messageHandlers.js
+++ b/Kontroler/handlers/messageHandlers.js
@@ -1,5 +1,6 @@
 const { downloadFile, cleanupFiles, safeEditMessage } = require('../utils/helpers');
 const { createBotLogger } = require('../../utils/consoleLogger');
+const { formatPolandDateTime } = require('../utils/timezone');
 const { EmbedBuilder } = require('discord.js');
 const cron = require('node-cron');
 const fs = require('fs').promises;
@@ -221,7 +222,7 @@ class MessageHandler {
         logger.info(`👤 Nick serwera: "${displayName}"`);
         logger.info(`👤 Nazwa użytkownika: "${username}"`);
         logger.info(`📷 Obraz: ${imageAttachment.name} (${Math.round(imageAttachment.size / 1024)}KB)`);
-        logger.info(`📅 Czas: ${new Date().toLocaleString('pl-PL')}`);
+        logger.info(`📅 Czas: ${formatPolandDateTime(new Date())}`);
         logger.info(`🔗 URL: ${imageAttachment.url}`);
         logger.info(`⚙️ Kanał ${channelConfig.name}: min=${channelConfig.minimumScore}, zakres=${channelConfig.scoreRange}, krok=${channelConfig.scoreStep}`);
         logger.info(`🎯 Wymagane ${channelConfig.requireSecondOccurrence ? 'DRUGIE' : 'PIERWSZE'} wystąpienie nicku`);

--- a/Kontroler/services/lotteryService.js
+++ b/Kontroler/services/lotteryService.js
@@ -3,6 +3,7 @@ const path = require('path');
 const cron = require('node-cron');
 const { EmbedBuilder } = require('discord.js');
 const { createBotLogger } = require('../../utils/consoleLogger');
+const { polandWallClockToUTC, getPolandParts, formatPolandDateTime } = require('../utils/timezone');
 
 const logger = createBotLogger('Kontroler');
 
@@ -146,26 +147,17 @@ class LotteryService {
         // Ustaw dokładną datę i czas pierwszego losowania w polskiej strefie czasowej
         // Tworzymy datę w formacie YYYY-MM-DD HH:MM w strefie Europe/Warsaw
         const year = drawDate.getFullYear();
-        const month = String(drawDate.getMonth() + 1).padStart(2, '0');
-        const day = String(drawDate.getDate()).padStart(2, '0');
-        const hourStr = String(hour).padStart(2, '0');
-        const minuteStr = String(minute).padStart(2, '0');
-        
-        // Tworzymy datę w polskiej strefie czasowej
-        const dateTimeString = `${year}-${month}-${day}T${hourStr}:${minuteStr}:00`;
-        
-        // Konwertujemy na UTC uwzględniając polską strefę czasową
-        const nextDrawDate = new Date(dateTimeString);
-        
-        // Sprawdź czy to czas letni (marzec-październik) czy zimowy
-        const isWinterTime = this.isWinterTime(nextDrawDate);
-        const offsetHours = isWinterTime ? -1 : -2; // Polska to UTC+1 (zimą) lub UTC+2 (latem)
-        
-        // Skoryguj o różnicę czasową (konwertuj z polskiego czasu na UTC)
-        nextDrawDate.setHours(nextDrawDate.getHours() + offsetHours);
-        
+        const monthNum = drawDate.getMonth() + 1;
+        const dayNum = drawDate.getDate();
+        const month = String(monthNum).padStart(2, '0');
+        const day = String(dayNum).padStart(2, '0');
+
+        // Polski zegar ścienny (Europe/Warsaw) → poprawny moment UTC.
+        // DST obsłużone automatycznie, niezależnie od strefy czasowej serwera.
+        const nextDrawDate = polandWallClockToUTC(year, monthNum, dayNum, hour, minute);
+
         const nextDrawTimestamp = nextDrawDate.getTime();
-        const formattedDate = nextDrawDate.toISOString().split('T')[0].replace(/-/g, ''); // YYYYMMDD
+        const formattedDate = `${year}${month}${day}`; // YYYYMMDD (polska data losowania)
         const roleShort = targetRole.name.toLowerCase().replace(/[^a-z0-9]/g, '').substring(0, 6);
         const clanShort = clanKey.toLowerCase();
         const randomSuffix = Math.random().toString(36).substr(2, 4);
@@ -183,7 +175,7 @@ class LotteryService {
             clanName: clan.name,
             clanDisplayName: clan.displayName,
             frequency: frequency,
-            firstDrawDate: drawDate.toISOString().split('T')[0], // Zapisz oryginalną datę w formacie YYYY-MM-DD
+            firstDrawDate: `${year}-${month}-${day}`, // Polska data pierwszego losowania (YYYY-MM-DD)
             hour: hour,
             minute: minute,
             winnersCount: winnersCount,
@@ -211,36 +203,13 @@ class LotteryService {
     }
 
     /**
-     * Sprawdza czy podana data jest w czasie zimowym (UTC+1) czy letnim (UTC+2) w Polsce
-     * @param {Date} date - Data do sprawdzenia
-     * @returns {boolean} - true jeśli czas zimowy, false jeśli letni
-     */
-    isWinterTime(date) {
-        const year = date.getFullYear();
-        
-        // Ostatnia niedziela marca (początek czasu letniego)
-        const lastSundayMarch = new Date(year, 2, 31);
-        lastSundayMarch.setDate(31 - lastSundayMarch.getDay());
-        
-        // Ostatnia niedziela października (powrót do czasu zimowego)
-        const lastSundayOctober = new Date(year, 9, 31);
-        lastSundayOctober.setDate(31 - lastSundayOctober.getDay());
-        
-        // Jeśli data jest przed ostatnią niedzielą marca lub po ostatniej niedzieli października
-        return date < lastSundayMarch || date > lastSundayOctober;
-    }
-
-    /**
      * Konwertuje czas UTC na polski czas lokalny dla wyświetlania
      * @param {Date} utcDate - Data w UTC
      * @returns {string} - Sformatowana data w polskim czasie
      */
     convertUTCToPolishTime(utcDate) {
-        const isWinter = this.isWinterTime(utcDate);
-        const offsetHours = isWinter ? 1 : 2; // Dodajemy offset dla konwersji UTC -> Polski czas
-        
-        const polishTime = new Date(utcDate.getTime() + offsetHours * 60 * 60 * 1000);
-        return polishTime.toLocaleString('pl-PL');
+        // Formatowanie w strefie Europe/Warsaw (DST automatyczne, niezależne od strefy serwera)
+        return formatPolandDateTime(utcDate);
     }
 
     /**
@@ -261,27 +230,16 @@ class LotteryService {
             return currentDrawDate;
         }
         
-        // Dla cyklicznych loterii - dodaj frequency dni do aktualnej daty
-        const currentDate = new Date(currentDrawDate);
-        const nextDate = new Date(currentDate);
-        nextDate.setDate(currentDate.getDate() + frequency);
-        
-        // Ustaw czas w polskiej strefie czasowej
-        const year = nextDate.getFullYear();
-        const month = String(nextDate.getMonth() + 1).padStart(2, '0');
-        const day = String(nextDate.getDate()).padStart(2, '0');
-        const hourStr = String(hour).padStart(2, '0');
-        const minuteStr = String(minute).padStart(2, '0');
-        
-        const dateTimeString = `${year}-${month}-${day}T${hourStr}:${minuteStr}:00`;
-        const polishTime = new Date(dateTimeString);
-        
-        // Sprawdź czy to czas letni czy zimowy i skoryguj
-        const isWinter = this.isWinterTime(polishTime);
-        const offsetHours = isWinter ? -1 : -2;
-        polishTime.setHours(polishTime.getHours() + offsetHours);
-        
-        return polishTime.toISOString();
+        // Dla cyklicznych loterii - dodaj frequency dni do POLSKIEJ daty bieżącego losowania,
+        // po czym przelicz polski zegar ścienny (hour:minute) na poprawny moment UTC.
+        const cur = getPolandParts(new Date(currentDrawDate));
+        const base = new Date(Date.UTC(cur.year, cur.month - 1, cur.day));
+        base.setUTCDate(base.getUTCDate() + frequency);
+        const year = base.getUTCFullYear();
+        const monthNum = base.getUTCMonth() + 1;
+        const dayNum = base.getUTCDate();
+
+        return polandWallClockToUTC(year, monthNum, dayNum, hour, minute).toISOString();
     }
 
     /**
@@ -464,9 +422,10 @@ class LotteryService {
                 return;
             }
 
-            // Sprawdź czy ostrzeżenie już zostało wysłane dla tego typu kanału w tej godzinie
+            // Sprawdź czy ostrzeżenie już zostało wysłane dla tego typu kanału w tej godzinie (czas polski)
             const now = new Date();
-            const warningKey = `closing_${channelType}_${now.getDate()}_${now.getMonth()}_${now.getHours()}_${now.getMinutes()}`;
+            const pl = getPolandParts(now);
+            const warningKey = `closing_${channelType}_${pl.day}_${pl.month}_${pl.hour}_${pl.minute}`;
             
             if (this.sentWarnings.has(warningKey)) {
                 logger.info(`📋 Ostrzeżenie zamknięcia już wysłane dla ${channelType} w tym czasie - pomijanie`);
@@ -534,9 +493,10 @@ class LotteryService {
                 return;
             }
 
-            // Sprawdź czy finalne ostrzeżenie już zostało wysłane dla tego typu kanału w tej godzinie
+            // Sprawdź czy finalne ostrzeżenie już zostało wysłane dla tego typu kanału w tej godzinie (czas polski)
             const now = new Date();
-            const warningKey = `final_${channelType}_${now.getDate()}_${now.getMonth()}_${now.getHours()}_${now.getMinutes()}`;
+            const pl = getPolandParts(now);
+            const warningKey = `final_${channelType}_${pl.day}_${pl.month}_${pl.hour}_${pl.minute}`;
             
             if (this.sentWarnings.has(warningKey)) {
                 logger.info(`📋 Finalne ostrzeżenie już wysłane dla ${channelType} w tym czasie - pomijanie`);

--- a/Kontroler/utils/timezone.js
+++ b/Kontroler/utils/timezone.js
@@ -1,0 +1,90 @@
+/**
+ * Obsługa czasu polskiego (Europe/Warsaw) NIEZALEŻNIE od strefy czasowej serwera.
+ *
+ * Serwer produkcyjny może działać w UTC lub innej strefie - te funkcje zawsze liczą
+ * względem Europe/Warsaw, z poprawną obsługą czasu letniego/zimowego (DST) przez Intl.
+ *
+ * - polandWallClockToUTC(): zegar ścienny w Polsce → poprawny moment UTC (Date)
+ * - getPolandParts(): komponenty (rok/miesiąc/dzień/godzina/minuta) "teraz" w Polsce
+ * - formatPoland*(): formatowanie do wyświetlenia w polskim czasie
+ */
+
+const POLAND_TZ = 'Europe/Warsaw';
+
+/**
+ * Zwraca przesunięcie strefy Europe/Warsaw względem UTC (w ms) dla danego momentu.
+ * Dodatnie = Polska jest przed UTC (UTC+1 zimą = 3600000, UTC+2 latem = 7200000).
+ */
+function getWarsawOffsetMs(date) {
+    const dtf = new Intl.DateTimeFormat('en-US', {
+        timeZone: POLAND_TZ,
+        hourCycle: 'h23',
+        year: 'numeric', month: '2-digit', day: '2-digit',
+        hour: '2-digit', minute: '2-digit', second: '2-digit'
+    });
+    const m = {};
+    for (const p of dtf.formatToParts(date)) {
+        if (p.type !== 'literal') m[p.type] = parseInt(p.value, 10);
+    }
+    // Zegar ścienny w Warszawie potraktowany jakby był UTC, minus rzeczywisty moment UTC
+    const asUTC = Date.UTC(m.year, m.month - 1, m.day, m.hour, m.minute, m.second);
+    return asUTC - date.getTime();
+}
+
+/**
+ * Konwertuje polski zegar ścienny (rok, miesiąc 1-12, dzień, godzina, minuta) na
+ * poprawny moment w UTC (obiekt Date). Poprawnie obsługuje DST na dowolnym serwerze.
+ */
+function polandWallClockToUTC(year, month, day, hour = 0, minute = 0, second = 0) {
+    const guess = Date.UTC(year, month - 1, day, hour, minute, second);
+    // Pierwsze przybliżenie offsetu
+    let offset = getWarsawOffsetMs(new Date(guess));
+    let utc = guess - offset;
+    // Korekta (poprawne przejścia DST)
+    offset = getWarsawOffsetMs(new Date(utc));
+    utc = guess - offset;
+    return new Date(utc);
+}
+
+/**
+ * Zwraca komponenty czasu polskiego dla danego momentu (domyślnie "teraz").
+ * @returns {{year:number, month:number, day:number, hour:number, minute:number, second:number}}
+ */
+function getPolandParts(date = new Date()) {
+    const dtf = new Intl.DateTimeFormat('en-US', {
+        timeZone: POLAND_TZ,
+        hourCycle: 'h23',
+        year: 'numeric', month: '2-digit', day: '2-digit',
+        hour: '2-digit', minute: '2-digit', second: '2-digit'
+    });
+    const m = {};
+    for (const p of dtf.formatToParts(date)) {
+        if (p.type !== 'literal') m[p.type] = parseInt(p.value, 10);
+    }
+    return { year: m.year, month: m.month, day: m.day, hour: m.hour, minute: m.minute, second: m.second };
+}
+
+/** Pełna data i czas w polskim formacie (np. "15.01.2025, 20:00:00"). */
+function formatPolandDateTime(date) {
+    return new Date(date).toLocaleString('pl-PL', { timeZone: POLAND_TZ });
+}
+
+/** Sama data w polskim formacie (np. "15.01.2025"). */
+function formatPolandDate(date) {
+    return new Date(date).toLocaleDateString('pl-PL', { timeZone: POLAND_TZ });
+}
+
+/** Sama godzina w polskim formacie (np. "20:00"). */
+function formatPolandTime(date) {
+    return new Date(date).toLocaleTimeString('pl-PL', { timeZone: POLAND_TZ, hour: '2-digit', minute: '2-digit' });
+}
+
+module.exports = {
+    POLAND_TZ,
+    getWarsawOffsetMs,
+    polandWallClockToUTC,
+    getPolandParts,
+    formatPolandDateTime,
+    formatPolandDate,
+    formatPolandTime
+};


### PR DESCRIPTION
## Zakres

PR zbiera zmiany z bieżącej sesji w dwóch obszarach: **Stalker** (batch AI dla komend OCR) oraz **Kontroler** (czas polski).

---

### Stalker — batch AI dla komend OCR
- `/faza1`, `/faza2`, `/remind`, `/punish` analizują wszystkie zdjęcia **naraz** (batch AI) z listą nicków roli klanowej w prompcie. `processImagesFromDisk()` → dyspozytor (AI → `processImagesBatch()`, brak AI → `processImagesPerImage()` Tesseract). `/remind`/`/punish` filtrują graczy z wynikiem **0**.
- **Przydział nicków 1:1 (`utils/nickMatcher.js`):** każdy gracz na screenie = jeden klanowicz, zachłannie po globalnym minimum odległości, Levenshtein na grafemach (emoji = 1 znak) po normalizacji (NFKD + diakrytyki + lowercase), bez progu. Naprawia rozjazd „44 vs 40" w Fazie 2.
- **Steppery postępu:** analiza (`📥→🤖→⚙️→📊`) oraz checklist etapu wysyłki (remind: deduplikacja → urlopy → wysyłka → tracking; punish: deduplikacja → urlopy → kary). Checklist zatrzymuje się na decyzje o urlopowiczach i wznawia po nich.
- **Dostarczalność DM (`/remind`):** embed wyniku pokazuje `✅ DM dostarczone` i `❌ DM nie dotarło — zablokowany bot lub wyłączone DM`.
- **Usunięto komendę `/test`** (wszystkie komendy działają już w trybie batch).

### Kontroler — czas polski (Europe/Warsaw)
- Bot operuje w czasie polskim **niezależnie od strefy serwera** (wcześniej zakładał UTC + ręczny offset DST).
- **Nowy `utils/timezone.js`:** `polandWallClockToUTC()` (DST przez `Intl`), `getPolandParts()`, `formatPolandDateTime/Date/Time()`.
- Loteria: tworzenie i kolejne losowania przez `polandWallClockToUTC` (usunięto kruche `isWinterTime`), wyświetlanie i klucze ostrzeżeń w czasie polskim, ID/`firstDrawDate` z polskiej daty.
- Walidacja daty loterii względem polskiego „dziś"; wszystkie wyświetlane daty z `timeZone: 'Europe/Warsaw'`.
- Bez zmian: `Date.now()`/`setTimeout`/ISO/cooldowny (absolutne, niezależne od strefy).

## Uwagi / do weryfikacji
- Stalker batch wymaga `USE_STALKER_AI_OCR=true` (inaczej fallback per-zdjęcie). Warto przejść pełny przebieg każdej komendy na środowisku z AI OCR.
- Kontroler: util strefy przetestowany w izolacji (zima/lato/granica DST/format) — warto sprawdzić realne tworzenie i wyświetlanie loterii.
- Wszystko sprawdzone składniowo (`node -c`).

https://claude.ai/code/session_016zCj7he2jxGCkm4E4UvUBX

---
_Generated by [Claude Code](https://claude.ai/code/session_016zCj7he2jxGCkm4E4UvUBX)_