### PR TITLE
Konklawe: wykluczenie kanału z cenzury Fortnite

### DIFF
--- a/Konklawe/config/config.js
+++ b/Konklawe/config/config.js
@@ -12,7 +12,10 @@ module.exports = {
         command: "1377633547028005027",
         attempts: "1377633547028005027",
         reminder: "1377633547028005027",
-        judgment: process.env.KONKLAWE_JUDGMENT_CHANNEL_ID
+        judgment: process.env.KONKLAWE_JUDGMENT_CHANNEL_ID,
+        fortniteCensorExcluded: [
+            "11519739015660568637"
+        ]
     },
     roles: {
         papal: "1298897770844786699",

--- a/Konklawe/handlers/messageHandlers.js
+++ b/Konklawe/handlers/messageHandlers.js
@@ -139,7 +139,8 @@ class MessageHandler {
             }
 
             // === FORTNITE - Cicha klątwa admina na 1h za napisanie "fortnite" (lub obejścia cenzury) ===
-            if (interactionHandler && message.member && this.detectFortnite(message.content)) {
+            const fortniteCensorExcluded = this.config.channels.fortniteCensorExcluded || [];
+            if (interactionHandler && message.member && !fortniteCensorExcluded.includes(message.channel.id) && this.detectFortnite(message.content)) {
                 try {
                     await interactionHandler.applyRandomCurseToUser(message.member, 'FortniteCensor', 60 * 60 * 1000);
                     logger.info(`🎮 Fortnite wykryto od ${message.author.tag} - nałożono cichą klątwę admina na 1h`);


### PR DESCRIPTION
## Podsumowanie

- Kanał `11519739015660568637` wyłączony ze sprawdzania cenzury Fortnite
- Lista wykluczonych kanałów (`fortniteCensorExcluded`) dodana do `config.js` — łatwe rozszerzanie w przyszłości

## Zmienione pliki

- `Konklawe/config/config.js` — nowa lista `fortniteCensorExcluded`
- `Konklawe/handlers/messageHandlers.js` — warunek pomijający wykluczone kanały

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01X1EZ6j2RWyWZBzPmeGe2G9)_