### PR TITLE
Usunięto publiczną wiadomość przy tworzeniu wątku sesji OCR

### DIFF
--- a/Stalker/handlers/interactionHandlers.js
+++ b/Stalker/handlers/interactionHandlers.js
@@ -23,15 +23,14 @@ function setSessionOwnerAuthor(embed, member, user) {
 /**
  * Tworzy dedykowany wątek dla sesji OCR - cała analiza (zdjęcia, postęp, potwierdzenia)
  * odbywa się w tym wątku, izolowana od innych równoległych sesji na tym samym kanale.
+ * Wątek tworzony jest bez wiadomości startowej (nie zaśmieca głównego kanału).
  * Wątek jest usuwany automatycznie przez ocrService po zakończeniu sesji.
  */
 async function createSessionThread(inter, ocrService, guildId, userId, threadTitle) {
-    const placeholderMessage = await inter.editReply({
-        content: '🧵 Sesja OCR rozpoczęta - kontynuuj w wątku poniżej.'
-    });
-    const thread = await placeholderMessage.startThread({
+    const thread = await inter.channel.threads.create({
         name: threadTitle,
-        autoArchiveDuration: 60
+        autoArchiveDuration: 60,
+        reason: `Sesja OCR: ${threadTitle}`
     });
     ocrService.setSessionThreadId(guildId, userId, thread.id);
     return thread;
@@ -219,7 +218,8 @@ async function handlePunishCommand(interaction, config, ocrService, punishmentSe
         // Sprawdź czy TEN użytkownik ma już aktywną sesję OCR (inni mogą działać równolegle)
         const isOCRActive = ocrService.isOCRActive(guildId, userId);
 
-        await interaction.deferReply({ ephemeral: false });
+        // Ephemeral - widoczne tylko dla wywołującego, żeby nie zaśmiecać głównego kanału
+        await interaction.deferReply({ ephemeral: true });
 
         if (isOCRActive) {
             await interaction.editReply({
@@ -254,6 +254,9 @@ async function handlePunishCommand(interaction, config, ocrService, punishmentSe
             session.publicInteraction = awaitingMessage;
             ocrService.setSessionMessageId(guildId, userId, awaitingMessage.id);
 
+            // Potwierdzenie ephemeralne dla wywołującego
+            await inter.editReply({ content: `✅ Sesja rozpoczęta w wątku: <#${thread.id}>` });
+
             logger.info(`[PUNISH] ✅ Sesja utworzona (wątek: ${thread.id}), czekam na zdjęcia od ${inter.user.tag}`);
         };
 
@@ -282,7 +285,8 @@ async function handleRemindCommand(interaction, config, ocrService, reminderServ
         // Sprawdź czy TEN użytkownik ma już aktywną sesję OCR (inni mogą działać równolegle)
         const isOCRActive = ocrService.isOCRActive(guildId, userId);
 
-        await interaction.deferReply({ ephemeral: false });
+        // Ephemeral - widoczne tylko dla wywołującego, żeby nie zaśmiecać głównego kanału
+        await interaction.deferReply({ ephemeral: true });
 
         if (isOCRActive) {
             await interaction.editReply({
@@ -350,6 +354,9 @@ async function handleRemindCommand(interaction, config, ocrService, reminderServ
             });
             session.publicInteraction = awaitingMessage;
             ocrService.setSessionMessageId(guildId, userId, awaitingMessage.id);
+
+            // Potwierdzenie ephemeralne dla wywołującego
+            await inter.editReply({ content: `✅ Sesja rozpoczęta w wątku: <#${thread.id}>` });
 
             logger.info(`[REMIND] ✅ Sesja utworzona (wątek: ${thread.id}), czekam na zdjęcia od ${inter.user.tag}`);
         };
@@ -3685,7 +3692,8 @@ async function handlePhase1Command(interaction, sharedState) {
     // Sprawdź czy TEN użytkownik ma już aktywną sesję OCR (inni mogą działać równolegle)
     const isOCRActive = ocrService.isOCRActive(guildId, userId);
 
-    await interaction.deferReply({ ephemeral: false });
+    // Ephemeral - widoczne tylko dla wywołującego, żeby nie zaśmiecać głównego kanału
+    await interaction.deferReply({ ephemeral: true });
 
     if (isOCRActive) {
         await interaction.editReply({
@@ -3753,6 +3761,8 @@ async function handlePhase1Command(interaction, sharedState) {
                         components: [warningEmbed.row]
                     });
                     ocrService.setSessionMessageId(guildId, userId, warningMessage.id);
+                    // Potwierdzenie ephemeralne dla wywołującego
+                    await inter.editReply({ content: `✅ Sesja rozpoczęta w wątku: <#${thread.id}>` });
                     return;
                 }
             }
@@ -3778,6 +3788,9 @@ async function handlePhase1Command(interaction, sharedState) {
             });
             session.publicInteraction = awaitingMessage;
             ocrService.setSessionMessageId(guildId, userId, awaitingMessage.id);
+
+            // Potwierdzenie ephemeralne dla wywołującego
+            await inter.editReply({ content: `✅ Sesja rozpoczęta w wątku: <#${thread.id}>` });
 
             logger.info(`[PHASE1] ✅ Sesja utworzona (wątek: ${thread.id}), czekam na zdjęcia od ${inter.user.tag}`);
         };
@@ -4390,7 +4403,8 @@ async function handlePhase2Command(interaction, sharedState) {
     // Sprawdź czy TEN użytkownik ma już aktywną sesję OCR (inni mogą działać równolegle)
     const isOCRActive = ocrService.isOCRActive(guildId, userId);
 
-    await interaction.deferReply({ ephemeral: false });
+    // Ephemeral - widoczne tylko dla wywołującego, żeby nie zaśmiecać głównego kanału
+    await interaction.deferReply({ ephemeral: true });
 
     if (isOCRActive) {
         await interaction.editReply({
@@ -4458,6 +4472,8 @@ async function handlePhase2Command(interaction, sharedState) {
                         components: [warningEmbed.row]
                     });
                     ocrService.setSessionMessageId(guildId, userId, warningMessage.id);
+                    // Potwierdzenie ephemeralne dla wywołującego
+                    await inter.editReply({ content: `✅ Sesja rozpoczęta w wątku: <#${thread.id}>` });
                     return;
                 }
             }
@@ -4483,6 +4499,9 @@ async function handlePhase2Command(interaction, sharedState) {
             });
             session.publicInteraction = awaitingMessage;
             ocrService.setSessionMessageId(guildId, userId, awaitingMessage.id);
+
+            // Potwierdzenie ephemeralne dla wywołującego
+            await inter.editReply({ content: `✅ Sesja rozpoczęta w wątku: <#${thread.id}>` });
 
             logger.info(`[PHASE2] ✅ Sesja utworzona (wątek: ${thread.id}), czekam na zdjęcia z rundy 1/3 od ${inter.user.tag}`);
         };


### PR DESCRIPTION
## Summary
- Poprzednia implementacja wątków sesji OCR (#1003) tworzyła publiczną wiadomość "🧵 Sesja OCR rozpoczęta - kontynuuj w wątku poniżej." na głównym kanale panelu, żeby mieć wiadomość-kotwicę do `message.startThread()`.
- Zamieniono na `channel.threads.create({...})` bez wiadomości startowej - Discord wspiera tworzenie wątków niezwiązanych z żadną wiadomością (widoczne tylko w liście wątków kanału, bez śmiecenia w głównym czacie).
- `deferReply` dla `/punish`, `/remind`, `/faza1`, `/faza2` jest teraz `ephemeral: true` (widoczne tylko dla wywołującego) - po utworzeniu wątku wywołujący dostaje krótkie ephemeralne potwierdzenie z linkiem do wątku.

## Test plan
- [x] `node -c` na zmienionym pliku
- [ ] Manualny test na serwerze: `/punish` nie tworzy żadnej widocznej wiadomości na głównym kanale, tylko wątek

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtyBXNy8Bc2gAHKX95NHxD)_