### PR TITLE
Dedykowane wątki dla sesji OCR + zawężenie auto-usuwania wiadomości

### DIFF
--- a/Stalker/handlers/interactionHandlers.js
+++ b/Stalker/handlers/interactionHandlers.js
@@ -20,6 +20,23 @@ function setSessionOwnerAuthor(embed, member, user) {
     });
 }
 
+/**
+ * Tworzy dedykowany wątek dla sesji OCR - cała analiza (zdjęcia, postęp, potwierdzenia)
+ * odbywa się w tym wątku, izolowana od innych równoległych sesji na tym samym kanale.
+ * Wątek jest usuwany automatycznie przez ocrService po zakończeniu sesji.
+ */
+async function createSessionThread(inter, ocrService, guildId, userId, threadTitle) {
+    const placeholderMessage = await inter.editReply({
+        content: '🧵 Sesja OCR rozpoczęta - kontynuuj w wątku poniżej.'
+    });
+    const thread = await placeholderMessage.startThread({
+        name: threadTitle,
+        autoArchiveDuration: 60
+    });
+    ocrService.setSessionThreadId(guildId, userId, thread.id);
+    return thread;
+}
+
 async function handleInteraction(interaction, sharedState, config) {
     const { client, databaseService, ocrService, punishmentService, reminderService, phaseService } = sharedState;
 
@@ -219,21 +236,25 @@ async function handlePunishCommand(interaction, config, ocrService, punishmentSe
             const activeOCR = ocrService.getActiveOCRUser(guildId, userId);
             const ocrExpiresAt = activeOCR ? activeOCR.expiresAt : null;
 
-            // Utwórz sesję punishment
-            const sessionId = punishmentService.createSession(userId, guildId, inter.channelId, ocrExpiresAt);
-            const session = punishmentService.getSession(sessionId);
-            session.publicInteraction = inter;
+            // Utwórz dedykowany wątek dla tej sesji
+            const memberName = inter.member?.displayName || inter.user.username;
+            const thread = await createSessionThread(inter, ocrService, guildId, userId, `💀 Punish - ${memberName}`);
 
-            // Pokaż embed z prośbą o zdjęcia
+            // Utwórz sesję punishment (w wątku)
+            const sessionId = punishmentService.createSession(userId, guildId, thread.id, ocrExpiresAt);
+            const session = punishmentService.getSession(sessionId);
+
+            // Pokaż embed z prośbą o zdjęcia (w wątku)
             const awaitingEmbed = punishmentService.createAwaitingImagesEmbed();
             setSessionOwnerAuthor(awaitingEmbed.embed, inter.member, inter.user);
-            const replyMessage = await inter.editReply({
+            const awaitingMessage = await thread.send({
                 embeds: [awaitingEmbed.embed],
                 components: [awaitingEmbed.row]
             });
-            ocrService.setSessionMessageId(guildId, userId, replyMessage.id);
+            session.publicInteraction = awaitingMessage;
+            ocrService.setSessionMessageId(guildId, userId, awaitingMessage.id);
 
-            logger.info(`[PUNISH] ✅ Sesja utworzona, czekam na zdjęcia od ${inter.user.tag}`);
+            logger.info(`[PUNISH] ✅ Sesja utworzona (wątek: ${thread.id}), czekam na zdjęcia od ${inter.user.tag}`);
         };
 
         await runSession(interaction);
@@ -312,21 +333,25 @@ async function handleRemindCommand(interaction, config, ocrService, reminderServ
             const activeOCR = ocrService.getActiveOCRUser(guildId, userId);
             const ocrExpiresAt = activeOCR ? activeOCR.expiresAt : null;
 
-            // Utwórz sesję przypomnienia
-            const sessionId = reminderService.createSession(userId, guildId, inter.channelId, userClanRoleId, ocrExpiresAt);
-            const session = reminderService.getSession(sessionId);
-            session.publicInteraction = inter;
+            // Utwórz dedykowany wątek dla tej sesji
+            const memberName = inter.member?.displayName || inter.user.username;
+            const thread = await createSessionThread(inter, ocrService, guildId, userId, `📢 Remind - ${memberName}`);
 
-            // Pokaż embed z prośbą o zdjęcia
+            // Utwórz sesję przypomnienia (w wątku)
+            const sessionId = reminderService.createSession(userId, guildId, thread.id, userClanRoleId, ocrExpiresAt);
+            const session = reminderService.getSession(sessionId);
+
+            // Pokaż embed z prośbą o zdjęcia (w wątku)
             const awaitingEmbed = reminderService.createAwaitingImagesEmbed();
             setSessionOwnerAuthor(awaitingEmbed.embed, inter.member, inter.user);
-            const replyMessage = await inter.editReply({
+            const awaitingMessage = await thread.send({
                 embeds: [awaitingEmbed.embed],
                 components: [awaitingEmbed.row]
             });
-            ocrService.setSessionMessageId(guildId, userId, replyMessage.id);
+            session.publicInteraction = awaitingMessage;
+            ocrService.setSessionMessageId(guildId, userId, awaitingMessage.id);
 
-            logger.info(`[REMIND] ✅ Sesja utworzona, czekam na zdjęcia od ${inter.user.tag}`);
+            logger.info(`[REMIND] ✅ Sesja utworzona (wątek: ${thread.id}), czekam na zdjęcia od ${inter.user.tag}`);
         };
 
         await runSession(interaction);
@@ -3698,6 +3723,10 @@ async function handlePhase1Command(interaction, sharedState) {
             const activeOCR = ocrService.getActiveOCRUser(guildId, userId);
             const ocrExpiresAt = activeOCR ? activeOCR.expiresAt : null;
 
+            // Utwórz dedykowany wątek dla tej sesji
+            const memberName = inter.member?.displayName || inter.user.username;
+            const thread = await createSessionThread(inter, ocrService, guildId, userId, `📊 Faza 1 - ${memberName}`);
+
             // Sprawdź czy dane dla tego tygodnia i klanu już istnieją
             const weekInfo = phaseService.getCurrentWeekInfo();
             const existingData = await databaseService.checkPhase1DataExists(
@@ -3708,7 +3737,7 @@ async function handlePhase1Command(interaction, sharedState) {
             );
 
             if (existingData.exists) {
-                // Pokaż ostrzeżenie z przyciskami
+                // Pokaż ostrzeżenie z przyciskami (w wątku)
                 const warningEmbed = await phaseService.createOverwriteWarningEmbed(
                     inter.guild.id,
                     weekInfo,
@@ -3719,38 +3748,38 @@ async function handlePhase1Command(interaction, sharedState) {
 
                 if (warningEmbed) {
                     setSessionOwnerAuthor(warningEmbed.embed, inter.member, inter.user);
-                    const replyMessage = await inter.editReply({
+                    const warningMessage = await thread.send({
                         embeds: [warningEmbed.embed],
                         components: [warningEmbed.row]
                     });
-                    ocrService.setSessionMessageId(guildId, userId, replyMessage.id);
+                    ocrService.setSessionMessageId(guildId, userId, warningMessage.id);
                     return;
                 }
             }
 
-            // Utwórz sesję
+            // Utwórz sesję (w wątku)
             const sessionId = phaseService.createSession(
                 inter.user.id,
                 inter.guild.id,
-                inter.channelId,
+                thread.id,
                 1, // phase
                 ocrExpiresAt // timestamp OCR
             );
 
             const session = phaseService.getSession(sessionId);
-            session.publicInteraction = inter;
             session.clan = userClan;
 
-            // Pokaż embed z prośbą o zdjęcia (PUBLICZNY)
+            // Pokaż embed z prośbą o zdjęcia (w wątku)
             const awaitingEmbed = phaseService.createAwaitingImagesEmbed();
             setSessionOwnerAuthor(awaitingEmbed.embed, inter.member, inter.user);
-            const replyMessage = await inter.editReply({
+            const awaitingMessage = await thread.send({
                 embeds: [awaitingEmbed.embed],
                 components: [awaitingEmbed.row]
             });
-            ocrService.setSessionMessageId(guildId, userId, replyMessage.id);
+            session.publicInteraction = awaitingMessage;
+            ocrService.setSessionMessageId(guildId, userId, awaitingMessage.id);
 
-            logger.info(`[PHASE1] ✅ Sesja utworzona, czekam na zdjęcia od ${inter.user.tag}`);
+            logger.info(`[PHASE1] ✅ Sesja utworzona (wątek: ${thread.id}), czekam na zdjęcia od ${inter.user.tag}`);
         };
 
         await runSession(interaction);
@@ -4399,6 +4428,10 @@ async function handlePhase2Command(interaction, sharedState) {
             const activeOCR = ocrService.getActiveOCRUser(guildId, userId);
             const ocrExpiresAt = activeOCR ? activeOCR.expiresAt : null;
 
+            // Utwórz dedykowany wątek dla tej sesji
+            const memberName = inter.member?.displayName || inter.user.username;
+            const thread = await createSessionThread(inter, ocrService, guildId, userId, `📈 Faza 2 - ${memberName}`);
+
             // Sprawdź czy dane dla tego tygodnia i klanu już istnieją
             const weekInfo = phaseService.getCurrentWeekInfo();
             const existingData = await databaseService.checkPhase2DataExists(
@@ -4409,7 +4442,7 @@ async function handlePhase2Command(interaction, sharedState) {
             );
 
             if (existingData.exists) {
-                // Pokaż ostrzeżenie z przyciskami
+                // Pokaż ostrzeżenie z przyciskami (w wątku)
                 const warningEmbed = await phaseService.createOverwriteWarningEmbed(
                     inter.guild.id,
                     weekInfo,
@@ -4420,38 +4453,38 @@ async function handlePhase2Command(interaction, sharedState) {
 
                 if (warningEmbed) {
                     setSessionOwnerAuthor(warningEmbed.embed, inter.member, inter.user);
-                    const replyMessage = await inter.editReply({
+                    const warningMessage = await thread.send({
                         embeds: [warningEmbed.embed],
                         components: [warningEmbed.row]
                     });
-                    ocrService.setSessionMessageId(guildId, userId, replyMessage.id);
+                    ocrService.setSessionMessageId(guildId, userId, warningMessage.id);
                     return;
                 }
             }
 
-            // Utwórz sesję dla fazy 2
+            // Utwórz sesję dla fazy 2 (w wątku)
             const sessionId = phaseService.createSession(
                 inter.user.id,
                 inter.guild.id,
-                inter.channelId,
+                thread.id,
                 2, // phase 2
                 ocrExpiresAt // timestamp OCR
             );
 
             const session = phaseService.getSession(sessionId);
-            session.publicInteraction = inter;
             session.clan = userClan;
 
-            // Pokaż embed z prośbą o zdjęcia dla rundy 1 (PUBLICZNY)
+            // Pokaż embed z prośbą o zdjęcia dla rundy 1 (w wątku)
             const awaitingEmbed = phaseService.createAwaitingImagesEmbed(2, 1);
             setSessionOwnerAuthor(awaitingEmbed.embed, inter.member, inter.user);
-            const replyMessage = await inter.editReply({
+            const awaitingMessage = await thread.send({
                 embeds: [awaitingEmbed.embed],
                 components: [awaitingEmbed.row]
             });
-            ocrService.setSessionMessageId(guildId, userId, replyMessage.id);
+            session.publicInteraction = awaitingMessage;
+            ocrService.setSessionMessageId(guildId, userId, awaitingMessage.id);
 
-            logger.info(`[PHASE2] ✅ Sesja utworzona, czekam na zdjęcia z rundy 1/3 od ${inter.user.tag}`);
+            logger.info(`[PHASE2] ✅ Sesja utworzona (wątek: ${thread.id}), czekam na zdjęcia z rundy 1/3 od ${inter.user.tag}`);
         };
 
         await runSession(interaction);

--- a/Stalker/index.js
+++ b/Stalker/index.js
@@ -993,18 +993,23 @@ client.on(Events.MessageCreate, async (message) => {
         }
     }
 
-    // Automatyczne czyszczenie kanału panelu OCR - usuń wszystkie wiadomości od użytkowników
+    // Automatyczne czyszczenie kanału panelu OCR - usuń tylko wiadomości od osób z AKTYWNĄ sesją OCR.
+    // Kilka osób może mieć równoległe sesje na tym samym kanale - nie wolno usuwać wiadomości
+    // przypadkowych osób bez aktywnej sesji (np. wiadomość niezwiązana z żadną sesją).
     const queueChannelId = '1437122516974829679';
     if (message.channelId === queueChannelId && !message.author.bot) {
-        try {
-            await message.delete();
-            logger.info(`[QUEUE-CLEANUP] 🧹 Usunięto wiadomość od ${message.author.tag} z kanału panelu OCR`);
-        } catch (error) {
-            // Ignoruj błąd Unknown Message (10008) - wiadomość została już usunięta przez inny proces
-            if (error.code === 10008) {
-                return;
+        const hasActiveSession = ocrService.isOCRActive(message.guild.id, message.author.id);
+        if (hasActiveSession) {
+            try {
+                await message.delete();
+                logger.info(`[QUEUE-CLEANUP] 🧹 Usunięto wiadomość od ${message.author.tag} z kanału panelu OCR (aktywna sesja)`);
+            } catch (error) {
+                // Ignoruj błąd Unknown Message (10008) - wiadomość została już usunięta przez inny proces
+                if (error.code === 10008) {
+                    return;
+                }
+                logger.error(`[QUEUE-CLEANUP] ❌ Błąd usuwania wiadomości: ${error.message}`);
             }
-            logger.error(`[QUEUE-CLEANUP] ❌ Błąd usuwania wiadomości: ${error.message}`);
         }
     }
 });

--- a/Stalker/services/ocrService.js
+++ b/Stalker/services/ocrService.js
@@ -1311,11 +1311,12 @@ class OCRService {
                 const guild = await this.client.guilds.fetch(guildId);
                 for (const session of sessions) {
                     const expiryTimestamp = Math.floor(session.expiresAt / 1000);
+                    const threadLink = session.threadId ? ` — <#${session.threadId}>` : '';
                     try {
                         const member = await guild.members.fetch(session.userId);
-                        description += `${member.displayName} - \`${session.commandName}\` (wygasa <t:${expiryTimestamp}:R>)\n`;
+                        description += `${member.displayName} - \`${session.commandName}\`${threadLink} (wygasa <t:${expiryTimestamp}:R>)\n`;
                     } catch (error) {
-                        description += `Użytkownik ${session.userId} - \`${session.commandName}\` (wygasa <t:${expiryTimestamp}:R>)\n`;
+                        description += `Użytkownik ${session.userId} - \`${session.commandName}\`${threadLink} (wygasa <t:${expiryTimestamp}:R>)\n`;
                     }
                 }
             } catch (error) {
@@ -1798,6 +1799,37 @@ class OCRService {
     }
 
     /**
+     * Zapisuje ID dedykowanego wątku sesji użytkownika (każda sesja OCR ma własny wątek).
+     */
+    setSessionThreadId(guildId, userId, threadId) {
+        const guildSessions = this.activeProcessing.get(guildId);
+        const active = guildSessions ? guildSessions.get(userId) : undefined;
+        if (active) {
+            active.threadId = threadId;
+        }
+    }
+
+    /**
+     * Usuwa wątek sesji po krótkim opóźnieniu (żeby użytkownik zdążył zobaczyć finalną wiadomość).
+     */
+    deleteSessionThread(threadId, delayMs = 10000) {
+        if (!threadId) return;
+        setTimeout(async () => {
+            try {
+                if (!this.client) return;
+                const thread = await this.client.channels.fetch(threadId).catch(() => null);
+                if (thread) {
+                    await thread.delete();
+                    logger.info(`[OCR] 🗑️ Usunięto wątek sesji: ${threadId}`);
+                }
+            } catch (error) {
+                // Ignoruj - wątek mógł już zostać usunięty
+                logger.warn(`[OCR] ⚠️ Nie udało się usunąć wątku ${threadId}: ${error.message}`);
+            }
+        }, delayMs);
+    }
+
+    /**
      * Pobiera listę wszystkich aktywnych sesji na serwerze (do wyświetlania w embedzie)
      */
     getActiveSessions(guildId) {
@@ -1904,6 +1936,9 @@ class OCRService {
         }
         logger.info(`[OCR] 🔓 Użytkownik ${userId} zakończył OCR`);
 
+        // Usuń wątek sesji (z opóźnieniem, żeby użytkownik zdążył zobaczyć finalną wiadomość)
+        this.deleteSessionThread(active.threadId, immediate ? 5000 : 10000);
+
         // Wyczyść osierocone pliki temp z processed_ocr/
         await cleanupOrphanedTempFiles(this.processedDir, 10 * 60 * 1000, logger);
 
@@ -1928,6 +1963,9 @@ class OCRService {
             this.activeProcessing.delete(guildId);
         }
         logger.info(`[OCR] ⏰ Sesja OCR wygasła i została usunięta dla ${userId}`);
+
+        // Usuń wątek sesji (z opóźnieniem, żeby użytkownik zdążył zobaczyć wiadomość o wygaśnięciu)
+        this.deleteSessionThread(active.threadId, 8000);
 
         // Wyczyść osierocone pliki temp z processed_ocr/
         await cleanupOrphanedTempFiles(this.processedDir, 10 * 60 * 1000, logger);


### PR DESCRIPTION
## Summary
Architektoniczne rozwiązanie problemów z izolacją równoległych sesji OCR na wspólnym kanale panelu:

- **Dedykowany wątek per sesja:** `/punish`, `/remind`, `/faza1`, `/faza2` tworzą teraz osobny wątek Discorda (np. "💀 Punish - Kowalski") zaraz po starcie. Cała analiza (prośba o zdjęcia, postęp OCR, potwierdzenia, rozwiązywanie konfliktów, decyzje o urlopowiczach, finalne zatwierdzenie) odbywa się wewnątrz tego wątku — nazwa wątku od razu pokazuje, czyja to sesja, więc nie trzeba już zgadywać "czyj jest ten embed" przy kilku równoległych sesjach na tym samym kanale.
- **Automatyczne usuwanie wątku po zakończeniu sesji** (sukces, anulowanie lub wygaśnięcie) — z krótkim opóźnieniem (5-10s), żeby użytkownik zdążył przeczytać finalną wiadomość. Eliminuje to całą klasę problemów z "wiedzeniem które wiadomości usunąć" — usuwany jest cały wątek naraz, nigdy wiadomości innej sesji.
- Panel OCR (lista aktywnych sesji) pokazuje teraz link do wątku każdej sesji.
- Zawężono automatyczne czyszczenie wiadomości na głównym kanale panelu OCR — usuwane są tylko wiadomości od osób z faktycznie aktywną sesją (wcześniej usuwana była każda ludzka wiadomość na tym kanale, niezależnie od kontekstu).

### Szczegóły implementacji
- `ocrService.setSessionThreadId()` / `deleteSessionThread()` - śledzenie i czyszczenie wątku per sesja.
- `createSessionThread()` w `interactionHandlers.js` - tworzy wątek z pierwszej odpowiedzi na komendę.
- Istniejący mechanizm `session.publicInteraction` (obsługujący zarówno `Interaction` jak i `Message`) pozwolił bezproblemowo przekierować wszystkie kolejne aktualizacje (postęp, rundy Fazy 2, finalne podsumowanie) do wiadomości w wątku bez zmian w logice biznesowej.
- Zdjęcia przesyłane przez użytkownika są teraz oczekiwane w wątku (`session.channelId` = ID wątku) - dopasowanie w `index.js` działa bez zmian, bo już wcześniej opierało się na `session.channelId === message.channelId`.

### Wymagania na Discordzie
Bot potrzebuje uprawnień **"Create Public Threads"** i **"Send Messages in Threads"** na kanale panelu OCR (`1437122516974829679`).

## Test plan
- [x] `node -c` na wszystkich zmienionych plikach
- [x] Przegląd wszystkich miejsc korzystających z `session.channelId` / `session.publicInteraction` (rundy Fazy 2, finalne podsumowanie, ghost pingi) - potwierdzono że działają bez zmian dzięki istniejącemu wzorcowi Message/Interaction
- [ ] Manualny test na serwerze: `/punish` tworzy wątek, zdjęcia są poprawnie przetwarzane w wątku, wątek znika po zakończeniu

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtyBXNy8Bc2gAHKX95NHxD)_