### PR TITLE
EndersEcho: 10 retry w /update — 3s delay + informowanie o przeciążeniu API

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -56,8 +56,8 @@
      - **Walidacja score vs Total:** Jeśli odczytany Best > Total → automatyczna korekta
      - Zalety: 100% pewność walidacji, fallback na tradycyjny OCR
    - **Komenda /update (wszyscy, wymaga AI OCR):** Używa `analyzeTestImage()` — weryfikacja wzorcem + ekstrakcja:
-     - **KROK 1:** Porównanie z wzorcem `files/Wzór.jpg` — jeden request z dwoma obrazami (10 tokenów)
-     - **KROK 2:** Ekstrakcja danych (boss + score) — bez sprawdzania Victory i autentyczności (500 tokenów)
+     - **KROK 1:** Porównanie z wzorcem `files/Wzór.jpg` — jeden request z dwoma obrazami (10 tokenów) — **10 retry** przy błędzie API (429/500/503), delay cappowany na 10s
+     - **KROK 2:** Ekstrakcja danych (boss + score) — bez sprawdzania Victory i autentyczności (500 tokenów) — **10 retry** przy błędzie API, delay cappowany na 10s
      - Gdy screen niepodobny do wzorca → embed `testNotSimilarTitle/Description` (brak zapisu)
      - Po udanej weryfikacji: pełny flow — zapis do rankingu, aktualizacja ról TOP, snippet globalnego rankingu (gdy pozycja globalna się zmieniła), powiadomienia DM
      - Wymaga `USE_ENDERSECHO_AI_OCR=true`; gdy AI wyłączone → ephemeral `testAiOcrRequired`

--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -41,7 +41,9 @@ const pol = {
     // /update — przetwarzanie (postęp krok po kroku)
     updateDownloading: '📥 Pobieranie obrazu...',
     updateComparingTemplate: '🔍 Analiza zgodności obrazu ze wzorcem...',
+    updateRetryTemplate: '⏳ API przeciążone — ponawiam sprawdzanie wzorca (próba {attempt}/{total})...',
     updateExtractingData: '✅ Analiza OK — odczytuję dane rekordu...',
+    updateRetryExtract: '⏳ API przeciążone — ponawiam odczytywanie danych (próba {attempt}/{total})...',
     updateSaving: '💾 Zapis danych...',
     updateNotImage: '❌ Załączony plik nie jest obrazem! Obsługiwane formaty: PNG, JPG, JPEG, GIF, BMP',
     updateFileTooLarge: '❌ Plik jest za duży! Maksymalny rozmiar: **{maxMB}MB**, twój plik: **{fileMB}MB**\n💡 **Tip:** Zmniejsz jakość obrazu lub użyj kompresji.',
@@ -412,7 +414,9 @@ const eng = {
     // /update — processing (step by step progress)
     updateDownloading: '📥 Downloading image...',
     updateComparingTemplate: '🔍 Checking image against template...',
+    updateRetryTemplate: '⏳ API overloaded — retrying template check (attempt {attempt}/{total})...',
     updateExtractingData: '✅ Match confirmed — reading record data...',
+    updateRetryExtract: '⏳ API overloaded — retrying data extraction (attempt {attempt}/{total})...',
     updateSaving: '💾 Saving data...',
     updateNotImage: '❌ The attached file is not an image! Supported formats: PNG, JPG, JPEG, GIF, BMP',
     updateFileTooLarge: '❌ File is too large! Maximum size: **{maxMB}MB**, your file: **{fileMB}MB**\n💡 **Tip:** Reduce image quality or use compression.',

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -3762,8 +3762,15 @@ class InteractionHandler {
                 }
             };
 
+            const onRetry = async (attempt, total, step) => {
+                const msgKey = step === 'extract' ? 'updateRetryExtract' : 'updateRetryTemplate';
+                const template = msgs[msgKey] || '⏳ API przeciążone — próba {attempt}/{total}...';
+                const text = template.replace('{attempt}', attempt + 1).replace('{total}', total);
+                await interaction.editReply({ content: text }).catch(() => {});
+            };
+
             const guildLang = this.config.getGuildConfig(interaction.guildId)?.lang || 'pol';
-            const aiResult = await this.aiOcrService.analyzeTestImage(tempImagePath, gl, null, guildLang, onProgress);
+            const aiResult = await this.aiOcrService.analyzeTestImage(tempImagePath, gl, null, guildLang, onProgress, onRetry);
 
             const fileExtension = attachment.name ? attachment.name.split('.').pop() : 'png';
 

--- a/EndersEcho/services/aiOcrService.js
+++ b/EndersEcho/services/aiOcrService.js
@@ -60,7 +60,7 @@ class AIOCRService {
      * Zachowuje poprzedni kształt odpowiedzi (text, promptTokens, outputTokens,
      * thoughtTokens) + dodaje pola telemetryczne (durationMs, traceId, provider).
      */
-    async _generateContent(parts, maxOutputTokens, meta = {}, retries = 3) {
+    async _generateContent(parts, maxOutputTokens, meta = {}, retries = 3, onRetry = null) {
         let lastError;
         for (let attempt = 0; attempt < retries; attempt++) {
             try {
@@ -88,15 +88,15 @@ class AIOCRService {
                 const status = err.status ?? err.statusCode ?? err.code;
                 const isRetryable = status === 429 || status === 503 || status === 500 || status === 'ECONNRESET' || status === 'ETIMEDOUT';
                 if (!isRetryable || attempt === retries - 1) throw err;
-                const delay = Math.min(1000 * Math.pow(2, attempt), 10000);
-                logger.warn(`[AI OCR] Gemini error ${status}, retry ${attempt + 1}/${retries - 1} za ${delay}ms`);
-                await new Promise(r => setTimeout(r, delay));
+                logger.warn(`[AI OCR] Gemini error ${status}, retry ${attempt + 1}/${retries - 1} za 3000ms`);
+                if (onRetry) await onRetry(attempt + 1, retries).catch(() => {});
+                await new Promise(r => setTimeout(r, 3000));
             }
         }
         throw lastError;
     }
 
-    async _extractData(base64Image, mediaType, telemetryMeta) {
+    async _extractData(base64Image, mediaType, telemetryMeta, onRetry = null) {
         const prompt = `To jest screen z wynikami z gry mobilnej. Odczytaj z niego trzy wartości:
 1. Nazwa bossa — widoczna jako nazwa postaci/przeciwnika na ekranie wyników
 2. Wynik Best — liczba z jednostką (np. 123.4M), oznaczona jako "Best" na ekranie
@@ -124,7 +124,7 @@ Odpowiedz WYŁĄCZNIE w tym formacie (3 linie, nic więcej):
             step: 'extract-data-eng',
             promptName: 'extract-data-eng',
             promptVersion: PROMPT_VERSIONS['extract-data-eng'],
-        }, 10);
+        }, 10, onRetry);
 
         return { text: res.text, promptTokens: res.promptTokens, outputTokens: res.outputTokens, thoughtTokens: res.thoughtTokens };
     }
@@ -291,7 +291,7 @@ Odpowiedz WYŁĄCZNIE w tym formacie (3 linie, nic więcej):
      * @param {object} [telemetryMeta] — { operationType, actorDiscordId, guildId, authorizationId }
      * @param {string} [lang]      — język serwera ('pol'|'eng'), wpływa na powód odrzucenia
      */
-    async analyzeTestImage(imagePath, log = logger, telemetryMeta = {}, lang = 'pol', onProgress = null) {
+    async analyzeTestImage(imagePath, log = logger, telemetryMeta = {}, lang = 'pol', onProgress = null, onRetry = null) {
         if (!this.enabled) throw new Error('AI OCR nie jest włączony');
 
         const tokenUsage = { promptTokens: 0, outputTokens: 0, thoughtTokens: 0 };
@@ -307,7 +307,8 @@ Odpowiedz WYŁĄCZNIE w tym formacie (3 linie, nic więcej):
             const wzorBase64 = wzorBuffer.toString('base64');
             const mediaType = 'image/png';
 
-            const { isSimilar, rejectionReason, usage: u1 } = await this._compareWithTemplate(wzorBase64, uploadedBase64, mediaType, log, telemetryMeta, lang);
+            const onRetryTemplate = onRetry ? (attempt, total) => onRetry(attempt, total, 'template') : null;
+            const { isSimilar, rejectionReason, usage: u1 } = await this._compareWithTemplate(wzorBase64, uploadedBase64, mediaType, log, telemetryMeta, lang, onRetryTemplate);
             tokenUsage.promptTokens  += u1.promptTokens;
             tokenUsage.outputTokens  += u1.outputTokens;
             tokenUsage.thoughtTokens += u1.thoughtTokens;
@@ -318,7 +319,8 @@ Odpowiedz WYŁĄCZNIE w tym formacie (3 linie, nic więcej):
 
             if (onProgress) await onProgress('extracting');
 
-            const extractRes = await this._extractData(uploadedBase64, mediaType, telemetryMeta);
+            const onRetryExtract = onRetry ? (attempt, total) => onRetry(attempt, total, 'extract') : null;
+            const extractRes = await this._extractData(uploadedBase64, mediaType, telemetryMeta, onRetryExtract);
             tokenUsage.promptTokens  += extractRes.promptTokens;
             tokenUsage.outputTokens  += extractRes.outputTokens;
             tokenUsage.thoughtTokens += extractRes.thoughtTokens;
@@ -333,7 +335,7 @@ Odpowiedz WYŁĄCZNIE w tym formacie (3 linie, nic więcej):
         }
     }
 
-    async _compareWithTemplate(wzorBase64, uploadedBase64, mediaType, log = logger, telemetryMeta, lang = 'pol') {
+    async _compareWithTemplate(wzorBase64, uploadedBase64, mediaType, log = logger, telemetryMeta, lang = 'pol', onRetry = null) {
         const isEng = lang === 'eng';
         const reasonLang = isEng ? 'English' : 'Polish';
         const exampleReasons = isEng
@@ -386,7 +388,7 @@ ${exampleReasons.join('\n')}
             step: 'compare-template',
             promptName: 'compare-template',
             promptVersion: PROMPT_VERSIONS['compare-template'],
-        }, 10);
+        }, 10, onRetry);
 
         const response = res.text.trim();
         const upper = response.toUpperCase();

--- a/EndersEcho/services/aiOcrService.js
+++ b/EndersEcho/services/aiOcrService.js
@@ -88,7 +88,7 @@ class AIOCRService {
                 const status = err.status ?? err.statusCode ?? err.code;
                 const isRetryable = status === 429 || status === 503 || status === 500 || status === 'ECONNRESET' || status === 'ETIMEDOUT';
                 if (!isRetryable || attempt === retries - 1) throw err;
-                const delay = 1000 * Math.pow(2, attempt);
+                const delay = Math.min(1000 * Math.pow(2, attempt), 10000);
                 logger.warn(`[AI OCR] Gemini error ${status}, retry ${attempt + 1}/${retries - 1} za ${delay}ms`);
                 await new Promise(r => setTimeout(r, delay));
             }
@@ -124,7 +124,7 @@ Odpowiedz WYŁĄCZNIE w tym formacie (3 linie, nic więcej):
             step: 'extract-data-eng',
             promptName: 'extract-data-eng',
             promptVersion: PROMPT_VERSIONS['extract-data-eng'],
-        });
+        }, 10);
 
         return { text: res.text, promptTokens: res.promptTokens, outputTokens: res.outputTokens, thoughtTokens: res.thoughtTokens };
     }
@@ -386,7 +386,7 @@ ${exampleReasons.join('\n')}
             step: 'compare-template',
             promptName: 'compare-template',
             promptVersion: PROMPT_VERSIONS['compare-template'],
-        });
+        }, 10);
 
         const response = res.text.trim();
         const upper = response.toUpperCase();


### PR DESCRIPTION
## Podsumowanie

Dwa commity na tym PR:

**1. 10 retry dla każdego zapytania API**
- `_compareWithTemplate` — 10 retry przy porównaniu zdjęcia ze wzorcem
- `_extractData` — 10 retry przy ekstrakcji boss/score
- Błędy retryowalne: `429`, `500`, `503`, `ECONNRESET`, `ETIMEDOUT`

**2. Stały delay 3s + informowanie użytkownika**
- Delay między retry zmieniony na stały **3 sekundy**
- Po pierwszej nieudanej próbie bot aktualizuje wiadomość ephemeral z numerem próby

Przykładowe komunikaty:
> ⏳ API przeciążone — ponawiam sprawdzanie wzorca (próba 2/10)...
> ⏳ API przeciążone — ponawiam odczytywanie danych (próba 3/10)...

Obie wersje językowe (PL/ENG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
