### PR TITLE
Naprawa crashu botów po starcie - override undici

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -173,6 +173,15 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@discordjs/rest/node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/@discordjs/util": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
@@ -1903,6 +1912,15 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cheerio/node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/chromium-bidi": {
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-16.0.1.tgz",
@@ -2241,6 +2259,15 @@
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/discord.js/node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/dom-serializer": {
@@ -4078,15 +4105,6 @@
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
       "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
       "license": "MIT"
-    },
-    "node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
-      }
     },
     "node_modules/undici-types": {
       "version": "7.8.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/Thashar/Test#readme",
   "overrides": {
-    "undici": ">=7.0.0"
+    "undici": "^6.27.0"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",


### PR DESCRIPTION
## Summary
- Po ostatnim mergu commit `7825d18` ("Naprawa 40 vulnerabilities npm") dodał `overrides: { "undici": ">=7.0.0" }`, co wymuszało globalnie undici 8.5.0 w całym drzewie zależności.
- `@discordjs/rest` (używany przez discord.js 14.25.1) wewnętrznie deklaruje zależność od `undici@6.24.1` - wymuszona wersja 8.x była niekompatybilna i powodowała crash wszystkich botów przy starcie: `TypeError: Headers constructor: Key Symbol(sensitiveHeaders) in init is a symbol, which cannot be converted to a ByteString`.
- Naprawa: zawężono override do `^6.27.0` - najnowszej łatanej wersji w tej samej głównej linii 6.x co oczekuje discord.js, więc żadna niezgodność wersji nie występuje, a `npm audit` nadal pokazuje 0 vulnerabilities.
- `npm install` potwierdza spójne, zgodne wersje undici (6.27.0) w podzależnościach `@discordjs/rest`, `discord.js` i `cheerio`.

## Test plan
- [x] `npm install` - 0 vulnerabilities
- [x] Weryfikacja drzewa zależności (`package-lock.json`) - brak zduplikowanych/niezgodnych wersji `undici`
- [x] `node -e` - konstrukcja `@discordjs/rest` REST client oraz `discord.js` `Client` bez błędów
- [ ] Manualny restart botów na serwerze produkcyjnym

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtyBXNy8Bc2gAHKX95NHxD)_