### PR TITLE
Fix: kolizja custom_id w paginacji rankingu corów

### DIFF
--- a/Stalker/handlers/interactionHandlers.js
+++ b/Stalker/handlers/interactionHandlers.js
@@ -2087,7 +2087,7 @@ async function handleButton(interaction, sharedState) {
         await handleProgresNavButton(interaction, sharedState);
     } else if (interaction.customId.startsWith('clan_status_prev|') || interaction.customId.startsWith('clan_status_next|')) {
         await handleClanStatusPageButton(interaction, sharedState);
-    } else if (interaction.customId.startsWith('core_ranking|')) {
+    } else if (interaction.customId.startsWith('core_ranking|') || interaction.customId.startsWith('core_ranking_nav|')) {
         await handleCoreRankingButton(interaction, sharedState);
     } else if (interaction.customId.startsWith('confirm_reminder_')) {
         await handleConfirmReminderButton(interaction, sharedState);
@@ -12383,7 +12383,7 @@ async function handleCoreRankingButton(interaction, sharedState) {
         // Wiersz 1: paginacja
         const rowPagination = new ARB().addComponents(
             new BB()
-                .setCustomId(`core_ranking|${coreName}|${safePage - 1}`)
+                .setCustomId(`core_ranking_nav|${coreName}|${safePage - 1}`)
                 .setLabel('◄')
                 .setStyle(BS.Secondary)
                 .setDisabled(safePage === 0),
@@ -12393,7 +12393,7 @@ async function handleCoreRankingButton(interaction, sharedState) {
                 .setStyle(BS.Secondary)
                 .setDisabled(true),
             new BB()
-                .setCustomId(`core_ranking|${coreName}|${safePage + 1}`)
+                .setCustomId(`core_ranking_nav|${coreName}|${safePage + 1}`)
                 .setLabel('►')
                 .setStyle(BS.Secondary)
                 .setDisabled(safePage === totalPages - 1)


### PR DESCRIPTION
## Problem

`COMPONENT_CUSTOM_ID_DUPLICATED components[1].components[1].custom_id` — błąd produkcyjny przy nawigacji paginacji w rankingu corów.

**Przyczyna:** Przyciski ◄/► używały formatu `core_ranking|${coreName}|${page}`, identycznego jak przyciski wyboru corów (`core_ranking|${name}|0`). Przy przejściu na stronę 1, przycisk ◄ generował `core_ranking|Xeno Pet Core|0` — duplikat przycisku "Xeno Pet Core".

## Naprawka

Zmieniono prefix przycisków nawigacyjnych z `core_ranking|` na `core_ranking_nav|`:
- ◄: `core_ranking_nav|${coreName}|${safePage - 1}`  
- ►: `core_ranking_nav|${coreName}|${safePage + 1}`

Zaktualizowano dispatch (linia 2090), żeby obsługiwał oba prefiksy i kierował do tego samego handlera `handleCoreRankingButton` (który parsuje z `split('|')` — działa dla obu formatów).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLbuTwt9WCA4EREiwk4QKY)_