### PR TITLE
Fix: Naprawiono parsowanie rivals - brak kolumny Members na garrytools

### DIFF
--- a/Gary/handlers/interactionHandlers.js
+++ b/Gary/handlers/interactionHandlers.js
@@ -2531,13 +2531,14 @@ class InteractionHandler {
 
             // Helper function to format rival data with conditional emojis
             const formatRivalField = (rival) => {
-                // Parse member count (e.g., "40/40" -> 40)
-                const memberCount = parseInt(rival.members.split('/')[0]);
                 let membersEmoji = '';
-                if (memberCount >= 1 && memberCount <= 29) {
-                    membersEmoji = ' <a:PepeBro:1341084788634681384>';
-                } else if (memberCount >= 30 && memberCount <= 36) {
-                    membersEmoji = ' <a:PepeEvil:1280067725355384905>';
+                if (rival.members) {
+                    const memberCount = parseInt(rival.members.split('/')[0]);
+                    if (memberCount >= 1 && memberCount <= 29) {
+                        membersEmoji = ' <a:PepeBro:1341084788634681384>';
+                    } else if (memberCount >= 30 && memberCount <= 36) {
+                        membersEmoji = ' <a:PepeEvil:1280067725355384905>';
+                    }
                 }
 
                 // Parse rival score and compare with user's score
@@ -2557,8 +2558,10 @@ class InteractionHandler {
                 if (rival.totalRelicCores !== undefined) {
                     result += `<:II_RC:1385139885924421653><:II_TransmuteCore:1458440558602092647> **RC+TC:** ${rival.totalRelicCores}+\n`;
                 }
-                result += `👥 **Members:** ${rival.members}${membersEmoji}\n` +
-                         `👤 **Leader:** ${rival.leader}\n` +
+                if (rival.members) {
+                    result += `👥 **Members:** ${rival.members}${membersEmoji}\n`;
+                }
+                result += `👤 **Leader:** ${rival.leader}\n` +
                          `⭐ **Grade:** ${rival.grade} (${rival.score})${scoreEmoji}`;
 
                 return result;

--- a/Gary/services/garrytoolsService.js
+++ b/Gary/services/garrytoolsService.js
@@ -662,19 +662,21 @@ class GarrytoolsService {
 
         tbody.find('tr').each((index, row) => {
             const cells = $(row).find('td');
-            if (cells.length < 7) return;
+            if (cells.length < 6) return;
 
             const isUserGuild = $(row).hasClass('text-success') ||
                               $(cells[0]).hasClass('text-success');
 
+            // Site removed "Members" column (was cells[3]), now: Rank, Guild ID, Name, Leader, Grade, Score
+            const hasMembersCol = cells.length >= 7;
             const rival = {
                 rank: $(cells[0]).text().trim(),
                 guildId: $(cells[1]).text().trim(),
                 name: $(cells[2]).text().trim(),
-                members: $(cells[3]).text().trim(),
-                leader: $(cells[4]).text().trim(),
-                grade: $(cells[5]).text().trim(),
-                score: $(cells[6]).text().trim(),
+                members: hasMembersCol ? $(cells[3]).text().trim() : null,
+                leader: $(cells[hasMembersCol ? 4 : 3]).text().trim(),
+                grade: $(cells[hasMembersCol ? 5 : 4]).text().trim(),
+                score: $(cells[hasMembersCol ? 6 : 5]).text().trim(),
                 isUserGuild: isUserGuild
             };
 


### PR DESCRIPTION
## Problem

Komenda `/rivals` zwracała 0 klanów mimo że strona garrytools.com/lunar/rivals zwracała poprawne tabele.

## Przyczyna

Strona garrytools usunęła kolumnę **Members** z tabel rivals. Tabela ma teraz 6 kolumn zamiast 7:

| Stara struktura | Nowa struktura |
|---|---|
| Rank, Guild ID, Name, **Members**, Leader, Grade, Score | Rank, Guild ID, Name, Leader, Grade, Score |

Kod w `parseRivalsTable` odrzucał każdy wiersz warunkiem `cells.length < 7` — żaden wiersz nie przechodził tej weryfikacji.

## Naprawione zmiany

### `Gary/services/garrytoolsService.js`
- Zmieniono minimum komórek z 7 na 6
- Kod obsługuje obie wersje tabeli (6 lub 7 kolumn) — jeśli jest 7 kolumn, `members` jest odczytywany ze starym indeksem; jeśli 6, `members = null` a pozostałe kolumny przesunięte

### `Gary/handlers/interactionHandlers.js`
- `formatRivalField` sprawdza `rival.members` przed wywołaniem `.split('/')` — brak crash gdy pole jest `null`
- Linia `👥 Members` jest wyświetlana tylko gdy dane są dostępne

---
_Generated by [Claude Code](https://claude.ai/code/session_01R8y5rp8k9c1GEUVduT8DUB)_