### PR TITLE
EndersEcho: jednostka Sp + jednoliniowy log rejestracji komend

### DIFF
--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -176,6 +176,7 @@ class InteractionHandler {
         for (const id of client.guilds.cache.keys()) guildIds.add(id);
 
         const skipped = [];
+        const registered = [];
         for (const guildId of guildIds) {
             if (!client.guilds.cache.has(guildId)) {
                 skipped.push(guildId);
@@ -188,10 +189,13 @@ class InteractionHandler {
                     Routes.applicationGuildCommands(this.config.clientId, guildId),
                     { body: commands }
                 );
-                logger.info(`✅ Zarejestrowano komendy dla serwera "${client.guilds.cache.get(guildId)?.name || guildId}" (${cfg.lang || 'eng'})`);
+                registered.push(`"${client.guilds.cache.get(guildId)?.name || guildId}" (${cfg.lang || 'eng'})`);
             } catch (error) {
                 logger.error(`Błąd rejestracji slash commands dla serwera "${client.guilds.cache.get(guildId)?.name || guildId}":`, error);
             }
+        }
+        if (registered.length > 0) {
+            logger.info(`✅ Zarejestrowano komendy dla ${registered.length} serwer(ów): ${registered.join(', ')}`);
         }
         if (skipped.length > 0) {
             logger.info(`ℹ️ Pominięto rejestrację komend dla ${skipped.length} serwer(ów) nieobecnych w cache (bot usunięty)`);


### PR DESCRIPTION
## Zmiany

### 1. Nowa jednostka Sp (1 Sp = 1000 Sx = 1e24)

Dodano jednostkę **Sp** we wszystkich niezbędnych miejscach:

| Plik | Co zmieniono |
|------|-------------|
| `config/config.js` | `'SP': 1e24` w tablicy `scoring.units` |
| `services/chartService.js` | `{ name: 'Sp', value: 1e24 }` na czele `SCORE_UNITS` (oś Y wykresu) |
| `services/rankingService.js` | `formatScore()`, `parseScoreValue()`, `getScoreUnit()`, `formatProgressInUnit()` |
| `services/aiOcrService.js` | Prompt AI, regex walidacji, `normalizeScore()`, `parseScoreToNumber()` |
| `services/ocrService.js` | Wszystkie regex ekstrakcji wyniku (tradycyjny Tesseract OCR) |
| `config/messages.js` | Komunikaty błędów (PL + ENG) |
| `CLAUDE.md` | Dokumentacja |

### 2. Jednoliniowy log rejestracji komend

Zamiast osobnej linii per serwer, wszystkie serwery logowane są w jednej linii:

**Przed:**
```
✅ Zarejestrowano komendy dla serwera "Polski Squad" (pol)
✅ Zarejestrowano komendy dla serwera "Test Server" (eng)
```

**Po:**
```
✅ Zarejestrowano komendy dla 2 serwer(ów): "Polski Squad" (pol), "Test Server" (eng)
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHkKUKn2GTEyqXMwN67yHz)_