### PR TITLE
Likwidacja kolejki OCR w Stalkerze - równoległe sesje

### DIFF
--- a/Stalker/CLAUDE.md
+++ b/Stalker/CLAUDE.md
@@ -16,15 +16,15 @@
      - **Checklist etapu wysyłki (`/remind`, `/punish`):** po kliknięciu „Wyślij przypomnienia" / „Dodaj punkty karne" pokazywana jest checklista kolejnych etapów (`buildSendChecklist()` w `interactionHandlers.js`): remind → `👥 Deduplikacja → 🏖️ Sprawdzanie urlopów → 📨 Wysyłanie przypomnień → 📊 Tracking`; punish → `👥 Deduplikacja → 🏖️ Sprawdzanie urlopów → 💀 Nakładanie kar`. Aktywny krok ma 🔄, ukończone ✅. Na kroku urlopów checklist zatrzymuje się, gdy pojawia się pytanie o urlopowiczów, i wznawia po decyzjach (wspólna ścieżka `finalizeAfterVacationDecisions()`).
      - **Dostarczalność DM (`/remind`):** `sendReminders()` zwraca listy `dmDelivered`/`dmFailed` (per osoba). Embed wyniku pokazuje pola `✅ DM dostarczone (N)` oraz `❌ DM nie dotarło (M) — zablokowany bot lub wyłączone DM` (helper `buildDmResultFields()`). Uwaga: osoby z niedostarczonym DM i tak dostają ping na kanale WARNING — nie dociera tylko wiadomość prywatna.
      - Walidacja wyników: 0–999999 (obsługuje wyniki 5-cyfrowe i wyższe)
-     - **Retry dla błędów 503 (przeciążone API): 10× z exponential backoff** (1s/2s/4s/8s/16s/32s/5s…5s) — po 10 nieudanych próbach rzuca `isAPIOverloaded=true`, wyświetla embed z komunikatem o przeciążeniu i opuszcza kolejkę OCR (bez dalszego przetwarzania). Inne retryable błędy (429/500/sieciowe): 3× retry bez zmian.
+     - **Retry dla błędów 503 (przeciążone API): 10× z exponential backoff** (1s/2s/4s/8s/16s/32s/5s…5s) — po 10 nieudanych próbach rzuca `isAPIOverloaded=true`, wyświetla embed z komunikatem o przeciążeniu i kończy sesję OCR (bez dalszego przetwarzania). Inne retryable błędy (429/500/sieciowe): 3× retry bez zmian.
      - Weryfikacja wersji promptów przez `PROMPT_VERSIONS` (Langfuse telemetria)
      - Inicjalizacja przez `llmAdapter` (wspólny wrapper `utils/llmAdapter.js`) + DI z `index.js`
 2. **Punkty** - `punishmentService.js`: 2pts=kara, 3pts=ban loterii, cron czyszczenie (pn 00:00). `/points` z ujemną wartością: gdy `points` spada do 0 → `lifetime_points` też zerowane do 0 (czyste konto); przy częściowym usunięciu → `lifetime_points` zmniejszane o tę samą liczbę. Odpowiedź pokazuje nowe `points` i status `lifetime_points`.
 3. **Urlopy** - `vacationService.js`: Przycisk → rola 15min, cooldown 6h
-4. **Kolejkowanie OCR** - `queueService.js`: Jeden user/guild, progress bar, 15min timeout, przyciski komend. Anulowanie w trakcie przetwarzania: embed aktualizowany do stanu "❌ Sesja anulowana" z usuniętymi przyciskami po zakończeniu bieżącego zdjęcia. **Dwa kanały kolejki** — główny (ID: `1437122516974829679`) z pełnym zestawem przycisków moderatora (row1: 📊 Faza 1, 📈 Faza 2, 🧪 Test [tylko admin], 📢 Remind, 💀 Punish; row4: raport wypalenia + 🚪 Wyjdź z kolejki), dodatkowy (ID: `1491801320602992690`) z przyciskiem "🎒 Skanuj ekwipunek". Oba embedy aktualizowane równolegle. Jeden użytkownik może korzystać z OCR na raz w całym serwerze.
+4. **Równoległe sesje OCR** - `ocrService.js` (sekcja "SYSTEM RÓWNOLEGŁYCH SESJI OCR"): Wiele osób może jednocześnie korzystać z komend OCR (`/punish`, `/remind`, `/faza1`, `/faza2`, "Skanuj ekwipunek") — brak globalnej kolejki/blokady na serwer. Limit jest tylko per-użytkownik: jedna aktywna sesja na osobę naraz (`isOCRActive(guildId, userId)`), timeout 15 min (1 min dla skanu ekwipunku), przyciski komend. Anulowanie w trakcie przetwarzania: embed aktualizowany do stanu "❌ Sesja anulowana" z usuniętymi przyciskami po zakończeniu bieżącego zdjęcia. **Dwa kanały panelu OCR** — główny (ID: `1437122516974829679`) z pełnym zestawem przycisków moderatora (row1: 📊 Faza 1, 📈 Faza 2, 🧪 Test [tylko admin], 📢 Remind, 💀 Punish; row4: raport wypalenia + ❌ Anuluj moją sesję), dodatkowy (ID: `1491801320602992690`) z przyciskiem "🎒 Skanuj ekwipunek". Oba embedy pokazują listę **aktualnie aktywnych sesji** (nick, komenda, czas do wygaśnięcia) zamiast pozycji w kolejce, aktualizowane równolegle. Przycisk "❌ Anuluj moją sesję" (`queue_leave`) kończy wyłącznie sesję wywołującego, nie wpływa na innych.
 13. **Skan Ekwipunku (Core Stock)** - Przycisk "🎒 Skanuj ekwipunek" na kanale `1491801320602992690`:
    - Dostępny dla wszystkich członków klanu (targetRoles)
-   - Wchodzi do wspólnej kolejki OCR (1-minutowy timeout sesji)
+   - Uruchamia sesję OCR równolegle z innymi użytkownikami (1-minutowy timeout sesji, jedna sesja na osobę naraz)
    - Po dostaniu dostępu: użytkownik ma 1 minutę na wysłanie zdjęcia zakładki "Core Stock"
    - Analiza przez AI (Google Gemini Vision): wyciąga nazwę przedmiotu + pierwszą liczbę przed "/" (ilość "All")
    - Prompt AI: wyciąga JSON `{"Transmute Core": 29, ...}` z ekranu Core Stock
@@ -139,8 +139,8 @@
 - **Auto-naprawa przy starcie:** `imageUrlFixer.js` - wykrywa wpisy bez `url` (np. z transferu), pobiera wiadomość po `messageId` z kanału archiwum i uzupełnia brakujący URL. Uruchamia się przy każdym starcie bota.
 - **Uprawnienia:** Tylko administratorzy i moderatorzy (allowedPunishRoles)
 - **Detekcja klanu:** Automatyczna detekcja z roli użytkownika (admin/moderator musi mieć rolę klanową)
-- **Dostępność:** Komenda `/img` + przycisk "📷 Dodaj zdjęcie rankingu" na embedzie kolejki OCR (drugi rząd przycisków)
-- **NIE używa kolejki OCR:** Komenda nie korzysta z systemu kolejkowania OCR (działa niezależnie)
+- **Dostępność:** Komenda `/img` + przycisk "📷 Dodaj zdjęcie rankingu" na embedzie panelu OCR (drugi rząd przycisków)
+- **NIE używa sesji OCR:** Komenda nie korzysta z systemu sesji OCR (działa niezależnie)
 - **Dostępne tygodnie:** Lista wszystkich tygodni z zapisanymi wynikami (Faza 1 LUB Faza 2) dla wybranego klanu (max 25)
 - **Logika agregacji:** Tygodnie z obu faz są łączone i deduplikowane, etykieta pokazuje które fazy są dostępne (F1, F2, F1+F2)
 - Obsługiwane formaty: PNG, JPG, JPEG, WEBP, GIF

--- a/Stalker/config/config.js
+++ b/Stalker/config/config.js
@@ -170,7 +170,7 @@ module.exports = {
         cooldownHours: 6
     },
 
-    // Kanał wyświetlania kolejki OCR
+    // Kanał panelu OCR (aktywne sesje)
     queueChannelId: '1437122516974829679',
 
     // Kanał skanowania ekwipunku (Core Stock)

--- a/Stalker/handlers/interactionHandlers.js
+++ b/Stalker/handlers/interactionHandlers.js
@@ -183,28 +183,29 @@ async function handleSlashCommand(interaction, sharedState) {
 
 async function handlePunishCommand(interaction, config, ocrService, punishmentService) {
     try {
-        // ===== SPRAWDZENIE KOLEJKI OCR =====
+        // ===== SPRAWDZENIE WŁASNEJ AKTYWNEJ SESJI OCR =====
         const guildId = interaction.guild.id;
         const userId = interaction.user.id;
         const commandName = '/punish';
 
-        // Sprawdź czy ktoś inny używa OCR
-        const isOCRActive = ocrService.isOCRActive(guildId);
-
-        // Sprawdź czy kolejka jest pusta
-        const isQueueEmpty = ocrService.isQueueEmpty(guildId);
-
-        // Określ czy użytkownik będzie dodany do kolejki
-        const willBeQueued = isOCRActive || !isQueueEmpty;
+        // Sprawdź czy TEN użytkownik ma już aktywną sesję OCR (inni mogą działać równolegle)
+        const isOCRActive = ocrService.isOCRActive(guildId, userId);
 
         await interaction.deferReply({ ephemeral: false });
 
+        if (isOCRActive) {
+            await interaction.editReply({
+                content: '❌ Masz już aktywną sesję OCR. Dokończ ją lub poczekaj aż wygaśnie.'
+            });
+            return;
+        }
+
         const runSession = async (inter) => {
             await ocrService.startOCRSession(guildId, userId, commandName);
-            logger.info(`[OCR-QUEUE] 🟢 ${inter.user.tag} rozpoczyna sesję OCR (${commandName})`);
+            logger.info(`[OCR] 🟢 ${inter.user.tag} rozpoczyna sesję OCR (${commandName})`);
 
-            // Pobierz timestamp wygaśnięcia OCR z kolejki
-            const activeOCR = ocrService.activeProcessing.get(guildId);
+            // Pobierz timestamp wygaśnięcia OCR
+            const activeOCR = ocrService.getActiveOCRUser(guildId, userId);
             const ocrExpiresAt = activeOCR ? activeOCR.expiresAt : null;
 
             // Utwórz sesję punishment
@@ -222,22 +223,6 @@ async function handlePunishCommand(interaction, config, ocrService, punishmentSe
             logger.info(`[PUNISH] ✅ Sesja utworzona, czekam na zdjęcia od ${inter.user.tag}`);
         };
 
-        if (willBeQueued) {
-            const { position } = await ocrService.addToOCRQueue(guildId, userId, commandName, interaction, runSession);
-
-            const queueEmbed = new EmbedBuilder()
-                .setTitle('⏳ Kolejka OCR')
-                .setDescription(`System OCR jest obecnie zajęty przez innego użytkownika.\n\n` +
-                               `Zostałeś dodany do kolejki na pozycji **#${position}**.\n\n` +
-                               `⚡ Sesja zostanie **automatycznie uruchomiona** gdy będzie Twoja kolej.`)
-                .setColor('#ffa500')
-                .setTimestamp()
-                .setFooter({ text: `Komenda: ${commandName} | Pozycja w kolejce: ${position}` });
-
-            await interaction.editReply({ embeds: [queueEmbed] });
-            return;
-        }
-
         await runSession(interaction);
 
     } catch (error) {
@@ -247,7 +232,7 @@ async function handlePunishCommand(interaction, config, ocrService, punishmentSe
         const guildId = interaction.guild.id;
         const userId = interaction.user.id;
         await ocrService.endOCRSession(guildId, userId, true);
-        logger.info(`[OCR-QUEUE] 🔴 ${interaction.user.tag} zakończył sesję OCR (błąd)`);
+        logger.info(`[OCR] 🔴 ${interaction.user.tag} zakończył sesję OCR (błąd)`);
 
         await interaction.editReply({ content: messages.errors.ocrError });
     }
@@ -255,21 +240,22 @@ async function handlePunishCommand(interaction, config, ocrService, punishmentSe
 
 async function handleRemindCommand(interaction, config, ocrService, reminderService, reminderUsageService) {
     try {
-        // ===== SPRAWDZENIE KOLEJKI OCR (przed deferReply) =====
+        // ===== SPRAWDZENIE WŁASNEJ AKTYWNEJ SESJI OCR (przed deferReply) =====
         const guildId = interaction.guild.id;
         const userId = interaction.user.id;
         const commandName = '/remind';
 
-        // Sprawdź czy ktoś inny używa OCR
-        const isOCRActive = ocrService.isOCRActive(guildId);
-
-        // Sprawdź czy kolejka jest pusta
-        const isQueueEmpty = ocrService.isQueueEmpty(guildId);
-
-        // Określ czy użytkownik będzie dodany do kolejki
-        const willBeQueued = isOCRActive || !isQueueEmpty;
+        // Sprawdź czy TEN użytkownik ma już aktywną sesję OCR (inni mogą działać równolegle)
+        const isOCRActive = ocrService.isOCRActive(guildId, userId);
 
         await interaction.deferReply({ ephemeral: false });
+
+        if (isOCRActive) {
+            await interaction.editReply({
+                content: '❌ Masz już aktywną sesję OCR. Dokończ ją lub poczekaj aż wygaśnie.'
+            });
+            return;
+        }
 
         // Znajdź rolę klanu użytkownika (do sprawdzania limitów)
         let userClanRoleId = null;
@@ -307,10 +293,10 @@ async function handleRemindCommand(interaction, config, ocrService, reminderServ
 
         const runSession = async (inter) => {
             await ocrService.startOCRSession(guildId, userId, commandName);
-            logger.info(`[OCR-QUEUE] 🟢 ${inter.user.tag} rozpoczyna sesję OCR (${commandName})`);
+            logger.info(`[OCR] 🟢 ${inter.user.tag} rozpoczyna sesję OCR (${commandName})`);
 
-            // Pobierz timestamp wygaśnięcia OCR z kolejki
-            const activeOCR = ocrService.activeProcessing.get(guildId);
+            // Pobierz timestamp wygaśnięcia OCR
+            const activeOCR = ocrService.getActiveOCRUser(guildId, userId);
             const ocrExpiresAt = activeOCR ? activeOCR.expiresAt : null;
 
             // Utwórz sesję przypomnienia
@@ -328,22 +314,6 @@ async function handleRemindCommand(interaction, config, ocrService, reminderServ
             logger.info(`[REMIND] ✅ Sesja utworzona, czekam na zdjęcia od ${inter.user.tag}`);
         };
 
-        if (willBeQueued) {
-            const { position } = await ocrService.addToOCRQueue(guildId, userId, commandName, interaction, runSession);
-
-            const queueEmbed = new EmbedBuilder()
-                .setTitle('⏳ Kolejka OCR')
-                .setDescription(`System OCR jest obecnie zajęty przez innego użytkownika.\n\n` +
-                               `Zostałeś dodany do kolejki na pozycji **#${position}**.\n\n` +
-                               `⚡ Sesja zostanie **automatycznie uruchomiona** gdy będzie Twoja kolej.`)
-                .setColor('#ffa500')
-                .setTimestamp()
-                .setFooter({ text: `Komenda: ${commandName} | Pozycja w kolejce: ${position}` });
-
-            await interaction.editReply({ embeds: [queueEmbed] });
-            return;
-        }
-
         await runSession(interaction);
 
     } catch (error) {
@@ -353,7 +323,7 @@ async function handleRemindCommand(interaction, config, ocrService, reminderServ
         const guildId = interaction.guild.id;
         const userId = interaction.user.id;
         await ocrService.endOCRSession(guildId, userId, true);
-        logger.info(`[OCR-QUEUE] 🔴 ${interaction.user.tag} zakończył sesję OCR (błąd)`);
+        logger.info(`[OCR] 🔴 ${interaction.user.tag} zakończył sesję OCR (błąd)`);
 
         await interaction.editReply({ content: messages.errors.ocrError });
     }
@@ -1273,81 +1243,50 @@ async function handleButton(interaction, sharedState) {
         return;
     }
 
-    // ============ KONIEC OBSŁUGI PRZYCISKÓW KOMEND Z KOLEJKI ============
+    // ============ KONIEC OBSŁUGI PRZYCISKÓW KOMEND Z PANELU OCR ============
 
-    // ============ OBSŁUGA PRZYCISKU "WYJDŹ Z KOLEJKI" ============
+    // ============ OBSŁUGA PRZYCISKU "ANULUJ MOJĄ SESJĘ" ============
 
     if (interaction.customId === 'queue_leave') {
         const guildId = interaction.guild.id;
         const userId = interaction.user.id;
 
-        // Sprawdź czy użytkownik ma aktywną sesję
-        const activeSession = sharedState.ocrService.activeProcessing.get(guildId);
-        const hasActiveSession = activeSession && activeSession.userId === userId;
+        // Sprawdź czy TEN użytkownik ma aktywną sesję
+        const activeSession = sharedState.ocrService.getActiveOCRUser(guildId, userId);
 
-        // Sprawdź czy użytkownik jest w kolejce
-        const queue = sharedState.ocrService.waitingQueue.get(guildId) || [];
-        const isInQueue = queue.find(item => item.userId === userId);
-
-        if (!hasActiveSession && !isInQueue) {
+        if (!activeSession) {
             await interaction.reply({
-                content: '❌ Nie jesteś w systemie kolejki OCR.',
+                content: '❌ Nie masz aktywnej sesji OCR.',
                 flags: MessageFlags.Ephemeral
             });
             return;
         }
 
-        // Jeśli ma aktywną sesję, zakończ ją
-        if (hasActiveSession) {
-            logger.info(`[OCR-QUEUE] 🚪 ${userId} opuszcza aktywną sesję (${activeSession.commandName})`);
+        logger.info(`[OCR] 🚪 ${userId} anuluje aktywną sesję (${activeSession.commandName})`);
 
-            // Znajdź sesję remind/punish i zatrzymaj ghost ping
-            const reminderSession = sharedState.reminderService.getSessionByUserId(userId);
-            const punishSession = sharedState.punishmentService.getSessionByUserId(userId);
+        // Znajdź sesję remind/punish i zatrzymaj ghost ping
+        const reminderSession = sharedState.reminderService.getSessionByUserId(userId);
+        const punishSession = sharedState.punishmentService.getSessionByUserId(userId);
 
-            if (reminderSession) {
-                stopGhostPing(reminderSession);
-                await sharedState.reminderService.cleanupSession(reminderSession.sessionId);
-                logger.info(`[OCR-QUEUE] 🧹 Wyczyszczono sesję /remind dla ${userId}`);
-            }
-
-            if (punishSession) {
-                stopGhostPing(punishSession);
-                await sharedState.punishmentService.cleanupSession(punishSession.sessionId);
-                logger.info(`[OCR-QUEUE] 🧹 Wyczyszczono sesję /punish dla ${userId}`);
-            }
-
-            // Zakończ sesję OCR (to automatycznie powiadomi następną osobę)
-            await sharedState.ocrService.endOCRSession(guildId, userId, true);
-
-            await interaction.reply({
-                content: '✅ Opuściłeś aktywną sesję OCR.',
-                flags: MessageFlags.Ephemeral
-            });
-            return;
+        if (reminderSession) {
+            stopGhostPing(reminderSession);
+            await sharedState.reminderService.cleanupSession(reminderSession.sessionId);
+            logger.info(`[OCR] 🧹 Wyczyszczono sesję /remind dla ${userId}`);
         }
 
-        if (isInQueue) {
-            // Usuń tylko z kolejki
-            const index = queue.findIndex(item => item.userId === userId);
-            if (index !== -1) {
-                queue.splice(index, 1);
-                logger.info(`[OCR-QUEUE] 🚪 ${userId} opuścił kolejkę (pozycja ${index + 1})`);
-            }
-
-            if (queue.length === 0) {
-                sharedState.ocrService.waitingQueue.delete(guildId);
-            }
+        if (punishSession) {
+            stopGhostPing(punishSession);
+            await sharedState.punishmentService.cleanupSession(punishSession.sessionId);
+            logger.info(`[OCR] 🧹 Wyczyszczono sesję /punish dla ${userId}`);
         }
 
-        // Aktualizuj wyświetlanie kolejki
-        await sharedState.ocrService.updateQueueDisplay(guildId);
+        // Zakończ sesję OCR (nie wpływa na sesje innych użytkowników)
+        await sharedState.ocrService.endOCRSession(guildId, userId, true);
 
         await interaction.reply({
-            content: '✅ Opuściłeś kolejkę OCR.',
+            content: '✅ Anulowałeś swoją aktywną sesję OCR.',
             flags: MessageFlags.Ephemeral
         });
-
         return;
     }
 
@@ -3674,17 +3613,18 @@ async function handlePhase1Command(interaction, sharedState) {
         return;
     }
 
-    // ===== SPRAWDZENIE KOLEJKI OCR (przed deferReply) =====
-    // Sprawdź czy ktoś inny używa OCR
-    const isOCRActive = ocrService.isOCRActive(guildId);
-
-    // Sprawdź czy kolejka jest pusta
-    const isQueueEmpty = ocrService.isQueueEmpty(guildId);
-
-    // Określ czy użytkownik będzie dodany do kolejki
-    const willBeQueued = isOCRActive || !isQueueEmpty;
+    // ===== SPRAWDZENIE WŁASNEJ AKTYWNEJ SESJI OCR (przed deferReply) =====
+    // Sprawdź czy TEN użytkownik ma już aktywną sesję OCR (inni mogą działać równolegle)
+    const isOCRActive = ocrService.isOCRActive(guildId, userId);
 
     await interaction.deferReply({ ephemeral: false });
+
+    if (isOCRActive) {
+        await interaction.editReply({
+            content: '❌ Masz już aktywną sesję OCR. Dokończ ją lub poczekaj aż wygaśnie.'
+        });
+        return;
+    }
 
     try {
         // Wykryj klan użytkownika
@@ -3709,10 +3649,10 @@ async function handlePhase1Command(interaction, sharedState) {
 
         const runSession = async (inter) => {
             await ocrService.startOCRSession(guildId, userId, commandName);
-            logger.info(`[OCR-QUEUE] 🟢 ${inter.user.tag} rozpoczyna sesję OCR (${commandName})`);
+            logger.info(`[OCR] 🟢 ${inter.user.tag} rozpoczyna sesję OCR (${commandName})`);
 
-            // Pobierz timestamp wygaśnięcia OCR z kolejki
-            const activeOCR = ocrService.activeProcessing.get(guildId);
+            // Pobierz timestamp wygaśnięcia OCR
+            const activeOCR = ocrService.getActiveOCRUser(guildId, userId);
             const ocrExpiresAt = activeOCR ? activeOCR.expiresAt : null;
 
             // Sprawdź czy dane dla tego tygodnia i klanu już istnieją
@@ -3766,22 +3706,6 @@ async function handlePhase1Command(interaction, sharedState) {
             logger.info(`[PHASE1] ✅ Sesja utworzona, czekam na zdjęcia od ${inter.user.tag}`);
         };
 
-        if (willBeQueued) {
-            const { position } = await ocrService.addToOCRQueue(guildId, userId, commandName, interaction, runSession);
-
-            const queueEmbed = new EmbedBuilder()
-                .setTitle('⏳ Kolejka OCR')
-                .setDescription(`System OCR jest obecnie zajęty przez innego użytkownika.\n\n` +
-                               `Zostałeś dodany do kolejki na pozycji **#${position}**.\n\n` +
-                               `⚡ Sesja zostanie **automatycznie uruchomiona** gdy będzie Twoja kolej.`)
-                .setColor('#ffa500')
-                .setTimestamp()
-                .setFooter({ text: `Komenda: ${commandName} | Pozycja w kolejce: ${position}` });
-
-            await interaction.editReply({ embeds: [queueEmbed] });
-            return;
-        }
-
         await runSession(interaction);
 
     } catch (error) {
@@ -3789,7 +3713,7 @@ async function handlePhase1Command(interaction, sharedState) {
 
         // Zakończ sesję OCR w przypadku błędu
         await ocrService.endOCRSession(guildId, userId, true);
-        logger.info(`[OCR-QUEUE] 🔴 ${interaction.user.tag} zakończył sesję OCR (błąd)`);
+        logger.info(`[OCR] 🔴 ${interaction.user.tag} zakończył sesję OCR (błąd)`);
 
         await interaction.editReply({
             content: '❌ Wystąpił błąd podczas inicjalizacji komendy /faza1.'
@@ -3805,7 +3729,7 @@ async function handlePhase1OverwriteButton(interaction, sharedState) {
     if (interaction.customId === 'phase1_overwrite_no') {
         // Anuluj - zakończ sesję OCR
         await ocrService.endOCRSession(interaction.guild.id, interaction.user.id, true);
-        logger.info(`[OCR-QUEUE] 🔴 ${interaction.user.tag} zakończył sesję OCR (anulowanie Phase1)`);
+        logger.info(`[OCR] 🔴 ${interaction.user.tag} zakończył sesję OCR (anulowanie Phase1)`);
 
         // Próbuj zaktualizować wiadomość (może być już usunięta przez cleanup)
         try {
@@ -3815,7 +3739,7 @@ async function handlePhase1OverwriteButton(interaction, sharedState) {
                 components: []
             });
         } catch (updateError) {
-            // Wiadomość została już usunięta przez cleanupQueueChannelMessages - to OK
+            // Wiadomość mogła zostać już usunięta - to OK
             logger.info(`[PHASE1] ℹ️ Nie można zaktualizować wiadomości (prawdopodobnie już usunięta): ${updateError.message}`);
         }
         return;
@@ -3843,8 +3767,8 @@ async function handlePhase1OverwriteButton(interaction, sharedState) {
 
     // Nadpisz - sesja OCR już aktywna (została rozpoczęta w handlePhase1Command)
 
-    // Pobierz timestamp wygaśnięcia OCR z kolejki
-    const activeOCR = ocrService.activeProcessing.get(interaction.guild.id);
+    // Pobierz timestamp wygaśnięcia OCR
+    const activeOCR = ocrService.getActiveOCRUser(interaction.guild.id, interaction.user.id);
     const ocrExpiresAt = activeOCR ? activeOCR.expiresAt : null;
 
     const sessionId = phaseService.createSession(
@@ -3903,7 +3827,7 @@ async function handlePhase1CompleteButton(interaction, sharedState) {
         // Anuluj sesję (cleanupSession wywołuje endOCRSession gdy to bezpieczne)
         await phaseService.cleanupSession(session.sessionId);
 
-        logger.info(`[OCR-QUEUE] 🔴 ${interaction.user.tag} zakończył sesję OCR (anulowanie Phase1)`);
+        logger.info(`[OCR] 🔴 ${interaction.user.tag} zakończył sesję OCR (anulowanie Phase1)`);
         logger.info(`[PHASE1] ❌ Sesja anulowana przez użytkownika: ${interaction.user.tag}`);
         return;
     }
@@ -4179,7 +4103,7 @@ async function handlePhase1FinalConfirmButton(interaction, sharedState) {
     if (interaction.customId === 'phase1_cancel_save') {
         // Anuluj - usuń pliki temp i zakończ sesję OCR (cleanupSession wywołuje endOCRSession)
         await phaseService.cleanupSession(session.sessionId);
-        logger.info(`[OCR-QUEUE] 🔴 ${interaction.user.tag} zakończył sesję OCR (anulowanie zapisu Phase1)`);
+        logger.info(`[OCR] 🔴 ${interaction.user.tag} zakończył sesję OCR (anulowanie zapisu Phase1)`);
 
         try {
             await interaction.update({
@@ -4302,14 +4226,14 @@ async function handlePhase1FinalConfirmButton(interaction, sharedState) {
 
         // TERAZ dopiero wyczyść całą sesję (to wywołuje endOCRSession i czyści kanał)
         await phaseService.cleanupSession(session.sessionId);
-        logger.info(`[OCR-QUEUE] 🔴 ${interaction.user.tag} zakończył sesję OCR (sukces Phase1)`);
+        logger.info(`[OCR] 🔴 ${interaction.user.tag} zakończył sesję OCR (sukces Phase1)`);
 
     } catch (error) {
         logger.error('[PHASE1] ❌ Błąd zapisu danych:', error);
 
         // Wyczyść sesję w przypadku błędu (to wywołuje endOCRSession)
         await phaseService.cleanupSession(session.sessionId);
-        logger.info(`[OCR-QUEUE] 🔴 ${interaction.user.tag} zakończył sesję OCR (błąd zapisu Phase1)`);
+        logger.info(`[OCR] 🔴 ${interaction.user.tag} zakończył sesję OCR (błąd zapisu Phase1)`);
 
         // Spróbuj odpowiedzieć użytkownikowi (może się nie udać jeśli interaction expired)
         try {
@@ -4384,17 +4308,18 @@ async function handlePhase2Command(interaction, sharedState) {
         return;
     }
 
-    // ===== SPRAWDZENIE KOLEJKI OCR (przed deferReply) =====
-    // Sprawdź czy ktoś inny używa OCR
-    const isOCRActive = ocrService.isOCRActive(guildId);
-
-    // Sprawdź czy kolejka jest pusta
-    const isQueueEmpty = ocrService.isQueueEmpty(guildId);
-
-    // Określ czy użytkownik będzie dodany do kolejki
-    const willBeQueued = isOCRActive || !isQueueEmpty;
+    // ===== SPRAWDZENIE WŁASNEJ AKTYWNEJ SESJI OCR (przed deferReply) =====
+    // Sprawdź czy TEN użytkownik ma już aktywną sesję OCR (inni mogą działać równolegle)
+    const isOCRActive = ocrService.isOCRActive(guildId, userId);
 
     await interaction.deferReply({ ephemeral: false });
+
+    if (isOCRActive) {
+        await interaction.editReply({
+            content: '❌ Masz już aktywną sesję OCR. Dokończ ją lub poczekaj aż wygaśnie.'
+        });
+        return;
+    }
 
     try {
         // Wykryj klan użytkownika
@@ -4419,10 +4344,10 @@ async function handlePhase2Command(interaction, sharedState) {
 
         const runSession = async (inter) => {
             await ocrService.startOCRSession(guildId, userId, commandName);
-            logger.info(`[OCR-QUEUE] 🟢 ${inter.user.tag} rozpoczyna sesję OCR (${commandName})`);
+            logger.info(`[OCR] 🟢 ${inter.user.tag} rozpoczyna sesję OCR (${commandName})`);
 
-            // Pobierz timestamp wygaśnięcia OCR z kolejki
-            const activeOCR = ocrService.activeProcessing.get(guildId);
+            // Pobierz timestamp wygaśnięcia OCR
+            const activeOCR = ocrService.getActiveOCRUser(guildId, userId);
             const ocrExpiresAt = activeOCR ? activeOCR.expiresAt : null;
 
             // Sprawdź czy dane dla tego tygodnia i klanu już istnieją
@@ -4476,22 +4401,6 @@ async function handlePhase2Command(interaction, sharedState) {
             logger.info(`[PHASE2] ✅ Sesja utworzona, czekam na zdjęcia z rundy 1/3 od ${inter.user.tag}`);
         };
 
-        if (willBeQueued) {
-            const { position } = await ocrService.addToOCRQueue(guildId, userId, commandName, interaction, runSession);
-
-            const queueEmbed = new EmbedBuilder()
-                .setTitle('⏳ Kolejka OCR')
-                .setDescription(`System OCR jest obecnie zajęty przez innego użytkownika.\n\n` +
-                               `Zostałeś dodany do kolejki na pozycji **#${position}**.\n\n` +
-                               `⚡ Sesja zostanie **automatycznie uruchomiona** gdy będzie Twoja kolej.`)
-                .setColor('#ffa500')
-                .setTimestamp()
-                .setFooter({ text: `Komenda: ${commandName} | Pozycja w kolejce: ${position}` });
-
-            await interaction.editReply({ embeds: [queueEmbed] });
-            return;
-        }
-
         await runSession(interaction);
 
     } catch (error) {
@@ -4499,7 +4408,7 @@ async function handlePhase2Command(interaction, sharedState) {
 
         // Zakończ sesję OCR w przypadku błędu
         await ocrService.endOCRSession(guildId, userId, true);
-        logger.info(`[OCR-QUEUE] 🔴 ${interaction.user.tag} zakończył sesję OCR (błąd Phase2)`);
+        logger.info(`[OCR] 🔴 ${interaction.user.tag} zakończył sesję OCR (błąd Phase2)`);
 
         await interaction.editReply({
             content: '❌ Wystąpił błąd podczas uruchamiania komendy.'
@@ -4512,7 +4421,7 @@ async function handlePhase2OverwriteButton(interaction, sharedState) {
 
     if (interaction.customId === 'phase2_overwrite_no') {
         await ocrService.endOCRSession(interaction.guild.id, interaction.user.id, true);
-        logger.info(`[OCR-QUEUE] 🔴 ${interaction.user.tag} zakończył sesję OCR (anulowanie Phase2)`);
+        logger.info(`[OCR] 🔴 ${interaction.user.tag} zakończył sesję OCR (anulowanie Phase2)`);
 
         // Próbuj zaktualizować wiadomość (może być już usunięta przez cleanup)
         try {
@@ -4522,7 +4431,7 @@ async function handlePhase2OverwriteButton(interaction, sharedState) {
                 components: []
             });
         } catch (updateError) {
-            // Wiadomość została już usunięta przez cleanupQueueChannelMessages - to OK
+            // Wiadomość mogła zostać już usunięta - to OK
             logger.info(`[PHASE2] ℹ️ Nie można zaktualizować wiadomości (prawdopodobnie już usunięta): ${updateError.message}`);
         }
         return;
@@ -4549,8 +4458,8 @@ async function handlePhase2OverwriteButton(interaction, sharedState) {
 
     // Sesja OCR już aktywna (została rozpoczęta w handlePhase2Command)
 
-    // Pobierz timestamp wygaśnięcia OCR z kolejki
-    const activeOCR = ocrService.activeProcessing.get(interaction.guild.id);
+    // Pobierz timestamp wygaśnięcia OCR
+    const activeOCR = ocrService.getActiveOCRUser(interaction.guild.id, interaction.user.id);
     const ocrExpiresAt = activeOCR ? activeOCR.expiresAt : null;
 
     const sessionId = phaseService.createSession(
@@ -4601,7 +4510,7 @@ async function handlePhase2CompleteButton(interaction, sharedState) {
         // Anuluj sesję (cleanupSession wywołuje endOCRSession gdy to bezpieczne)
         await phaseService.cleanupSession(session.sessionId);
 
-        logger.info(`[OCR-QUEUE] 🔴 ${interaction.user.tag} zakończył sesję OCR (anulowanie Phase2)`);
+        logger.info(`[OCR] 🔴 ${interaction.user.tag} zakończył sesję OCR (anulowanie Phase2)`);
         logger.info(`[PHASE2] ❌ Sesja anulowana przez użytkownika: ${interaction.user.tag}`);
         return;
     }
@@ -4709,7 +4618,7 @@ async function handlePhase2FinalConfirmButton(interaction, sharedState) {
     stopGhostPing(session);
 
     if (interaction.customId === 'phase2_cancel_save') {
-        // Najpierw zaktualizuj interakcję PRZED cleanupem (cleanup usuwa wiadomości z kanału kolejki)
+        // Najpierw zaktualizuj interakcję PRZED cleanupem
         await interaction.update({
             content: '❌ Anulowano zapis danych.',
             embeds: [],
@@ -4718,7 +4627,7 @@ async function handlePhase2FinalConfirmButton(interaction, sharedState) {
 
         // Anuluj zapis i zakończ sesję OCR (cleanupSession wywołuje endOCRSession)
         await phaseService.cleanupSession(session.sessionId);
-        logger.info(`[OCR-QUEUE] 🔴 ${interaction.user.tag} zakończył sesję OCR (anulowanie zapisu Phase2)`);
+        logger.info(`[OCR] 🔴 ${interaction.user.tag} zakończył sesję OCR (anulowanie zapisu Phase2)`);
         return;
     }
 
@@ -4863,14 +4772,14 @@ async function handlePhase2FinalConfirmButton(interaction, sharedState) {
 
         // TERAZ dopiero wyczyść całą sesję (to wywołuje endOCRSession i czyści kanał)
         await phaseService.cleanupSession(session.sessionId);
-        logger.info(`[OCR-QUEUE] 🔴 ${interaction.user.tag} zakończył sesję OCR (sukces Phase2)`);
+        logger.info(`[OCR] 🔴 ${interaction.user.tag} zakończył sesję OCR (sukces Phase2)`);
 
     } catch (error) {
         logger.error('[PHASE2] ❌ Błąd zapisu:', error);
 
         // Wyczyść sesję w przypadku błędu (to wywołuje endOCRSession)
         await phaseService.cleanupSession(session.sessionId);
-        logger.info(`[OCR-QUEUE] 🔴 ${interaction.user.tag} zakończył sesję OCR (błąd zapisu Phase2)`);
+        logger.info(`[OCR] 🔴 ${interaction.user.tag} zakończył sesję OCR (błąd zapisu Phase2)`);
 
         // Spróbuj odpowiedzieć użytkownikowi (może się nie udać jeśli interaction expired)
         try {
@@ -12464,21 +12373,16 @@ async function handleEquipmentScanCommand(interaction, sharedState) {
         return;
     }
 
-    // Sprawdź stan kolejki (synchroniczne operacje - przed deferReply)
-    const activeSession = ocrService.activeProcessing.get(guildId);
-    const isCurrentUserActive = activeSession && activeSession.userId === userId;
+    // Sprawdź czy TEN użytkownik ma już aktywną sesję (synchroniczne operacje - przed deferReply)
+    const isOCRActive = ocrService.isOCRActive(guildId, userId);
 
-    if (isCurrentUserActive) {
+    if (isOCRActive) {
         await interaction.reply({
             content: '❌ Już korzystasz z OCR. Prześlij zdjęcie lub poczekaj aż Twoja sesja wygaśnie.',
             flags: MessageFlags.Ephemeral
         });
         return;
     }
-
-    const isOCRActive = ocrService.isOCRActive(guildId);
-    const isQueueEmpty = ocrService.isQueueEmpty(guildId);
-    const willBeQueued = isOCRActive || !isQueueEmpty;
 
     // Defer reply przed operacjami async (Discord wymaga odpowiedzi w 3 sekundy)
     await interaction.deferReply({ ephemeral: true });
@@ -12596,21 +12500,13 @@ async function handleEquipmentScanCommand(interaction, sharedState) {
 
         collector.on('end', async (collected) => {
             if (collected.size === 0) {
-                // Timeout - sesja już powinna być zakończona przez system kolejki
+                // Timeout - sesja już powinna być zakończona przez wygaśnięcie w ocrService
                 try {
                     await inter.editReply({ content: '⏰ Czas minął. Nie przesłano zdjęcia w ciągu 1 minuty. Kliknij przycisk ponownie, aby spróbować.' });
                 } catch {}
             }
         });
     };
-
-    if (willBeQueued) {
-        const { position } = await ocrService.addToOCRQueue(guildId, userId, commandName, interaction, runSession);
-        await interaction.editReply({
-            content: `⏳ Zostałeś dodany do kolejki na pozycji **#${position}**.\n\n⚡ Sesja zostanie **automatycznie uruchomiona** gdy będzie Twoja kolej.`
-        });
-        return;
-    }
 
     await runSession(interaction);
 }

--- a/Stalker/index.js
+++ b/Stalker/index.js
@@ -291,7 +291,7 @@ client.once(Events.ClientReady, async () => {
     }
 
     await ocrService.initializeOCR();
-    ocrService.setClient(client); // Ustaw klienta dla systemu kolejkowania OCR
+    ocrService.setClient(client); // Ustaw klienta dla systemu równoległych sesji OCR
     await messageCleanupService.init();
     await raportCleanupService.initialize();
     await broadcastMessageService.initialize();
@@ -319,11 +319,11 @@ client.once(Events.ClientReady, async () => {
     // Rejestracja komend slash
     await registerSlashCommands(client);
 
-    // Inicjalizacja wyświetlania kolejki OCR
+    // Inicjalizacja panelu OCR (lista aktywnych sesji)
     try {
         await ocrService.initializeQueueDisplay(client);
     } catch (error) {
-        logger.error(`❌ Błąd inicjalizacji wyświetlania kolejki OCR: ${error.message}`);
+        logger.error(`❌ Błąd inicjalizacji panelu OCR: ${error.message}`);
     }
 
     // Sprawdź i upewnij się, że wiadomość o urlopach jest ostatnia na kanale
@@ -989,12 +989,12 @@ client.on(Events.MessageCreate, async (message) => {
         }
     }
 
-    // Automatyczne czyszczenie kanału kolejki - usuń wszystkie wiadomości od użytkowników
+    // Automatyczne czyszczenie kanału panelu OCR - usuń wszystkie wiadomości od użytkowników
     const queueChannelId = '1437122516974829679';
     if (message.channelId === queueChannelId && !message.author.bot) {
         try {
             await message.delete();
-            logger.info(`[QUEUE-CLEANUP] 🧹 Usunięto wiadomość od ${message.author.tag} z kanału kolejki`);
+            logger.info(`[QUEUE-CLEANUP] 🧹 Usunięto wiadomość od ${message.author.tag} z kanału panelu OCR`);
         } catch (error) {
             // Ignoruj błąd Unknown Message (10008) - wiadomość została już usunięta przez inny proces
             if (error.code === 10008) {

--- a/Stalker/services/ocrService.js
+++ b/Stalker/services/ocrService.js
@@ -22,15 +22,14 @@ class OCRService {
         // Inicjalizuj AI OCR Service (opcjonalny) — Google Gemini przez llmAdapter
         this.aiOcrService = new AIOCRService(config, llmAdapter);
 
-        // System kolejkowania OCR - wspólny dla wszystkich komend używających OCR
-        this.activeProcessing = new Map(); // guildId → {userId, commandName, expiresAt, timeout}
-        this.waitingQueue = new Map(); // guildId → [{userId, addedAt, commandName, interaction, autoStartFn}]
+        // System sesji OCR - równoległe sesje, jeden użytkownik = jedna aktywna sesja naraz
+        this.activeProcessing = new Map(); // guildId → Map<userId, {commandName, expiresAt, timeout}>
 
-        // Wyświetlanie kolejki
-        this.queueMessageId = null; // ID wiadomości z embdem kolejki
+        // Wyświetlanie aktywnych sesji
+        this.queueMessageId = null; // ID wiadomości z embedem aktywnych sesji
         this.queueChannelId = this.config.queueChannelId;
 
-        // Kanał ekwipunku (drugi embed kolejki z przyciskiem "Skanuj ekwipunek")
+        // Kanał ekwipunku (drugi embed z przyciskiem "Skanuj ekwipunek")
         this.equipmentMessageId = null;
         this.equipmentChannelId = this.config.equipmentChannelId;
 
@@ -1281,70 +1280,49 @@ class OCRService {
         }
     }
 
-    // ==================== WYŚWIETLANIE KOLEJKI OCR ====================
+    // ==================== WYŚWIETLANIE AKTYWNYCH SESJI OCR ====================
 
     /**
-     * Tworzy embed z aktualną kolejką OCR
+     * Tworzy embed z listą aktualnie aktywnych (równoległych) sesji OCR
      */
-    async createQueueEmbed(guildId) {
-        const queue = this.waitingQueue.get(guildId) || [];
-        const active = this.activeProcessing.get(guildId);
+    async createActiveSessionsEmbed(guildId) {
+        const sessions = this.getActiveSessions(guildId);
 
         // Dynamiczny kolor embeda
-        let embedColor = '#00FF00'; // Zielony (domyślnie - pusta kolejka)
-
-        if (active) {
-            // Jeśli coś jest w użyciu
-            if (queue.length > 2) {
-                embedColor = '#FF0000'; // Czerwony (więcej niż 2 osoby w kolejce)
-            } else {
-                embedColor = '#FFA500'; // Żółty (w użyciu, max 2 osoby)
-            }
-        } else if (queue.length > 2) {
-            embedColor = '#FF0000'; // Czerwony (więcej niż 2 osoby czeka)
-        } else if (queue.length > 0) {
-            embedColor = '#FFA500'; // Żółty (1-2 osoby czekają)
+        let embedColor = '#00FF00'; // Zielony (domyślnie - brak aktywnych sesji)
+        if (sessions.length > 2) {
+            embedColor = '#FF0000'; // Czerwony (więcej niż 2 osoby naraz)
+        } else if (sessions.length > 0) {
+            embedColor = '#FFA500'; // Żółty (1-2 osoby)
         }
 
         const embed = new EmbedBuilder()
-            .setTitle('📋 Kolejka OCR')
+            .setTitle('📋 Panel OCR')
             .setColor(embedColor)
             .setTimestamp()
             .setFooter({ text: 'Aktualizowane automatycznie' });
 
         let description = '';
 
-        // Aktywne przetwarzanie
-        if (active) {
+        if (sessions.length > 0) {
+            description += `🔒 **Aktywne sesje:** (${sessions.length})\n\n`;
+
             try {
                 const guild = await this.client.guilds.fetch(guildId);
-                const member = await guild.members.fetch(active.userId);
-                const expiryTimestamp = Math.floor(active.expiresAt / 1000);
-                description += `🔒 **Aktualnie w użyciu:**\n`;
-                description += `${member.displayName} - \`${active.commandName}\` (wygasa <t:${expiryTimestamp}:R>)\n\n`;
-            } catch (error) {
-                const expiryTimestamp = Math.floor(active.expiresAt / 1000);
-                description += `🔒 **Aktualnie w użyciu:**\n`;
-                description += `Użytkownik ${active.userId} - \`${active.commandName}\` (wygasa <t:${expiryTimestamp}:R>)\n\n`;
-            }
-        }
-
-        // Kolejka oczekujących
-        if (queue.length > 0) {
-            description += `⏳ **Kolejka oczekujących:** (${queue.length})\n\n`;
-
-            const guild = await this.client.guilds.fetch(guildId);
-            for (let i = 0; i < queue.length; i++) {
-                const person = queue[i];
-                try {
-                    const member = await guild.members.fetch(person.userId);
-                    description += `**${i + 1}.** ${member.displayName} - \`${person.commandName}\`\n`;
-                } catch (error) {
-                    description += `**${i + 1}.** Użytkownik ${person.userId} - \`${person.commandName}\`\n`;
+                for (const session of sessions) {
+                    const expiryTimestamp = Math.floor(session.expiresAt / 1000);
+                    try {
+                        const member = await guild.members.fetch(session.userId);
+                        description += `${member.displayName} - \`${session.commandName}\` (wygasa <t:${expiryTimestamp}:R>)\n`;
+                    } catch (error) {
+                        description += `Użytkownik ${session.userId} - \`${session.commandName}\` (wygasa <t:${expiryTimestamp}:R>)\n`;
+                    }
                 }
+            } catch (error) {
+                logger.warn('[OCR] ⚠️ Błąd pobierania danych gildii dla embeda sesji:', error.message);
             }
-        } else if (!active) {
-            description += `✅ **Kolejka pusta**\n\nOCR jest dostępny do użycia!`;
+        } else {
+            description += `✅ **Brak aktywnych sesji**\n\nOCR jest dostępny do użycia! Wiele osób może korzystać jednocześnie.`;
         }
 
         embed.setDescription(description || 'Brak danych');
@@ -1352,7 +1330,7 @@ class OCRService {
     }
 
     /**
-     * Aktualizuje wyświetlanie kolejki na kanale
+     * Aktualizuje wyświetlanie panelu OCR na kanale
      */
     async updateQueueDisplay(guildId) {
         // Aktualizuj oba kanały równolegle
@@ -1363,7 +1341,7 @@ class OCRService {
     }
 
     /**
-     * Aktualizuje embed kolejki na głównym kanale OCR
+     * Aktualizuje embed panelu OCR na głównym kanale
      */
     async _updateMainQueueChannel(guildId) {
         try {
@@ -1371,11 +1349,11 @@ class OCRService {
 
             const channel = await this.client.channels.fetch(this.queueChannelId);
             if (!channel) {
-                logger.warn('[OCR-QUEUE] ⚠️ Nie znaleziono kanału kolejki');
+                logger.warn('[OCR] ⚠️ Nie znaleziono kanału panelu OCR');
                 return;
             }
 
-            const embed = await this.createQueueEmbed(guildId);
+            const embed = await this.createActiveSessionsEmbed(guildId);
             const { ButtonBuilder, ActionRowBuilder, ButtonStyle } = require('discord.js');
 
             const faza1Button = new ButtonBuilder()
@@ -1404,8 +1382,8 @@ class OCRService {
 
             const leaveQueueButton = new ButtonBuilder()
                 .setCustomId('queue_leave')
-                .setLabel('Wyjdź z kolejki')
-                .setEmoji('🚪')
+                .setLabel('Anuluj moją sesję')
+                .setEmoji('❌')
                 .setStyle(ButtonStyle.Danger);
 
             const dodajButton = new ButtonBuilder()
@@ -1466,22 +1444,22 @@ class OCRService {
                 try {
                     const message = await channel.messages.fetch(this.queueMessageId);
                     await message.edit({ embeds: [embed], components: [row1, row2, row3, row4] });
-                    logger.info('[OCR-QUEUE] 📝 Zaktualizowano embed kolejki');
+                    logger.info('[OCR] 📝 Zaktualizowano embed panelu OCR');
                     return;
                 } catch (error) {
-                    logger.warn('[OCR-QUEUE] ⚠️ Nie można zaktualizować embeda, tworzę nowy jako pierwszą wiadomość');
+                    logger.warn('[OCR] ⚠️ Nie można zaktualizować embeda, tworzę nowy jako pierwszą wiadomość');
                     this.queueMessageId = null;
                 }
             }
 
-            logger.warn('[OCR-QUEUE] ⚠️ Brak embeda kolejki - zostanie utworzony podczas inicjalizacji');
+            logger.warn('[OCR] ⚠️ Brak embeda panelu OCR - zostanie utworzony podczas inicjalizacji');
         } catch (error) {
-            logger.error('[OCR-QUEUE] ❌ Błąd aktualizacji głównego kanału kolejki:', error);
+            logger.error('[OCR] ❌ Błąd aktualizacji głównego kanału panelu OCR:', error);
         }
     }
 
     /**
-     * Aktualizuje embed kolejki na kanale ekwipunku (z przyciskiem "Skanuj ekwipunek")
+     * Aktualizuje embed panelu OCR na kanale ekwipunku (z przyciskiem "Skanuj ekwipunek")
      */
     async _updateEquipmentChannel(guildId) {
         try {
@@ -1490,7 +1468,7 @@ class OCRService {
             const channel = await this.client.channels.fetch(this.equipmentChannelId);
             if (!channel) return;
 
-            const embed = await this.createQueueEmbed(guildId);
+            const embed = await this.createActiveSessionsEmbed(guildId);
             const { ButtonBuilder, ActionRowBuilder, ButtonStyle } = require('discord.js');
 
             const scanButton = new ButtonBuilder()
@@ -1501,8 +1479,8 @@ class OCRService {
 
             const leaveQueueButton = new ButtonBuilder()
                 .setCustomId('queue_leave')
-                .setLabel('Wyjdź z kolejki')
-                .setEmoji('🚪')
+                .setLabel('Anuluj moją sesję')
+                .setEmoji('❌')
                 .setStyle(ButtonStyle.Danger);
 
             const rankingButton = new ButtonBuilder()
@@ -1520,109 +1498,33 @@ class OCRService {
                     await message.edit({ embeds: [embed], components: [row1, row2] });
                     return;
                 } catch (error) {
-                    logger.warn('[OCR-QUEUE] ⚠️ Nie można zaktualizować embeda ekwipunku');
+                    logger.warn('[OCR] ⚠️ Nie można zaktualizować embeda ekwipunku');
                     this.equipmentMessageId = null;
                 }
             }
 
-            logger.warn('[OCR-QUEUE] ⚠️ Brak embeda ekwipunku - zostanie utworzony podczas inicjalizacji');
+            logger.warn('[OCR] ⚠️ Brak embeda ekwipunku - zostanie utworzony podczas inicjalizacji');
         } catch (error) {
-            logger.error('[OCR-QUEUE] ❌ Błąd aktualizacji kanału ekwipunku:', error);
+            logger.error('[OCR] ❌ Błąd aktualizacji kanału ekwipunku:', error);
         }
     }
 
 
     /**
-     * Czyści wiadomości z kanału kolejki (zostawia tylko pierwszą z embedem)
-     */
-    async cleanupQueueChannelMessages() {
-        try {
-            if (!this.client || !this.queueChannelId) {
-                return;
-            }
-
-            const channel = await this.client.channels.fetch(this.queueChannelId);
-            if (!channel) {
-                return;
-            }
-
-            // Pobierz wszystkie wiadomości z kanału
-            const messages = await channel.messages.fetch({ limit: 100 });
-
-            let deletedCount = 0;
-            for (const [messageId, message] of messages) {
-                // Pomiń pierwszą wiadomość z embedem kolejki
-                if (messageId === this.queueMessageId) {
-                    continue;
-                }
-
-                // Usuń wszystkie inne wiadomości
-                try {
-                    await message.delete();
-                    deletedCount++;
-                } catch (error) {
-                    // Ignoruj błędy usuwania (np. brak uprawnień)
-                }
-            }
-
-            if (deletedCount > 0) {
-                logger.info(`[OCR-QUEUE] 🧹 Wyczyszczono ${deletedCount} wiadomości z kanału kolejki`);
-            }
-        } catch (error) {
-            // Ignoruj błędy czyszczenia
-        }
-    }
-
-    async cleanupEquipmentChannelMessages() {
-        try {
-            if (!this.client || !this.equipmentChannelId) {
-                return;
-            }
-
-            const channel = await this.client.channels.fetch(this.equipmentChannelId);
-            if (!channel) {
-                return;
-            }
-
-            const messages = await channel.messages.fetch({ limit: 100 });
-
-            let deletedCount = 0;
-            for (const [messageId, message] of messages) {
-                if (messageId === this.equipmentMessageId) {
-                    continue;
-                }
-
-                try {
-                    await message.delete();
-                    deletedCount++;
-                } catch (error) {
-                    // Ignoruj błędy usuwania
-                }
-            }
-
-            if (deletedCount > 0) {
-                logger.info(`[OCR-QUEUE] 🧹 Wyczyszczono ${deletedCount} wiadomości z kanału ekwipunku`);
-            }
-        } catch (error) {
-            // Ignoruj błędy czyszczenia
-        }
-    }
-
-    /**
-     * Czyści wszystkie wiadomości z kanału kolejki OCR
+     * Czyści wszystkie wiadomości z kanału panelu OCR
      */
     async cleanupQueueChannel() {
         try {
             if (!this.client || !this.queueChannelId) {
-                logger.warn('[OCR-QUEUE] ⚠️ Brak klienta lub kanału kolejki do wyczyszczenia');
+                logger.warn('[OCR] ⚠️ Brak klienta lub kanału panelu OCR do wyczyszczenia');
                 return;
             }
 
-            logger.info('[OCR-QUEUE] 🧹 Rozpoczynam czyszczenie kanału kolejki...');
+            logger.info('[OCR] 🧹 Rozpoczynam czyszczenie kanału panelu OCR...');
 
             const channel = await this.client.channels.fetch(this.queueChannelId);
             if (!channel) {
-                logger.warn('[OCR-QUEUE] ⚠️ Nie znaleziono kanału kolejki');
+                logger.warn('[OCR] ⚠️ Nie znaleziono kanału panelu OCR');
                 return;
             }
 
@@ -1630,7 +1532,7 @@ class OCRService {
             const messages = await channel.messages.fetch({ limit: 100 });
 
             if (messages.size === 0) {
-                logger.info('[OCR-QUEUE] ✅ Kanał kolejki jest już pusty');
+                logger.info('[OCR] ✅ Kanał panelu OCR jest już pusty');
                 // Wyślij nowy embed
                 await this.updateQueueDisplay(channel.guildId);
                 return;
@@ -1643,57 +1545,57 @@ class OCRService {
                     await message.delete();
                     deletedCount++;
                 } catch (error) {
-                    logger.warn(`[OCR-QUEUE] ⚠️ Nie można usunąć wiadomości ${messageId}: ${error.message}`);
+                    logger.warn(`[OCR] ⚠️ Nie można usunąć wiadomości ${messageId}: ${error.message}`);
                 }
             }
 
-            logger.info(`[OCR-QUEUE] 🗑️ Usunięto ${deletedCount} wiadomości z kanału kolejki`);
+            logger.info(`[OCR] 🗑️ Usunięto ${deletedCount} wiadomości z kanału panelu OCR`);
 
-            // Resetuj ID embeda kolejki
+            // Resetuj ID embeda panelu OCR
             this.queueMessageId = null;
 
-            // Wyślij nowy embed kolejki
+            // Wyślij nowy embed panelu OCR
             await this.updateQueueDisplay(channel.guildId);
 
-            logger.info('[OCR-QUEUE] ✅ Czyszczenie kanału kolejki zakończone');
+            logger.info('[OCR] ✅ Czyszczenie kanału panelu OCR zakończone');
         } catch (error) {
-            logger.error('[OCR-QUEUE] ❌ Błąd czyszczenia kanału kolejki:', error);
+            logger.error('[OCR] ❌ Błąd czyszczenia kanału panelu OCR:', error);
         }
     }
 
     /**
-     * Inicjalizuje wyświetlanie kolejki podczas startu bota
+     * Inicjalizuje wyświetlanie panelu OCR podczas startu bota
      */
     async initializeQueueDisplay(client) {
         try {
             if (!this.queueChannelId) {
-                logger.warn('[OCR-QUEUE] ⚠️ Brak skonfigurowanego kanału kolejki');
+                logger.warn('[OCR] ⚠️ Brak skonfigurowanego kanału panelu OCR');
                 return;
             }
 
-            logger.info('[OCR-QUEUE] 🚀 Inicjalizacja wyświetlania kolejki...');
+            logger.info('[OCR] 🚀 Inicjalizacja wyświetlania panelu OCR...');
 
             const channel = await client.channels.fetch(this.queueChannelId);
             if (!channel) {
-                logger.warn('[OCR-QUEUE] ⚠️ Nie znaleziono kanału kolejki');
+                logger.warn('[OCR] ⚠️ Nie znaleziono kanału panelu OCR');
                 return;
             }
 
             // Pobierz wszystkie wiadomości z kanału
             const messages = await channel.messages.fetch({ limit: 100 });
 
-            // Znajdź PIERWSZĄ wiadomość od bota z embedem kolejki (najstarsza)
+            // Znajdź PIERWSZĄ wiadomość od bota z embedem panelu OCR (najstarsza)
             let queueMessage = null;
             for (const [messageId, message] of messages) {
                 if (message.author.id === client.user.id &&
                     message.embeds.length > 0 &&
-                    message.embeds[0].title === '📋 Kolejka OCR') {
+                    (message.embeds[0].title === '📋 Panel OCR' || message.embeds[0].title === '📋 Kolejka OCR')) {
                     queueMessage = message;
                     // Nie break - chcemy znaleźć najstarszą (iterujemy od najnowszych do najstarszych)
                 }
             }
 
-            const embed = await this.createQueueEmbed(channel.guildId);
+            const embed = await this.createActiveSessionsEmbed(channel.guildId);
             const { ButtonBuilder, ActionRowBuilder, ButtonStyle } = require('discord.js');
 
             // Przyciski w jednym rzędzie
@@ -1723,8 +1625,8 @@ class OCRService {
 
             const leaveQueueButton = new ButtonBuilder()
                 .setCustomId('queue_leave')
-                .setLabel('Wyjdź z kolejki')
-                .setEmoji('🚪')
+                .setLabel('Anuluj moją sesję')
+                .setEmoji('❌')
                 .setStyle(ButtonStyle.Danger);
 
             const dodajButton = new ButtonBuilder()
@@ -1785,25 +1687,25 @@ class OCRService {
                 // Zaktualizuj istniejący embed
                 await queueMessage.edit({ embeds: [embed], components: [row1, row2, row3, row4] });
                 this.queueMessageId = queueMessage.id;
-                logger.info('[OCR-QUEUE] ✅ Zaktualizowano istniejący embed kolejki (ID: ' + queueMessage.id + ')');
+                logger.info('[OCR] ✅ Zaktualizowano istniejący embed panelu OCR (ID: ' + queueMessage.id + ')');
             } else {
                 // Wyślij nowy embed jako pierwszą wiadomość
                 const message = await channel.send({ embeds: [embed], components: [row1, row2, row3, row4] });
                 this.queueMessageId = message.id;
-                logger.info('[OCR-QUEUE] ✅ Utworzono nowy embed kolejki (ID: ' + message.id + ')');
+                logger.info('[OCR] ✅ Utworzono nowy embed panelu OCR (ID: ' + message.id + ')');
             }
 
-            logger.info('[OCR-QUEUE] ✅ Inicjalizacja wyświetlania kolejki zakończona');
+            logger.info('[OCR] ✅ Inicjalizacja wyświetlania panelu OCR zakończona');
         } catch (error) {
-            logger.error('[OCR-QUEUE] ❌ Błąd inicjalizacji wyświetlania kolejki:', error);
+            logger.error('[OCR] ❌ Błąd inicjalizacji wyświetlania panelu OCR:', error);
         }
 
-        // Zainicjalizuj kanał ekwipunku (drugi embed kolejki)
+        // Zainicjalizuj kanał ekwipunku (drugi embed panelu OCR)
         await this._initializeEquipmentChannel(client);
     }
 
     /**
-     * Inicjalizuje embed kolejki na kanale ekwipunku
+     * Inicjalizuje embed panelu OCR na kanale ekwipunku
      */
     async _initializeEquipmentChannel(client) {
         try {
@@ -1811,7 +1713,7 @@ class OCRService {
 
             const channel = await client.channels.fetch(this.equipmentChannelId);
             if (!channel) {
-                logger.warn('[OCR-QUEUE] ⚠️ Nie znaleziono kanału ekwipunku');
+                logger.warn('[OCR] ⚠️ Nie znaleziono kanału ekwipunku');
                 return;
             }
 
@@ -1821,12 +1723,12 @@ class OCRService {
             for (const [, message] of messages) {
                 if (message.author.id === client.user.id &&
                     message.embeds.length > 0 &&
-                    message.embeds[0].title === '📋 Kolejka OCR') {
+                    (message.embeds[0].title === '📋 Panel OCR' || message.embeds[0].title === '📋 Kolejka OCR')) {
                     equipmentMessage = message;
                 }
             }
 
-            const embed = await this.createQueueEmbed(channel.guildId);
+            const embed = await this.createActiveSessionsEmbed(channel.guildId);
             const { ButtonBuilder, ActionRowBuilder, ButtonStyle } = require('discord.js');
 
             const scanButton = new ButtonBuilder()
@@ -1837,8 +1739,8 @@ class OCRService {
 
             const leaveQueueButton = new ButtonBuilder()
                 .setCustomId('queue_leave')
-                .setLabel('Wyjdź z kolejki')
-                .setEmoji('🚪')
+                .setLabel('Anuluj moją sesję')
+                .setEmoji('❌')
                 .setStyle(ButtonStyle.Danger);
 
             const rankingButton = new ButtonBuilder()
@@ -1853,36 +1755,44 @@ class OCRService {
             if (equipmentMessage) {
                 await equipmentMessage.edit({ embeds: [embed], components: [row1, row2] });
                 this.equipmentMessageId = equipmentMessage.id;
-                logger.info('[OCR-QUEUE] ✅ Zaktualizowano istniejący embed ekwipunku (ID: ' + equipmentMessage.id + ')');
+                logger.info('[OCR] ✅ Zaktualizowano istniejący embed ekwipunku (ID: ' + equipmentMessage.id + ')');
             } else {
                 const message = await channel.send({ embeds: [embed], components: [row1, row2] });
                 this.equipmentMessageId = message.id;
-                logger.info('[OCR-QUEUE] ✅ Utworzono nowy embed ekwipunku (ID: ' + message.id + ')');
+                logger.info('[OCR] ✅ Utworzono nowy embed ekwipunku (ID: ' + message.id + ')');
             }
         } catch (error) {
-            logger.error('[OCR-QUEUE] ❌ Błąd inicjalizacji kanału ekwipunku:', error);
+            logger.error('[OCR] ❌ Błąd inicjalizacji kanału ekwipunku:', error);
         }
     }
 
-    // ==================== SYSTEM KOLEJKOWANIA OCR ====================
+    // ==================== SYSTEM RÓWNOLEGŁYCH SESJI OCR ====================
 
     /**
-     * Sprawdza czy ktoś obecnie używa OCR
+     * Sprawdza czy DANY użytkownik ma już aktywną sesję OCR (nie blokuje innych użytkowników)
      */
-    isOCRActive(guildId) {
-        return this.activeProcessing.has(guildId);
+    isOCRActive(guildId, userId) {
+        const guildSessions = this.activeProcessing.get(guildId);
+        return !!(guildSessions && guildSessions.has(userId));
     }
 
     /**
-     * Pobiera info kto obecnie używa OCR
+     * Pobiera info o aktywnej sesji danego użytkownika
      */
-    getActiveOCRUser(guildId) {
-        return this.activeProcessing.get(guildId);
+    getActiveOCRUser(guildId, userId) {
+        const guildSessions = this.activeProcessing.get(guildId);
+        return guildSessions ? guildSessions.get(userId) : undefined;
     }
 
     /**
-     * Rozpoczyna sesję OCR dla użytkownika
+     * Pobiera listę wszystkich aktywnych sesji na serwerze (do wyświetlania w embedzie)
      */
+    getActiveSessions(guildId) {
+        const guildSessions = this.activeProcessing.get(guildId);
+        if (!guildSessions) return [];
+        return Array.from(guildSessions.entries()).map(([userId, session]) => ({ userId, ...session }));
+    }
+
     /**
      * Określa timeout dla sesji na podstawie komendy
      */
@@ -1895,15 +1805,14 @@ class OCRService {
         return 15 * 60 * 1000;
     }
 
+    /**
+     * Rozpoczyna sesję OCR dla użytkownika (równolegle z sesjami innych użytkowników)
+     */
     async startOCRSession(guildId, userId, commandName) {
-        // Usuń z kolejki jeśli tam jest
-        if (this.waitingQueue.has(guildId)) {
-            const queue = this.waitingQueue.get(guildId);
-            const index = queue.findIndex(item => item.userId === userId);
-            if (index !== -1) {
-                queue.splice(index, 1);
-            }
+        if (!this.activeProcessing.has(guildId)) {
+            this.activeProcessing.set(guildId, new Map());
         }
+        const guildSessions = this.activeProcessing.get(guildId);
 
         // Określ timeout na podstawie komendy
         const timeoutDuration = this.getSessionTimeout(commandName);
@@ -1911,15 +1820,15 @@ class OCRService {
 
         // Ustaw timeout który wywoła wygaśnięcie sesji
         const timeout = setTimeout(async () => {
-            logger.warn(`[OCR-QUEUE] ⏰ Sesja OCR wygasła dla ${userId} (${commandName})`);
+            logger.warn(`[OCR] ⏰ Sesja OCR wygasła dla ${userId} (${commandName})`);
             await this.expireOCRSession(guildId, userId);
         }, timeoutDuration);
 
-        this.activeProcessing.set(guildId, { userId, commandName, expiresAt, timeout });
+        guildSessions.set(userId, { commandName, expiresAt, timeout });
         const minutes = timeoutDuration / (60 * 1000);
-        logger.info(`[OCR-QUEUE] 🔒 Użytkownik ${userId} rozpoczął ${commandName} (timeout: ${minutes} min)`);
+        logger.info(`[OCR] 🔒 Użytkownik ${userId} rozpoczął ${commandName} (timeout: ${minutes} min, aktywnych sesji: ${guildSessions.size})`);
 
-        // Aktualizuj wyświetlanie kolejki
+        // Aktualizuj wyświetlanie aktywnych sesji
         await this.updateQueueDisplay(guildId);
     }
 
@@ -1927,9 +1836,10 @@ class OCRService {
      * Odnawia timeout sesji OCR (wywoływane przy każdym kliknięciu przycisku)
      */
     async refreshOCRSession(guildId, userId) {
-        const active = this.activeProcessing.get(guildId);
-        if (!active || active.userId !== userId) {
-            return; // Nie ta sesja lub sesja nie istnieje
+        const guildSessions = this.activeProcessing.get(guildId);
+        const active = guildSessions ? guildSessions.get(userId) : undefined;
+        if (!active) {
+            return; // Sesja nie istnieje
         }
 
         // Wyczyść stary timeout
@@ -1943,29 +1853,30 @@ class OCRService {
 
         // Ustaw nowy timeout
         const timeout = setTimeout(async () => {
-            logger.warn(`[OCR-QUEUE] ⏰ Sesja OCR wygasła dla ${userId} (${active.commandName})`);
+            logger.warn(`[OCR] ⏰ Sesja OCR wygasła dla ${userId} (${active.commandName})`);
             await this.expireOCRSession(guildId, userId);
         }, timeoutDuration);
 
         // Zaktualizuj sesję z nowym timeoutem
         active.expiresAt = expiresAt;
         active.timeout = timeout;
-        this.activeProcessing.set(guildId, active);
+        guildSessions.set(userId, active);
 
         const minutes = timeoutDuration / (60 * 1000);
-        logger.info(`[OCR-QUEUE] 🔄 Odświeżono timeout dla ${userId} (${active.commandName}, +${minutes} min)`);
+        logger.info(`[OCR] 🔄 Odświeżono timeout dla ${userId} (${active.commandName}, +${minutes} min)`);
 
-        // Aktualizuj wyświetlanie kolejki (odświeża timestamp w embedzie)
+        // Aktualizuj wyświetlanie aktywnych sesji (odświeża timestamp w embedzie)
         await this.updateQueueDisplay(guildId);
     }
 
     /**
-     * Kończy sesję OCR i powiadamia następną osobę w kolejce
+     * Kończy sesję OCR danego użytkownika (nie wpływa na sesje innych osób)
      */
     async endOCRSession(guildId, userId, immediate = false) {
-        const active = this.activeProcessing.get(guildId);
-        if (!active || active.userId !== userId) {
-            return; // Nie ten użytkownik
+        const guildSessions = this.activeProcessing.get(guildId);
+        const active = guildSessions ? guildSessions.get(userId) : undefined;
+        if (!active) {
+            return; // Sesja już zakończona
         }
 
         // Wyczyść timeout jeśli istnieje
@@ -1974,48 +1885,36 @@ class OCRService {
         }
 
         // Usuń z aktywnego przetwarzania NATYCHMIAST (zapobiega wielokrotnym kliknięciom)
-        this.activeProcessing.delete(guildId);
-        logger.info(`[OCR-QUEUE] 🔓 Użytkownik ${userId} zakończył OCR`);
+        guildSessions.delete(userId);
+        if (guildSessions.size === 0) {
+            this.activeProcessing.delete(guildId);
+        }
+        logger.info(`[OCR] 🔓 Użytkownik ${userId} zakończył OCR`);
 
         // Wyczyść osierocone pliki temp z processed_ocr/
         await cleanupOrphanedTempFiles(this.processedDir, 10 * 60 * 1000, logger);
 
-        // Opóźnienie przed czyszczeniem kanału i powiadomieniem następnej osoby
-        const delay = immediate ? 0 : 5000; // 5 sekund jeśli nie immediate
-
-        if (delay > 0) {
-            logger.info(`[OCR-QUEUE] ⏳ Oczekiwanie 5 sekund przed czyszczeniem kanału kolejki...`);
-            await new Promise(resolve => setTimeout(resolve, delay));
-            logger.info(`[OCR-QUEUE] 🧹 Czyszczenie kanału i powiadamianie kolejnej osoby...`);
-        }
-
-        // Wyczyść kanał kolejki (usuń wszystkie wiadomości oprócz pierwszej z embedem)
-        await Promise.all([
-            this.cleanupQueueChannelMessages(),
-            this.cleanupEquipmentChannelMessages()
-        ]);
-
-        // Aktualizuj wyświetlanie kolejki
+        // Aktualizuj wyświetlanie aktywnych sesji
         await this.updateQueueDisplay(guildId);
-
-        // Auto-start sesji dla następnej osoby w kolejce
-        await this.autoStartNextInQueue(guildId);
     }
 
     /**
-     * Wygasa aktywną sesję OCR (timeout 15 minut)
+     * Wygasa aktywną sesję OCR danego użytkownika (timeout)
      */
     async expireOCRSession(guildId, userId) {
-        const active = this.activeProcessing.get(guildId);
+        const guildSessions = this.activeProcessing.get(guildId);
+        const active = guildSessions ? guildSessions.get(userId) : undefined;
 
-        // Sprawdź czy to nadal ta sama sesja
-        if (!active || active.userId !== userId) {
-            return; // Sesja już zakończona lub inna osoba
+        if (!active) {
+            return; // Sesja już zakończona
         }
 
         // Usuń z aktywnego przetwarzania
-        this.activeProcessing.delete(guildId);
-        logger.info(`[OCR-QUEUE] ⏰ Sesja OCR wygasła i została usunięta dla ${userId}`);
+        guildSessions.delete(userId);
+        if (guildSessions.size === 0) {
+            this.activeProcessing.delete(guildId);
+        }
+        logger.info(`[OCR] ⏰ Sesja OCR wygasła i została usunięta dla ${userId}`);
 
         // Wyczyść osierocone pliki temp z processed_ocr/
         await cleanupOrphanedTempFiles(this.processedDir, 10 * 60 * 1000, logger);
@@ -2027,7 +1926,7 @@ class OCRService {
             if (reminderSession) {
                 stopGhostPing(reminderSession);
                 await this.reminderService.cleanupSession(reminderSession.sessionId);
-                logger.info(`[OCR-QUEUE] 🧹 Wyczyszczono sesję /remind dla ${userId} (timeout)`);
+                logger.info(`[OCR] 🧹 Wyczyszczono sesję /remind dla ${userId} (timeout)`);
             }
         }
 
@@ -2037,7 +1936,7 @@ class OCRService {
             if (punishSession) {
                 stopGhostPing(punishSession);
                 await this.punishmentService.cleanupSession(punishSession.sessionId);
-                logger.info(`[OCR-QUEUE] 🧹 Wyczyszczono sesję /punish dla ${userId} (timeout)`);
+                logger.info(`[OCR] 🧹 Wyczyszczono sesję /punish dla ${userId} (timeout)`);
             }
         }
 
@@ -2047,173 +1946,14 @@ class OCRService {
             if (phaseSession) {
                 stopGhostPing(phaseSession);
                 await this.phaseService.cleanupSession(phaseSession.sessionId);
-                logger.info(`[OCR-QUEUE] 🧹 Wyczyszczono sesję phase dla ${userId} (timeout)`);
+                logger.info(`[OCR] 🧹 Wyczyszczono sesję phase dla ${userId} (timeout)`);
             }
         }
 
-        logger.info(`[OCR-QUEUE] ⏰ Sesja OCR wygasła dla ${userId} (${active.commandName})`);
+        logger.info(`[OCR] ⏰ Sesja OCR wygasła dla ${userId} (${active.commandName})`);
 
-
-        // Wyczyść kanał kolejki
-        await Promise.all([
-            this.cleanupQueueChannelMessages(),
-            this.cleanupEquipmentChannelMessages()
-        ]);
-
-        // Aktualizuj wyświetlanie kolejki
+        // Aktualizuj wyświetlanie aktywnych sesji
         await this.updateQueueDisplay(guildId);
-
-        // Auto-start sesji dla następnej osoby w kolejce
-        await this.autoStartNextInQueue(guildId);
-    }
-
-    /**
-     * Sprawdza czy kolejka OCR jest pusta
-     */
-    isQueueEmpty(guildId) {
-        if (!this.waitingQueue.has(guildId)) {
-            return true;
-        }
-        const queue = this.waitingQueue.get(guildId);
-        return queue.length === 0;
-    }
-
-    /**
-     * Dodaje użytkownika do kolejki OCR
-     */
-    async addToOCRQueue(guildId, userId, commandName, interaction, autoStartFn) {
-        if (!this.waitingQueue.has(guildId)) {
-            this.waitingQueue.set(guildId, []);
-        }
-
-        const queue = this.waitingQueue.get(guildId);
-
-        // Sprawdź czy już jest w kolejce
-        if (queue.find(item => item.userId === userId)) {
-            return { position: queue.findIndex(item => item.userId === userId) + 1 };
-        }
-
-        queue.push({ userId, addedAt: Date.now(), commandName, interaction, autoStartFn });
-        const position = queue.length;
-
-        logger.info(`[OCR-QUEUE] ➕ ${userId} dodany do kolejki OCR (pozycja: ${position}, komenda: ${commandName})`);
-
-        // Aktualizuj wyświetlanie kolejki
-        await this.updateQueueDisplay(guildId);
-
-        return { position };
-    }
-
-    /**
-     * Automatycznie startuje sesję OCR dla następnej osoby w kolejce
-     */
-    async autoStartNextInQueue(guildId) {
-        if (!this.waitingQueue.has(guildId)) return;
-
-        const queue = this.waitingQueue.get(guildId);
-        if (queue.length === 0) {
-            this.waitingQueue.delete(guildId);
-            return;
-        }
-
-        const nextPerson = queue.shift();
-        if (queue.length === 0) {
-            this.waitingQueue.delete(guildId);
-        }
-
-        const { userId, commandName, interaction, autoStartFn } = nextPerson;
-        logger.info(`[OCR-QUEUE] 🚀 Auto-start sesji dla ${userId} (${commandName})`);
-
-
-
-        // Wyślij ghost ping na odpowiednim kanale
-        try {
-            const pingChannelId = commandName === 'Skanuj ekwipunek'
-                ? this.equipmentChannelId
-                : this.queueChannelId;
-            if (this.client && pingChannelId) {
-                const pingChannel = await this.client.channels.fetch(pingChannelId);
-                if (pingChannel) {
-                    await pingChannel.send(`<@${userId}> ✅ Twoja kolej! Sesja \`${commandName}\` została automatycznie uruchomiona.`);
-                }
-            }
-        } catch (error) {
-            logger.warn(`[OCR-QUEUE] ⚠️ Nie można wysłać ghost pinga: ${error.message}`);
-        }
-
-        // Wywołaj callback sesji
-        if (autoStartFn && interaction) {
-            try {
-                await autoStartFn(interaction);
-            } catch (error) {
-                logger.error(`[OCR-QUEUE] ❌ Błąd auto-start dla ${userId}:`, error.message);
-                await this.endOCRSession(guildId, userId, true);
-            }
-        }
-    }
-
-    /**
-     * Powiadamia użytkownika o pozycji w kolejce
-     */
-    async notifyQueuePosition(guildId, userId, position, commandName) {
-        try {
-            if (!this.client) return;
-
-            const queue = this.waitingQueue.get(guildId) || [];
-            const peopleAhead = queue.slice(0, position - 1);
-
-            let description = `Ktoś obecnie używa komendy OCR.\n\n`;
-            description += `📊 **Twoja pozycja w kolejce:** ${position}\n`;
-            description += `👥 **Łącznie osób w kolejce:** ${queue.length}\n\n`;
-
-            if (peopleAhead.length > 0) {
-                description += `⏳ **Osoby przed Tobą:**\n`;
-                for (let i = 0; i < peopleAhead.length; i++) {
-                    const person = peopleAhead[i];
-                    const member = await this.client.users.fetch(person.userId);
-                    description += `${i + 1}. ${member.tag} - \`${person.commandName}\`\n`;
-                }
-            }
-
-            description += `\n💡 **Dostaniesz powiadomienie gdy będzie Twoja kolej.**`;
-
-            const user = await this.client.users.fetch(userId);
-            await user.send({
-                embeds: [new EmbedBuilder()
-                    .setTitle('⏳ Jesteś w kolejce OCR')
-                    .setDescription(description)
-                    .setColor('#FFA500')
-                    .setTimestamp()
-                ]
-            });
-        } catch (error) {
-            logger.error(`[OCR-QUEUE] ❌ Błąd powiadomienia o kolejce:`, error.message);
-        }
-    }
-
-    /**
-     * Usuwa użytkownika z kolejki (anulowanie)
-     */
-    async removeFromOCRQueue(guildId, userId) {
-        // Usuń z kolejki
-        if (this.waitingQueue.has(guildId)) {
-            const queue = this.waitingQueue.get(guildId);
-            const index = queue.findIndex(item => item.userId === userId);
-            if (index !== -1) {
-                queue.splice(index, 1);
-                logger.info(`[OCR-QUEUE] ➖ Usunięto ${userId} z kolejki OCR`);
-
-                if (queue.length === 0) {
-                    this.waitingQueue.delete(guildId);
-                }
-
-                // Aktualizuj wyświetlanie kolejki
-                await this.updateQueueDisplay(guildId);
-                return true;
-            }
-        }
-
-        return false;
     }
 
 }

--- a/Stalker/services/phaseService.js
+++ b/Stalker/services/phaseService.js
@@ -16,322 +16,6 @@ class PhaseService {
         this.client = client;
         this.activeSessions = new Map(); // sessionId → session data
         this.tempDir = path.join(__dirname, '..', 'temp', 'phase1');
-        this.activeProcessing = new Map(); // guildId → userId (kto obecnie przetwarza)
-        this.waitingQueue = new Map(); // guildId → [{userId, addedAt}] (uporządkowana kolejka FIFO)
-        this.queueReservation = new Map(); // guildId → {userId, expiresAt, timeout} (rezerwacja dla pierwszej osoby)
-    }
-
-    /**
-     * Sprawdza czy ktoś obecnie przetwarza w danym guild
-     */
-    isProcessingActive(guildId) {
-        return this.activeProcessing.has(guildId);
-    }
-
-    /**
-     * Pobiera ID użytkownika który obecnie przetwarza
-     */
-    getActiveProcessor(guildId) {
-        return this.activeProcessing.get(guildId);
-    }
-
-    /**
-     * Ustawia aktywne przetwarzanie
-     */
-    setActiveProcessing(guildId, userId) {
-        this.activeProcessing.set(guildId, userId);
-        logger.info(`[PHASE1] 🔒 Użytkownik ${userId} zablokował przetwarzanie dla guild ${guildId}`);
-    }
-
-    /**
-     * Dodaje użytkownika do kolejki czekających
-     */
-    async addToWaitingQueue(guildId, userId) {
-        if (!this.waitingQueue.has(guildId)) {
-            this.waitingQueue.set(guildId, []);
-        }
-
-        const queue = this.waitingQueue.get(guildId);
-
-        // Sprawdź czy użytkownik już jest w kolejce
-        if (queue.find(item => item.userId === userId)) {
-            logger.warn(`[QUEUE] ⚠️ Użytkownik ${userId} jest już w kolejce dla guild ${guildId}`);
-            return;
-        }
-
-        queue.push({ userId, addedAt: Date.now() });
-        const position = queue.length;
-
-        logger.info(`[QUEUE] ➕ Użytkownik ${userId} dodany do kolejki (pozycja: ${position}) dla guild ${guildId}`);
-
-    }
-
-    /**
-     * Usuwa aktywne przetwarzanie i powiadamia czekających
-     */
-    async clearActiveProcessing(guildId) {
-        this.activeProcessing.delete(guildId);
-        logger.info(`[PHASE] 🔓 Odblokowano przetwarzanie dla guild ${guildId}`);
-
-        // Sprawdź czy są osoby w kolejce
-        if (this.waitingQueue.has(guildId)) {
-            const queue = this.waitingQueue.get(guildId);
-
-            if (queue.length > 0) {
-                // Pobierz pierwszą osobę z kolejki
-                const nextPerson = queue[0];
-                logger.info(`[QUEUE] 📢 Następna osoba w kolejce: ${nextPerson.userId}`);
-
-                // Stwórz rezerwację na 5 minut
-                await this.createQueueReservation(guildId, nextPerson.userId);
-
-                // Powiadom pozostałe osoby w kolejce o zmianie pozycji
-                for (let i = 1; i < queue.length; i++) {
-                    await this.notifyQueuePosition(guildId, queue[i].userId, i);
-                }
-            } else {
-                // Brak osób w kolejce - wyczyść
-                this.waitingQueue.delete(guildId);
-            }
-        }
-    }
-
-    /**
-     * Tworzy rezerwację dla pierwszej osoby w kolejce (5 min)
-     */
-    async createQueueReservation(guildId, userId) {
-        // Wyczyść poprzednią rezerwację jeśli istnieje
-        if (this.queueReservation.has(guildId)) {
-            const oldReservation = this.queueReservation.get(guildId);
-            if (oldReservation.timeout) {
-                clearTimeout(oldReservation.timeout);
-            }
-        }
-
-        const expiresAt = Date.now() + (3 * 60 * 1000); // 3 minuty
-
-        // Timeout który usuwa rezerwację i powiadamia następną osobę
-        const timeout = setTimeout(async () => {
-            logger.warn(`[QUEUE] ⏰ Rezerwacja wygasła dla użytkownika ${userId}`);
-            await this.expireReservation(guildId, userId);
-        }, 3 * 60 * 1000);
-
-        this.queueReservation.set(guildId, { userId, expiresAt, timeout });
-
-        // Powiadom użytkownika że może użyć komendy
-        try {
-            const user = await this.client.users.fetch(userId);
-            const expiryTimestamp = Math.floor(expiresAt / 1000);
-            await user.send({
-                embeds: [new EmbedBuilder()
-                    .setTitle('✅ Twoja kolej!')
-                    .setDescription(`Możesz teraz użyć komendy \`/faza1\` lub \`/faza2\`.\n\n⏱️ Masz czas do: <t:${expiryTimestamp}:R>\n\n⚠️ **Jeśli nie użyjesz komendy w ciągu 3 minut, Twoja kolej przepadnie.**`)
-                    .setColor('#00FF00')
-                    .setTimestamp()
-                ]
-            });
-            logger.info(`[QUEUE] ✅ Powiadomiono użytkownika ${userId} o jego kolejce`);
-        } catch (error) {
-            logger.error(`[QUEUE] ❌ Nie udało się powiadomić użytkownika ${userId}:`, error.message);
-        }
-    }
-
-    /**
-     * Wygasa rezerwację i przechodzi do następnej osoby
-     */
-    async expireReservation(guildId, userId) {
-        // Usuń rezerwację
-        this.queueReservation.delete(guildId);
-
-        // Usuń użytkownika z kolejki
-        if (this.waitingQueue.has(guildId)) {
-            const queue = this.waitingQueue.get(guildId);
-            const index = queue.findIndex(item => item.userId === userId);
-
-            if (index !== -1) {
-                queue.splice(index, 1);
-                logger.info(`[QUEUE] ➖ Użytkownik ${userId} usunięty z kolejki (timeout)`);
-
-                // Powiadom użytkownika że stracił kolejkę
-                try {
-                    const user = await this.client.users.fetch(userId);
-                    await user.send({
-                        embeds: [new EmbedBuilder()
-                            .setTitle('⏰ Czas minął')
-                            .setDescription('Nie użyłeś komendy w ciągu 3 minut. Twoja kolej przepadła.\n\nMożesz użyć komendy ponownie, aby dołączyć na koniec kolejki.')
-                            .setColor('#FF0000')
-                            .setTimestamp()
-                        ]
-                    });
-                } catch (error) {
-                    logger.error(`[QUEUE] ❌ Nie udało się powiadomić użytkownika ${userId} o wygaśnięciu:`, error.message);
-                }
-            }
-
-            // Powiadom następną osobę jeśli jest
-            if (queue.length > 0) {
-                const nextPerson = queue[0];
-                await this.createQueueReservation(guildId, nextPerson.userId);
-
-                // WYŁĄCZONE: Powiadamianie pozostałych osób o zmianie pozycji
-            } else {
-                this.waitingQueue.delete(guildId);
-            }
-        }
-    }
-
-    /**
-     * Powiadamia użytkownika o jego pozycji w kolejce
-     */
-    async notifyQueuePosition(guildId, userId, position) {
-        try {
-            const guild = await this.client.guilds.fetch(guildId);
-            const user = await this.client.users.fetch(userId);
-            const activeUserId = this.activeProcessing.get(guildId);
-
-            let description = `Twoja pozycja w kolejce: **${position}**\n\n`;
-
-            if (activeUserId) {
-                try {
-                    const activeMember = await guild.members.fetch(activeUserId);
-                    description += `🔒 Obecnie używa: **${activeMember.displayName}**\n`;
-                } catch (err) {
-                    description += `🔒 Obecnie system jest zajęty\n`;
-                }
-            }
-
-            // Dodaj informację o osobach przed użytkownikiem
-            if (this.waitingQueue.has(guildId)) {
-                const queue = this.waitingQueue.get(guildId);
-                const peopleAhead = queue.slice(0, position - 1);
-
-                if (peopleAhead.length > 0) {
-                    description += `\n👥 Przed Tobą w kolejce:\n`;
-                    for (let i = 0; i < Math.min(peopleAhead.length, 3); i++) {
-                        try {
-                            const personMember = await guild.members.fetch(peopleAhead[i].userId);
-                            description += `${i + 1}. **${personMember.displayName}**\n`;
-                        } catch (err) {
-                            description += `${i + 1}. *Użytkownik*\n`;
-                        }
-                    }
-
-                    if (peopleAhead.length > 3) {
-                        description += `... i ${peopleAhead.length - 3} innych\n`;
-                    }
-                }
-            }
-
-            description += `\n✅ Dostaniesz powiadomienie, gdy będzie Twoja kolej.`;
-
-            await user.send({
-                embeds: [new EmbedBuilder()
-                    .setTitle('📋 Jesteś w kolejce')
-                    .setDescription(description)
-                    .setColor('#FFA500')
-                    .setTimestamp()
-                ]
-            });
-
-            logger.info(`[QUEUE] 📬 Powiadomiono użytkownika ${userId} o pozycji ${position}`);
-        } catch (error) {
-            logger.error(`[QUEUE] ❌ Nie udało się powiadomić użytkownika ${userId} o pozycji:`, error.message);
-        }
-    }
-
-    /**
-     * Sprawdza czy użytkownik ma rezerwację
-     */
-    hasReservation(guildId, userId) {
-        if (!this.queueReservation.has(guildId)) {
-            return false;
-        }
-        const reservation = this.queueReservation.get(guildId);
-        return reservation.userId === userId && reservation.expiresAt > Date.now();
-    }
-
-    /**
-     * Pobiera informacje o kolejce dla użytkownika (do wyświetlenia w kanale)
-     */
-    async getQueueInfo(guildId, userId) {
-        const guild = await this.client.guilds.fetch(guildId);
-        const activeUserId = this.activeProcessing.get(guildId);
-        const queue = this.waitingQueue.get(guildId) || [];
-        const userIndex = queue.findIndex(item => item.userId === userId);
-        const position = userIndex + 1;
-
-        let description = '';
-
-        // Informacja o osobie obecnie używającej
-        if (activeUserId) {
-            try {
-                const activeMember = await guild.members.fetch(activeUserId);
-                description += `🔒 **Obecnie używa:** ${activeMember.displayName}\n\n`;
-            } catch (err) {
-                description += `🔒 **System jest obecnie zajęty**\n\n`;
-            }
-        }
-
-        // Pozycja użytkownika
-        description += `📋 **Twoja pozycja w kolejce:** ${position}\n`;
-        description += `👥 **Łącznie osób w kolejce:** ${queue.length}\n\n`;
-
-        // Lista osób przed użytkownikiem
-        const peopleAhead = queue.slice(0, userIndex);
-        if (peopleAhead.length > 0) {
-            description += `**Osoby przed Tobą:**\n`;
-            const displayLimit = Math.min(peopleAhead.length, 3);
-
-            for (let i = 0; i < displayLimit; i++) {
-                try {
-                    const personMember = await guild.members.fetch(peopleAhead[i].userId);
-                    description += `${i + 1}. ${personMember.displayName}\n`;
-                } catch (err) {
-                    description += `${i + 1}. *Użytkownik*\n`;
-                }
-            }
-
-            if (peopleAhead.length > 3) {
-                description += `... i ${peopleAhead.length - 3} innych\n`;
-            }
-            description += `\n`;
-        }
-
-        description += `✅ **Dostaniesz powiadomienie na priv** gdy będzie Twoja kolej.`;
-
-        return { description, position, queueLength: queue.length };
-    }
-
-    /**
-     * Usuwa użytkownika z kolejki po użyciu komendy
-     */
-    removeFromQueue(guildId, userId) {
-        // Wyczyść rezerwację
-        if (this.queueReservation.has(guildId)) {
-            const reservation = this.queueReservation.get(guildId);
-            if (reservation.userId === userId) {
-                if (reservation.timeout) {
-                    clearTimeout(reservation.timeout);
-                }
-                this.queueReservation.delete(guildId);
-                logger.info(`[QUEUE] ✅ Usunięto rezerwację dla użytkownika ${userId}`);
-            }
-        }
-
-        // Usuń z kolejki
-        if (this.waitingQueue.has(guildId)) {
-            const queue = this.waitingQueue.get(guildId);
-            const index = queue.findIndex(item => item.userId === userId);
-
-            if (index !== -1) {
-                queue.splice(index, 1);
-                logger.info(`[QUEUE] ➖ Użytkownik ${userId} usunięty z kolejki (rozpoczął używanie)`);
-            }
-
-            if (queue.length === 0) {
-                this.waitingQueue.delete(guildId);
-            }
-        }
     }
 
     /**
@@ -402,7 +86,7 @@ class PhaseService {
             roleNicksSnapshotPath: null, // ścieżka do snapshotu nicków z roli
             isProcessing: false, // flaga czy aktualnie przetwarza zdjęcia (blokuje anulowanie)
             cancelled: false, // flaga czy sesja została anulowana (do sprawdzania w pętli)
-            ocrExpiresAt // timestamp wygaśnięcia sesji OCR (z kolejki OCR)
+            ocrExpiresAt // timestamp wygaśnięcia sesji OCR
         };
 
         this.activeSessions.set(sessionId, session);
@@ -539,13 +223,10 @@ class PhaseService {
             session.downloadedFiles = null;
         }
 
-        // Odblokuj przetwarzanie dla tego guild (ghost ping queue)
-        await this.clearActiveProcessing(session.guildId);
-
-        // KRYTYCZNE: Zakończ sesję OCR w kolejce (zapobiega deadlockowi)
+        // Zakończ sesję OCR (nie wpływa na sesje innych użytkowników)
         if (this.ocrService && session.guildId && session.userId) {
             await this.ocrService.endOCRSession(session.guildId, session.userId, true);
-            logger.info(`[PHASE${session.phase || 1}] 🔓 Zwolniono kolejkę OCR dla użytkownika ${session.userId}`);
+            logger.info(`[PHASE${session.phase || 1}] 🔓 Zakończono sesję OCR dla użytkownika ${session.userId}`);
         }
 
         // Usuń sesję z mapy
@@ -1206,9 +887,9 @@ class PhaseService {
                 if (editError.code === 10008 || editError.message?.includes('Unknown Message')) {
                     logger.warn('[PHASE] ⚠️ Wiadomość postępu usunięta - kontynuuję przetwarzanie bez aktualizacji postępu');
                     // Nie przerywaj - index.js wyśle nową wiadomość po zakończeniu
-                // Interakcja wygasła - anuluj sesję i odblokuj kolejkę
+                // Interakcja wygasła - anuluj sesję
                 } else if (editError.code === 10015 || editError.message?.includes('Unknown Webhook') || editError.message?.includes('Invalid Webhook Token')) {
-                    logger.warn('[PHASE] ⏰ Interakcja wygasła, anuluję sesję i odblokowuję kolejkę');
+                    logger.warn('[PHASE] ⏰ Interakcja wygasła, anuluję sesję');
 
                     // Wyślij informację do kanału
                     try {
@@ -1227,9 +908,8 @@ class PhaseService {
                         logger.error('[PHASE] Nie udało się wysłać informacji o wygaśnięciu sesji:', channelError.message);
                     }
 
-                    // Wyczyść sesję i odblokuj przetwarzanie
+                    // Wyczyść sesję
                     await this.cleanupSession(session.sessionId);
-                    this.clearActiveProcessing(session.guildId);
 
                     return; // Przerwij przetwarzanie
                 } else {

--- a/Stalker/services/punishmentService.js
+++ b/Stalker/services/punishmentService.js
@@ -358,7 +358,7 @@ class PunishmentService {
             createdAt: Date.now(),
             timeout: null,
             publicInteraction: null,
-            ocrExpiresAt // timestamp wygaśnięcia sesji OCR (z kolejki OCR)
+            ocrExpiresAt // timestamp wygaśnięcia sesji OCR
         };
 
         this.activeSessions.set(sessionId, session);
@@ -434,7 +434,7 @@ class PunishmentService {
         // KRYTYCZNE: Zakończ sesję OCR w kolejce (zapobiega deadlockowi)
         if (this.ocrService && session.guildId && session.userId) {
             await this.ocrService.endOCRSession(session.guildId, session.userId, true);
-            logger.info(`[PUNISH] 🔓 Zwolniono kolejkę OCR dla użytkownika ${session.userId}`);
+            logger.info(`[PUNISH] 🔓 Zakończono sesję OCR dla użytkownika ${session.userId}`);
         }
 
         this.activeSessions.delete(sessionId);

--- a/Stalker/services/reminderService.js
+++ b/Stalker/services/reminderService.js
@@ -328,7 +328,7 @@ class ReminderService {
             publicInteraction: null,
             isProcessing: false, // flaga czy aktualnie przetwarza zdjęcia
             cancelled: false, // flaga czy sesja została anulowana
-            ocrExpiresAt // timestamp wygaśnięcia sesji OCR (z kolejki OCR)
+            ocrExpiresAt // timestamp wygaśnięcia sesji OCR
         };
 
         this.activeSessions.set(sessionId, session);
@@ -411,7 +411,7 @@ class ReminderService {
         // KRYTYCZNE: Zakończ sesję OCR w kolejce (zapobiega deadlockowi)
         if (this.ocrService && session.guildId && session.userId) {
             await this.ocrService.endOCRSession(session.guildId, session.userId, true);
-            logger.info(`[REMIND] 🔓 Zwolniono kolejkę OCR dla użytkownika ${session.userId}`);
+            logger.info(`[REMIND] 🔓 Zakończono sesję OCR dla użytkownika ${session.userId}`);
         }
 
         this.activeSessions.delete(sessionId);


### PR DESCRIPTION
## Summary
- Usunięto globalną kolejkę OCR w Stalkerze (`waitingQueue` per guild) - teraz wiele osób może jednocześnie korzystać z `/punish`, `/remind`, `/faza1`, `/faza2` i "Skanuj ekwipunek" bez czekania na siebie nawzajem.
- Limit pozostaje wyłącznie per-użytkownik: jedna aktywna sesja OCR na osobę naraz (`isOCRActive(guildId, userId)`), reszta logiki (timeouty, ghost pingi, sesje `punish`/`remind`/`faza`) działa bez zmian, bo już wcześniej była per-user.
- Embed panelu OCR na obu kanałach (`Faza1/Faza2/Remind/Punish` oraz "Skanuj ekwipunek") pokazuje teraz listę **aktywnych sesji** (kto, jaka komenda, kiedy wygasa) zamiast pozycji w kolejce.
- Przycisk "Wyjdź z kolejki" zamieniony na "❌ Anuluj moją sesję" - kończy wyłącznie sesję wywołującego.
- Usunięto bulk-czyszczenie kanału po zakończeniu sesji (bezpieczne tylko przy jednej sesji na raz; przy równoległych sesjach kasowałoby wiadomości innych użytkowników).
- Usunięto martwy, niewykorzystywany legacy system kolejkowania w `phaseService.js` (osobny, niepodłączony `activeProcessing`/`waitingQueue`/`queueReservation`).
- Zaktualizowano `Stalker/CLAUDE.md`.

## Test plan
- [x] `node -c` na wszystkich zmienionych plikach JS w `Stalker/`
- [x] Statyczny przegląd wszystkich miejsc wywołań usuniętych metod (`addToOCRQueue`, `isQueueEmpty`, `autoStartNextInQueue`, `notifyQueuePosition`, `removeFromOCRQueue`) - brak pozostałości
- [ ] Manualny test na serwerze produkcyjnym: dwie różne osoby uruchamiają `/punish` i `/remind` jednocześnie i obie kończą sesje niezależnie


---
_Generated by [Claude Code](https://claude.ai/code/session_01TtyBXNy8Bc2gAHKX95NHxD)_