### PR TITLE
Konklawe: cenzura Fortnite - klątwa admina na 1h

### DIFF
--- a/Konklawe/CLAUDE.md
+++ b/Konklawe/CLAUDE.md
@@ -31,7 +31,8 @@
 7. **Virtue Check** - 10 cnót + porady (0 many)
 8. **Losowe Odpowiedzi** - Użytkownicy papiescy: 1/100 szansa, emoji JP2roll
 10. **Chaos Bomby** - `bombChaosService.js`: Komenda `/bomba` (admin) aktywuje 1h chaos — każda wiadomość ma 30% szansę na ghost ping `💥 @user 💥` (usuwany po 2s). Persystencja w `shared_data/bomb_chaos_state.json`. Pomija użytkowników z rolą gracza (`EXEMPT_ROLE_ID`).
-9. **Herezja Full HP** - `messageHandlers.js`: Automatyczna cicha losowa klątwa za napisanie "Full HP najlepsze" (lub wariantów z leet speak, separatorami, próbami obejścia cenzury). Wykrywa: małe/wielkie litery, leet speak (0→o, 1→i, 3→e, 4→a...), separatory (spacje, kropki, myślniki między literami). Klątwa nakładana bez żadnego publicznego powiadomienia.
+9. **Herezja Full HP** - `messageHandlers.js`: Automatyczna cicha losowa klątwa (5min) za napisanie "Full HP najlepsze" (lub wariantów z leet speak, separatorami, próbami obejścia cenzury). Wykrywa: małe/wielkie litery, leet speak (0→o, 1→i, 3→e, 4→a...), separatory (spacje, kropki, myślniki między literami). Klątwa nakładana bez żadnego publicznego powiadomienia.
+11. **Cenzura Fortnite** - `messageHandlers.js`: Automatyczna cicha klątwa admina na **1 godzinę** za napisanie "fortnite" (lub zaawansowanych prób obejścia). Algorytm wykrywania: leet speak (0→o, 1→i, 3→e, 7→t...), homoglify unicode, separatory (f.o.r.t.n.i.t.e), podwojone litery (forrtniite→fortnite), podział "fort nite", fonetyczne zamienniki (ph→f, y→i, kn→n, fortnight). Wywołuje `applyRandomCurseToUser` z czasem 60min. Brak publicznego powiadomienia.
 
 **Komendy:** `/podpowiedz`, `/podpowiedzi`, `/statystyki`, `/blessing`, `/curse`, `/revenge`, `/virtue-check`, `/bomba` (admin)
 **Env:** TOKEN, CLIENT_ID, GUILD_ID, KONKLAWE_AI_PROVIDER (opcjonalne), KONKLAWE_ANTHROPIC_API_KEY (opcjonalne), KONKLAWE_AI_MODEL (opcjonalne), KONKLAWE_GROK_MODEL (opcjonalne), XAI_API_KEY (opcjonalne)

--- a/Konklawe/handlers/interactionHandlers.js
+++ b/Konklawe/handlers/interactionHandlers.js
@@ -3359,7 +3359,7 @@ class InteractionHandler {
      * @param {GuildMember} targetMember - Cel klątwy
      * @param {string} source - Źródło klątwy (dla logów)
      */
-    async applyRandomCurseToUser(targetMember, source = 'Unknown') {
+    async applyRandomCurseToUser(targetMember, source = 'Unknown', duration = 5 * 60 * 1000) {
         const userId = targetMember.id;
         const guild = targetMember.guild;
 
@@ -3392,9 +3392,10 @@ class InteractionHandler {
             selectedCurse = curses[Math.floor(Math.random() * curses.length)];
         }
 
-        // Nałóż klątwę (5 minut)
-        await this.applyCurse(targetMember, selectedCurse, guild);
-        logger.info(`🔥 ${source}: Nałożono losową klątwę "${selectedCurse}" na ${targetMember.user.tag}`);
+        // Nałóż klątwę z zadanym czasem trwania
+        const endTime = Date.now() + duration;
+        await this.applyCurse(targetMember, selectedCurse, guild, endTime);
+        logger.info(`🔥 ${source}: Nałożono losową klątwę "${selectedCurse}" na ${targetMember.user.tag} (${Math.round(duration / 60000)}min)`);
     }
 
     async applyCurse(targetMember, curseType, guild, customEndTime = null) {

--- a/Konklawe/handlers/messageHandlers.js
+++ b/Konklawe/handlers/messageHandlers.js
@@ -15,6 +15,68 @@ class MessageHandler {
     }
 
     /**
+     * Wykrywa słowo "fortnite" i zaawansowane próby ominięcia cenzury.
+     * Obsługuje: leet speak, separatory, podwojone litery, homoglify unicode,
+     * podział na "fort nite", fonetyczne zamienniki (ph→f, y→i, kn→n).
+     * @param {string} text - Treść wiadomości
+     * @returns {boolean} true jeśli wykryto "fortnite"
+     */
+    detectFortnite(text) {
+        // Krok 1: małe litery
+        let normalized = text.toLowerCase();
+
+        // Krok 2: homoglify unicode (litery wyglądające jak łacińskie)
+        normalized = normalized
+            .replace(/[ꜰᶠℱ𝐟𝑓𝒻𝓯𝔣𝕗𝖋𝗳𝘧𝙛]/g, 'f')
+            .replace(/[ºοοо𝐨𝑜𝒐𝓸𝔬𝕠𝖔𝗼𝘰𝙤ₒ]/g, 'o')
+            .replace(/[ʀʁ𝐫𝑟𝓻𝔯𝕣𝖗𝗿𝘳𝙧]/g, 'r')
+            .replace(/[ᴛ𝐭𝑡𝓽𝔱𝕥𝖙𝗍𝘵𝙩]/g, 't')
+            .replace(/[ɴ𝐧𝑛𝓷𝔫𝕟𝖓𝗻𝘯𝙣]/g, 'n')
+            .replace(/[ɪ𝐢𝑖𝓲𝔦𝕚𝖎𝗶𝘪𝙞]/g, 'i')
+            .replace(/[ᴇ𝐞𝑒𝓮𝔢𝕖𝖊𝗲𝘦𝙚]/g, 'e');
+
+        // Krok 3: leet speak
+        normalized = normalized
+            .replace(/0/g, 'o')
+            .replace(/1/g, 'i')
+            .replace(/3/g, 'e')
+            .replace(/4/g, 'a')
+            .replace(/5/g, 's')
+            .replace(/7/g, 't')
+            .replace(/\$/g, 's')
+            .replace(/@/g, 'a')
+            .replace(/\|/g, 'i');
+
+        // Krok 4: fonetyczne zamienniki (ph→f, y→i przy "nyte", kn→n)
+        normalized = normalized
+            .replace(/ph/g, 'f')
+            .replace(/kn/g, 'n');
+
+        // Krok 5: usuń separatory
+        const noSep = normalized.replace(/[\s.\-_*|,!?'"`~^+=&#%@/\\]/g, '');
+
+        // Krok 6: usuń podwojone litery (forrtniite → fortnite)
+        const deduplicated = noSep.replace(/(.)\1+/g, '$1');
+
+        // Sprawdzenia po usunięciu separatorów (fortnite, f0rtn1t3, f.o.r.t.n.i.t.e itp.)
+        if (noSep.includes('fortnite')) return true;
+        if (deduplicated.includes('fortnite')) return true;
+
+        // Wariant "fort nite" (spacja w środku słowa)
+        const spacedNorm = normalized.replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
+        if (spacedNorm.includes('fort nite')) return true;
+
+        // Fonetyczny wariant "fortnight" → po usunięciu 'gh' zostaje fortnit
+        if (noSep.replace(/gh/g, '').includes('fortnit')) return true;
+
+        // Wariant z "y" jako "i": "fortnyte" → zamień y→i
+        const yToI = noSep.replace(/y/g, 'i');
+        if (yToI.includes('fortnite')) return true;
+
+        return false;
+    }
+
+    /**
      * Wykrywa herezję "Full HP najlepsze" i próby obejścia cenzury
      * @param {string} text - Treść wiadomości
      * @returns {boolean} true jeśli wykryto herezję
@@ -73,6 +135,16 @@ class MessageHandler {
                     logger.info(`🔱 Herezja Full HP wykryta od ${message.author.tag} - nałożono cichą klątwę`);
                 } catch (error) {
                     logger.error(`❌ Błąd nakładania klątwy za herezję Full HP: ${error.message}`);
+                }
+            }
+
+            // === FORTNITE - Cicha klątwa admina na 1h za napisanie "fortnite" (lub obejścia cenzury) ===
+            if (interactionHandler && message.member && this.detectFortnite(message.content)) {
+                try {
+                    await interactionHandler.applyRandomCurseToUser(message.member, 'FortniteCensor', 60 * 60 * 1000);
+                    logger.info(`🎮 Fortnite wykryto od ${message.author.tag} - nałożono cichą klątwę admina na 1h`);
+                } catch (error) {
+                    logger.error(`❌ Błąd nakładania klątwy za Fortnite: ${error.message}`);
                 }
             }
 


### PR DESCRIPTION
## Podsumowanie

- Dodano wykrywanie słowa "fortnite" z zaawansowaną ochroną przed próbami ominięcia cenzury
- Za napisanie "fortnite" bot nakłada cichą losową klątwę admina trwającą **1 godzinę** (bez publicznego powiadomienia)
- Rozszerzono `applyRandomCurseToUser` o parametr `duration` (wcześniej zawsze było 5 minut)

## Algorytm wykrywania (`detectFortnite`)

Kolejne warstwy normalizacji przed sprawdzeniem:
1. **Homoglify unicode** – litery wyglądające jak łacińskie (ℱ→f, ο→o itd.)
2. **Leet speak** – 0→o, 1→i, 3→e, 4→a, 5→s, 7→t, $→s, @→a, |→i
3. **Fonetyczne** – ph→f, kn→n
4. **Separatory** – usunięcie spacji, kropek, myślników, podkreśleń itp. (wykrywa `f.o.r.t.n.i.t.e`)
5. **Podwojone litery** – `forrtniite` → `fortnite`
6. **Podział "fort nite"** – spacja w środku słowa
7. **Fortnight** – usunięcie `gh` → `fortnit`
8. **y→i** – "fortnyte" → "fortnite"

## Plan testów

- [ ] `fortnite` – podstawowe
- [ ] `FORTNITE`, `FoRtNiTe` – wielkość liter
- [ ] `f0rtn1t3` – leet speak
- [ ] `f.o.r.t.n.i.t.e` – separatory
- [ ] `fort nite` – podział
- [ ] `forrtniite` – podwojone litery
- [ ] `fortnyte` – y→i
- [ ] `phortnight` – fonetyczny

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01X1EZ6j2RWyWZBzPmeGe2G9)_