### PR TITLE
Brak punktów za odgadnięcie hasła domyślnego Konklawe

### DIFF
--- a/Konklawe/CLAUDE.md
+++ b/Konklawe/CLAUDE.md
@@ -1,7 +1,7 @@
 ### ⛪ Konklawe Bot
 
 **8 Systemów:**
-1. **Gra Hasłowa** - `gameService.js`: Hasło "Konklawe" (admin może zmienić), poprawna→rola papieska
+1. **Gra Hasłowa** - `gameService.js`: Hasło "Konklawe" (admin może zmienić), poprawna→rola papieska. Za odgadnięcie hasła domyślnego "Konklawe" NIE przyznawane są punkty (tylko rola papieska) - dotyczy każdego użycia, nie tylko pierwszego
 2. **Osiągnięcia** - Medal Virtutti Papajlari: 30+ odpowiedzi, reset rankingu, specjalne uprawnienia
 3. **Timery** - `timerService.js`: 15/30/60min przypomnienia, auto-reset, persistent (`game_state.json`), restore po restarcie
 4. **AI Wspomaganie** - `aiService.js`: Generowanie haseł i podpowiedzi przez Anthropic lub Grok API

--- a/Konklawe/handlers/messageHandlers.js
+++ b/Konklawe/handlers/messageHandlers.js
@@ -315,8 +315,8 @@ class MessageHandler {
         this.gameService.resetHints();
         this.gameService.clearAttempts();
 
-        // Obsługa specjalnego przypadku słowa "konklawe"
-        if (currentTrigger.toLowerCase() === this.config.messages.defaultPassword.toLowerCase() && !this.gameService.konklaweUsed) {
+        // Obsługa specjalnego przypadku słowa "konklawe" - za hasło domyślne NIE przyznajemy punktów
+        if (currentTrigger.toLowerCase() === this.config.messages.defaultPassword.toLowerCase()) {
             this.gameService.konklaweUsed = true;
             await this.timerService.setAutoResetTimer();
             await this.timerService.setReminderTimer(message.author.id);


### PR DESCRIPTION
## Problem

W bocie Konklawe za odgadnięcie hasła domyślnego "konklawe" w niektórych przypadkach przyznawane były punkty.

## Przyczyna

W `Konklawe/handlers/messageHandlers.js` warunek pomijający przyznanie punktów dla hasła domyślnego zawierał dodatkowy człon `&& !this.gameService.konklaweUsed`. Flaga `konklaweUsed` była ustawiana na `true` przy pierwszym użyciu i nigdy nie wracała do `false`. W efekcie:

- **Pierwsze** odgadnięcie "konklawe" → brak punktów (poprawnie)
- **Każde kolejne** (po auto-resecie na hasło domyślne) → flaga już `true`, więc kod przechodził dalej do `addPoints()` i **przyznawał punkt**

## Rozwiązanie

Usunięto warunek `&& !this.gameService.konklaweUsed`, dzięki czemu odgadnięcie hasła domyślnego "Konklawe" **nigdy** nie przyznaje punktów — przyznawana jest tylko rola papieska. Zaktualizowano też dokumentację `Konklawe/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013xxawhkaJvtU5wGNA7HsPz)_