### PR TITLE
EndersEcho: wyciąganie nazwy z custom emoji w tagu serwera

### DIFF
--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -5703,7 +5703,7 @@ class InteractionHandler {
             const cvGuildConfig = this.config.getGuildConfig(session.guildId);
             const cvGuildTag = cvGuildConfig?.tag || null;
             const cvGuildIcon = sourceGuild?.iconURL({ dynamic: true, size: 64 }) || cvGuildConfig?.icon || null;
-            const cvAuthorName = cvGuildTag ? `${cvGuildTag}  ${sourceGuild?.name || session.guildId}` : (sourceGuild?.name || session.guildId);
+            const cvAuthorName = cvGuildTag ? `${cvGuildTag.replace(/^<a?:([^:]+):\d+>$/, '$1')}  ${sourceGuild?.name || session.guildId}` : (sourceGuild?.name || session.guildId);
             const cvUserAvatar = targetUser?.displayAvatarURL({ dynamic: true, size: 64 }) || cvGuildIcon || null;
 
             // Pobierz screenshota z oryginalnej wiadomości (embed.image lub attachment)
@@ -8907,7 +8907,7 @@ class InteractionHandler {
                 const guildConfig = this.config.getGuildConfig(interaction.guildId);
                 const guildTag = guildConfig?.tag || null;
                 const guildIcon = interaction.guild?.iconURL({ dynamic: true, size: 64 }) || guildConfig?.icon || null;
-                const authorName = guildTag ? `${guildTag}  ${serverName}` : serverName;
+                const authorName = guildTag ? `${guildTag.replace(/^<a?:([^:]+):\d+>$/, '$1')}  ${serverName}` : serverName;
                 const userAvatar = interaction.user.displayAvatarURL({ dynamic: true, size: 64 });
 
                 const fields = [

--- a/EndersEcho/services/globalTop10Service.js
+++ b/EndersEcho/services/globalTop10Service.js
@@ -217,7 +217,7 @@ class GlobalTop10Service {
             const tag       = guildTagMap.get(player.sourceGuildId);
             const date      = new Date(player.timestamp);
             const shortDate = `${date.getDate().toString().padStart(2, '0')}.${(date.getMonth() + 1).toString().padStart(2, '0')}`;
-            const tagSuffix = tag ? `  ·  ${tag}` : '';
+            const tagSuffix = tag ? `  ·  ${tag.replace(/^<a?:([^:]+):\d+>$/, '$1')}` : '';
             const scoreStr  = player.score || this.rankingService.formatScore(player.scoreValue);
             const bossStr   = player.bossName || msgs.unknownBoss;
 
@@ -357,7 +357,7 @@ class GlobalTop10Service {
             const tag = guildTagMap.get(player.sourceGuildId);
             const date = new Date(player.timestamp);
             const shortDate = `${date.getDate().toString().padStart(2, '0')}.${(date.getMonth() + 1).toString().padStart(2, '0')}`;
-            const serverSuffix = tag ? ` • ${tag}` : '';
+            const serverSuffix = tag ? ` • ${tag.replace(/^<a?:([^:]+):\d+>$/, '$1')}` : '';
             return `${posLabel} ${displayName} • **${player.score || this.rankingService.formatScore(player.scoreValue)}**\n*(${shortDate})* • ${player.bossName || msgs.unknownBoss}${serverSuffix}`;
         };
 
@@ -422,7 +422,7 @@ class GlobalTop10Service {
             const tag = guildTagMap.get(player.sourceGuildId);
             const date = new Date(player.timestamp);
             const shortDate = `${date.getDate().toString().padStart(2, '0')}.${(date.getMonth() + 1).toString().padStart(2, '0')}`;
-            const serverSuffix = tag ? ` • ${tag}` : '';
+            const serverSuffix = tag ? ` • ${tag.replace(/^<a?:([^:]+):\d+>$/, '$1')}` : '';
             return `${posLabel} ${displayName} • **${player.score || this.rankingService.formatScore(player.scoreValue)}**\n*(${shortDate})* • ${bossName}${serverSuffix}`;
         };
 

--- a/EndersEcho/services/logService.js
+++ b/EndersEcho/services/logService.js
@@ -165,7 +165,7 @@ class LogService {
                 .setTitle(`${cfg.emoji} ${cfg.label}`)
                 .setTimestamp();
 
-            const authorName = guildTag ? `${guildTag}  ${guildName}` : guildName;
+            const authorName = guildTag ? `${guildTag.replace(/^<a?:([^:]+):\d+>$/, '$1')}  ${guildName}` : guildName;
             embed.setAuthor({ name: authorName, iconURL: guildIcon || undefined });
             const thumbnailUrl = userAvatar || guildIcon;
             if (thumbnailUrl) embed.setThumbnail(thumbnailUrl);

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -180,7 +180,7 @@ class RankingService {
             const posLabel = rank <= 3
                 ? `\`${String(rank).padStart(2, '0')}\` ${MEDALS[rank - 1]}`
                 : `\`${String(rank).padStart(2, '0')}\``;
-            const tagPart = gs.tag ? `  ·  ${gs.tag}` : '';
+            const tagPart = gs.tag ? `  ·  ${gs.tag.replace(/^<a?:([^:]+):\d+>$/, '$1')}` : '';
             const isCaller = callerGuildId && gs.guildId === callerGuildId;
             const nameFormatted = isCaller ? `__**${gs.guildName}**__` : `**${gs.guildName}**`;
             rankingText += `${posLabel}  ${nameFormatted}  ·  **${gs.totalScore}**\n> ${gs.playerCount} ${playersLabel}  ·  ${bestLabel}: ${gs.topScore}${tagPart}\n\n`;
@@ -404,7 +404,7 @@ class RankingService {
                 let tagSuffix = '';
                 if (isGlobal) {
                     const guildTag = this.config.getAllGuilds().find(g => g.id === player.sourceGuildId)?.tag;
-                    tagSuffix = guildTag ? `  ·  ${guildTag}` : '';
+                    tagSuffix = guildTag ? `  ·  ${guildTag.replace(/^<a?:([^:]+):\d+>$/, '$1')}` : '';
                 }
 
                 const lineText = `${posLabel}  ${nickDisplay}  ·  **${player.score || this.formatScore(player.scoreValue)}**\n> ${bossName}  ·  *${shortDate}*${tagSuffix}\n\n`;
@@ -716,7 +716,7 @@ class RankingService {
             const guildTag = p.sourceGuildId
                 ? (this.config.getAllGuilds().find(g => g.id === p.sourceGuildId)?.tag || null)
                 : null;
-            const tagSuffix = guildTag ? `  ·  ${guildTag}` : '';
+            const tagSuffix = guildTag ? `  ·  ${guildTag.replace(/^<a?:([^:]+):\d+>$/, '$1')}` : '';
 
             rankingText += `${posLabel}  ${nickDisplay}  ·  **${score}**\n> *${shortDate}*${tagSuffix}\n\n`;
         }


### PR DESCRIPTION
## Zmiana

Gdy tag serwera jest w formacie `<:NAZWA:123456789>` (custom Discord emoji), w miejscach gdzie emoji nie może się wyrenderować jako ikona, wyświetlany jest teraz tylko tekst między dwukropkami (np. `NAZWA`).

## Zmienione pliki (9 miejsc)

| Plik | Miejsce |
|------|---------|
| `services/rankingService.js` | Ranking serwerów globalny (tagPart) |
| `services/rankingService.js` | Ranking globalny graczy (tagSuffix) |
| `services/rankingService.js` | Ranking per-boss (tagSuffix) |
| `services/logService.js` | Embed OCR analizy (authorName w setAuthor) |
| `services/globalTop10Service.js` | Snippet TOP10 w embedzie rekordu (tagSuffix) |
| `services/globalTop10Service.js` | Raport cykliczny TOP10 — buildSnippetFieldData (serverSuffix) |
| `services/globalTop10Service.js` | Raport cykliczny TOP10 — buildOnDemandEmbed (serverSuffix) |
| `handlers/interactionHandlers.js` | Embed Community Verification (cvAuthorName) |
| `handlers/interactionHandlers.js` | Embed raportu odrzuconego screena (authorName) |

## Mechanizm

Regex inline `.replace(/^<a?:([^:]+):\d+>$/, '$1')` — obsługuje zarówno statyczne (`<:NAME:ID>`) jak i animowane (`<a:NAME:ID>`) emoji. Jeśli tag nie pasuje do formatu (zwykły tekst lub unicode emoji), string wraca niezmieniony.

---
_Generated by [Claude Code](https://claude.ai/code/session_017TTF5AMzHxqjjcTgPEBzKd)_