### PR TITLE
EndersEcho: Dodano osiągnięcia dla jednostki Sp

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -142,8 +142,8 @@
    - Limit: max 25 subskrypcji wyświetlanych naraz w select menu (Discord API limit)
 
 7. **System Osiągnięć** — `achievementService.js` + `config/achievements.js`:
-   - **77 stałych osiągnięć** w 5 kategoriach + 1 dynamiczny status (`status_top1` — rewokowany gdy wynik usunięty)
-   - **Kategorie:** 🏆 Wyniki (8) · 🔁 Rekordy (8) · 🎯 Bossowie (6) · 🕵️ Eksplorator/ukryte (43) · 💎 Prestiż (13)
+   - **78 stałych osiągnięć** w 5 kategoriach + 1 dynamiczny status (`status_top1` — rewokowany gdy wynik usunięty)
+   - **Kategorie:** 🏆 Wyniki (9) · 🔁 Rekordy (8) · 🎯 Bossowie (6) · 🕵️ Eksplorator/ukryte (43) · 💎 Prestiż (13)
    - **Rarities:** ⬜ Common · 🟩 Uncommon · 🟦 Rare · 🟪 Epic · 🟧 Legendary · 🔴 Mythic
    - **Odblokowanie:** osiągnięcia score/records/bosses/prestige blokowane przy każdym nowym rekordzie; ukryte (explorer) blokowane natychmiast przy przegladzie rankingu lub subskrypcji
    - **Kasowanie częściowe:** `clearUserAchievements(guildId, userId)` — usuwa WSZYSTKIE osiągnięcia kategorii `score` i `records` oraz resetuje `recordCount`/`lastRecordAt`/`lastRecordBeatAt`; pozostałe kategorie (bosses, explorer, prestige) zostają; wywoływane przy usunięciu gracza z rankingu (panel admina + komenda `/remove` — usunięcie całego gracza)

--- a/EndersEcho/config/achievements.js
+++ b/EndersEcho/config/achievements.js
@@ -64,16 +64,16 @@ const ACHIEVEMENTS = [
         check: (_p, ctx) => (ctx.scoreValue || 0) >= 1e23,
     },
     {
-        id: 'score_1sp', category: 'score', rarity: 'mythic', hidden: false, icon: '🌀',
-        namePol: 'Poza Granicami',   nameEng: 'Beyond Limits',
-        descPol: 'Osiągnij wynik 1Sp', descEng: 'Reach a score of 1Sp',
-        check: (_p, ctx) => (ctx.scoreValue || 0) >= 1e24,
-    },
-    {
-        id: 'score_100xx', category: 'score', rarity: 'mythic', hidden: false, icon: '💫',
+        id: 'score_100sp', category: 'score', rarity: 'mythic', hidden: false, icon: '💫',
         namePol: 'Władca Septylionów',   nameEng: 'Lord of Septillions',
         descPol: 'Osiągnij wynik 100Sp', descEng: 'Reach a score of 100Sp',
         check: (_p, ctx) => (ctx.scoreValue || 0) >= 1e26,
+    },
+    {
+        id: 'score_100xx', category: 'score', rarity: 'mythic', hidden: false, icon: '🌀',
+        namePol: 'Poza Granicami',   nameEng: 'Beyond Limits',
+        descPol: 'Osiągnij wynik w nieznanej jednostce', descEng: 'Reach a score in an unknown unit',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 1e29,
     },
 
     // ===== REKORDY (RECORDS) =====

--- a/EndersEcho/config/achievements.js
+++ b/EndersEcho/config/achievements.js
@@ -64,9 +64,15 @@ const ACHIEVEMENTS = [
         check: (_p, ctx) => (ctx.scoreValue || 0) >= 1e23,
     },
     {
-        id: 'score_100xx', category: 'score', rarity: 'mythic', hidden: false, icon: '🌀',
+        id: 'score_1sp', category: 'score', rarity: 'mythic', hidden: false, icon: '🌀',
         namePol: 'Poza Granicami',   nameEng: 'Beyond Limits',
-        descPol: 'Osiągnij wynik w nieznanej jednostce', descEng: 'Reach a score in an unknown unit',
+        descPol: 'Osiągnij wynik 1Sp', descEng: 'Reach a score of 1Sp',
+        check: (_p, ctx) => (ctx.scoreValue || 0) >= 1e24,
+    },
+    {
+        id: 'score_100xx', category: 'score', rarity: 'mythic', hidden: false, icon: '💫',
+        namePol: 'Władca Septylionów',   nameEng: 'Lord of Septillions',
+        descPol: 'Osiągnij wynik 100Sp', descEng: 'Reach a score of 100Sp',
         check: (_p, ctx) => (ctx.scoreValue || 0) >= 1e26,
     },
 


### PR DESCRIPTION
## Zmiany

- Dodano nowe osiągnięcie `score_1sp` 🌀 **Poza Granicami** — próg 1Sp (10²⁴), rarity: mythic
- Zaktualizowano istniejące `score_100xx` → 💫 **Władca Septylionów** — próg 100Sp (10²⁶), poprawiona nazwa i opis (wcześniej błędnie opisane jako "nieznana jednostka")
- Zaktualizowano dokumentację `EndersEcho/CLAUDE.md` (78 osiągnięć, kategoria Wyniki: 9)

---
_Generated by [Claude Code](https://claude.ai/code/session_011vbo89wpjksJ4okqvDwBs6)_