### PR TITLE
EndersEcho: FAKE_PHOTO zamiast obcinania wyniku + tie-break po timestampie w rankingu

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -86,6 +86,7 @@
    - Eksport do `shared_data/endersecho_ranking.json` (globalny, format: `{updatedAt, players: [{rank, userId, username, score, scoreValue, bossName, timestamp, sourceGuildId}]}`)
    - Eksport przy każdym zapisie i przy starcie bota
    - **Migracja:** Przy pierwszym starcie stary `ranking.json` jest automatycznie migrowany do `ranking_{guild1Id}.json`
+   - **Tie-break przy remisie (identyczny `scoreValue`):** `compareByScoreThenTimestamp` (`utils/helpers.js`) — gracz który zdobył dany wynik **wcześniej** (starszy `timestamp`) jest wyżej; ten kto powtórzył identyczny wynik jako drugi ląduje niżej. Używane we wszystkich sortowaniach po wyniku: ranking serwera (`getSortedPlayers`), ranking globalny (`getGlobalRanking`, `saveSharedRanking`), symulacje `/test` (`simulateSortedPlayers`, `simulateGlobalRanking`), ranking per-boss (`bossRecordService.getGlobalBossRanking`, `simulateGlobalBossRanking`) oraz pomocnicze wyliczenia „poprzednia pozycja" (delta ▲/▼ w ogłoszeniach rekordu)
 
 3. **Role TOP (opcjonalne)** - `roleService.js`:
    - Do **10 w pełni konfigurowalnych progów** per serwer; każdy próg = zakres pozycji rankingowych + rola Discord

--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -54,6 +54,7 @@
        - **KROK 2:** Sprawdza autentyczność zdjęcia (10 tokenów)
        - **KROK 3:** Wyciąga nazwę bossa, wynik (Best) i Total (500 tokenów)
      - **Walidacja score vs Total:** Jeśli odczytany Best > Total → automatyczna korekta
+     - **Walidacja długości cyfr** (`normalizeScore` w `aiOcrService.js`): jeśli wynik z jednostką (K/M/B/T/Q/Qi/Sx/Sp) ma więcej niż 5 cyfr przed jednostką LUB za dużo miejsc po przecinku → wynik **odrzucany jako podróbka** (`error: 'FAKE_PHOTO'`, `score: null`), NIE obcinany. Wcześniej funkcja obcinała nadmiarowe cyfry (`substring(0, 5)`), co potrafiło zaniżyć poprawnie odczytany wynik (np. AI poprawnie odczytało `213769Q`, obcięcie zamieniało go w błędny `21376Q` i wynik fałszywie nie bił rekordu)
      - Zalety: 100% pewność walidacji, fallback na tradycyjny OCR
    - **Komenda /update (wszyscy, wymaga AI OCR):** Używa `analyzeTestImage()` — weryfikacja wzorcem + ekstrakcja:
      - **KROK 1:** Porównanie z wzorcem `files/Wzór.jpg` — jeden request z dwoma obrazami (10 tokenów) — **10 retry** przy błędzie API (429/500/503), delay cappowany na 10s

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, REST, Routes, AttachmentBuilder, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, ModalBuilder, TextInputBuilder, TextInputStyle, PermissionFlagsBits, ChannelSelectMenuBuilder, ChannelType, RoleSelectMenuBuilder } = require('discord.js');
-const { downloadFile, downloadBuffer, formatMessage } = require('../utils/helpers');
+const { downloadFile, downloadBuffer, formatMessage, compareByScoreThenTimestamp } = require('../utils/helpers');
 const { formatCooldownTime } = require('../services/updateCooldownService');
 const { generatePositionIcon } = require('../services/positionIconService');
 const ProfileService = require('../services/profileService');
@@ -4434,7 +4434,7 @@ class InteractionHandler {
                                 if (csPrevBossRecord) {
                                     const prevValCs = csPrevBossRecord.scoreValue;
                                     const tempCs = bossRankingCs.map(p => p.userId === userId ? { ...p, scoreValue: prevValCs } : p);
-                                    tempCs.sort((a, b) => b.scoreValue - a.scoreValue);
+                                    tempCs.sort(compareByScoreThenTimestamp);
                                     const prevIdxCs = tempCs.findIndex(p => p.userId === userId);
                                     prevBossPosCs = prevIdxCs !== -1 ? prevIdxCs + 1 : null;
                                 }
@@ -4799,7 +4799,7 @@ class InteractionHandler {
                             const tempRanking = bossRanking.map(p =>
                                 p.userId === userId ? { ...p, scoreValue: prevBossScoreValue } : p
                             );
-                            tempRanking.sort((a, b) => b.scoreValue - a.scoreValue);
+                            tempRanking.sort(compareByScoreThenTimestamp);
                             const prevBossIdx = tempRanking.findIndex(p => p.userId === userId);
                             bossPositionChange = (prevBossIdx + 1) - newBossPosition;
                             prevBossPosition = prevBossIdx !== -1 ? prevBossIdx + 1 : null;
@@ -6876,7 +6876,7 @@ class InteractionHandler {
             if (previousBossRecord) {
                 const prevVal = this.rankingService.parseScoreValue(previousBossRecord.score);
                 const temp = bossRanking.map(p => p.userId === userId ? { ...p, scoreValue: prevVal } : p);
-                temp.sort((a, b) => b.scoreValue - a.scoreValue);
+                temp.sort(compareByScoreThenTimestamp);
                 const prevIdx = temp.findIndex(p => p.userId === userId);
                 prevBossPosition = prevIdx !== -1 ? prevIdx + 1 : null;
             }

--- a/EndersEcho/services/aiOcrService.js
+++ b/EndersEcho/services/aiOcrService.js
@@ -235,8 +235,8 @@ Odpowiedz WYŁĄCZNIE w tym formacie (3 linie, nic więcej):
 
         if (unit) {
             if (integerPart.length > 5) {
-                log.warn(`[AI OCR] normalizeScore: obcięto ${integerPart.length} cyfr → 5 (${unit})`);
-                integerPart = integerPart.substring(0, 5);
+                log.warn(`[AI OCR] normalizeScore: "${originalScore}" za dużo cyfr przed jednostką (${integerPart.length} > 5) — odrzucam jako podróbkę`);
+                return null;
             }
             if (decimalPart) {
                 const maxDec = integerPart.length === 1 ? 2 : 1;

--- a/EndersEcho/services/bossRecordService.js
+++ b/EndersEcho/services/bossRecordService.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs').promises;
 const path = require('path');
+const { compareByScoreThenTimestamp } = require('../utils/helpers');
 
 class BossRecordService {
     constructor(dataDir) {
@@ -121,7 +122,7 @@ class BossRecordService {
         }
         return Array.from(bestPerPlayer.entries())
             .map(([userId, entry]) => ({ userId, ...entry }))
-            .sort((a, b) => b.scoreValue - a.scoreValue);
+            .sort(compareByScoreThenTimestamp);
     }
 
     /**
@@ -133,12 +134,12 @@ class BossRecordService {
         const idx = ranking.findIndex(p => p.userId === userId);
         if (idx !== -1) {
             if (scoreValue > (ranking[idx].scoreValue || 0)) {
-                ranking[idx] = { ...ranking[idx], score, scoreValue, sourceGuildId };
+                ranking[idx] = { ...ranking[idx], score, scoreValue, sourceGuildId, timestamp: new Date().toISOString() };
             }
         } else {
-            ranking.push({ userId, username, score, scoreValue, sourceGuildId });
+            ranking.push({ userId, username, score, scoreValue, sourceGuildId, timestamp: new Date().toISOString() });
         }
-        ranking.sort((a, b) => b.scoreValue - a.scoreValue);
+        ranking.sort(compareByScoreThenTimestamp);
         return ranking;
     }
 

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -4,7 +4,7 @@ const { createBotLogger } = require('../../utils/consoleLogger');
 
 const logger = createBotLogger('EndersEcho');
 const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
-const { formatMessage } = require('../utils/helpers');
+const { formatMessage, compareByScoreThenTimestamp } = require('../utils/helpers');
 
 class RankingService {
     constructor(config, scoreHistoryService = null) {
@@ -117,7 +117,7 @@ class RankingService {
         }
 
         const sorted = Array.from(bestPerPlayer.values())
-            .sort((a, b) => b.scoreValue - a.scoreValue);
+            .sort(compareByScoreThenTimestamp);
 
         if (!activeGuildIds) this._globalCache = sorted;
         return sorted;
@@ -237,14 +237,14 @@ class RankingService {
 
             // Ranking globalny (posortowany malejąco)
             const globalSorted = Array.from(bestPerPlayer.values())
-                .sort((a, b) => b.scoreValue - a.scoreValue);
+                .sort(compareByScoreThenTimestamp);
 
             // Rankingi per-serwer: posortowane userId dla każdej gildii
             const perGuildSortedIds = new Map();
             for (const [guildId, ranking] of perGuildData) {
                 const sorted = Object.entries(ranking)
                     .filter(([, d]) => d.scoreValue > 0)
-                    .sort(([, a], [, b]) => b.scoreValue - a.scoreValue)
+                    .sort(([, a], [, b]) => compareByScoreThenTimestamp(a, b))
                     .map(([userId]) => userId);
                 perGuildSortedIds.set(guildId, sorted);
             }
@@ -1023,7 +1023,7 @@ class RankingService {
                         const userPlayer = tempPlayers.find(p => p.userId === userId);
                         if (userPlayer) {
                             userPlayer.scoreValue = this.parseScoreValue(previousScore);
-                            tempPlayers.sort((a, b) => b.scoreValue - a.scoreValue);
+                            tempPlayers.sort(compareByScoreThenTimestamp);
                             const previousIndex = tempPlayers.findIndex(player => player.userId === userId);
                             positionChange = (previousIndex + 1) - currentPosition;
                         }
@@ -1383,7 +1383,7 @@ class RankingService {
         const ranking = await this.loadRanking(guildId);
         const sorted = Object.entries(ranking)
             .map(([userId, data]) => ({ ...data, userId }))
-            .sort((a, b) => b.scoreValue - a.scoreValue);
+            .sort(compareByScoreThenTimestamp);
         this._sortedCache.set(guildId, sorted);
         return sorted;
     }
@@ -1398,12 +1398,12 @@ class RankingService {
         const idx = sorted.findIndex(p => p.userId === userId);
         if (idx !== -1) {
             if (newScoreValue > (sorted[idx].scoreValue || 0)) {
-                sorted[idx] = { ...sorted[idx], score: bestScore, scoreValue: newScoreValue };
+                sorted[idx] = { ...sorted[idx], score: bestScore, scoreValue: newScoreValue, timestamp: new Date().toISOString() };
             }
         } else {
-            sorted.push({ userId, username: userName, score: bestScore, scoreValue: newScoreValue });
+            sorted.push({ userId, username: userName, score: bestScore, scoreValue: newScoreValue, timestamp: new Date().toISOString() });
         }
-        sorted.sort((a, b) => b.scoreValue - a.scoreValue);
+        sorted.sort(compareByScoreThenTimestamp);
         return sorted;
     }
 
@@ -1416,12 +1416,12 @@ class RankingService {
         const idx = ranking.findIndex(p => p.userId === userId);
         if (idx !== -1) {
             if (newScoreValue > (ranking[idx].scoreValue || 0)) {
-                ranking[idx] = { ...ranking[idx], score: bestScore, scoreValue: newScoreValue, sourceGuildId };
+                ranking[idx] = { ...ranking[idx], score: bestScore, scoreValue: newScoreValue, sourceGuildId, timestamp: new Date().toISOString() };
             }
         } else {
-            ranking.push({ userId, username: userName, score: bestScore, scoreValue: newScoreValue, sourceGuildId });
+            ranking.push({ userId, username: userName, score: bestScore, scoreValue: newScoreValue, sourceGuildId, timestamp: new Date().toISOString() });
         }
-        ranking.sort((a, b) => b.scoreValue - a.scoreValue);
+        ranking.sort(compareByScoreThenTimestamp);
         return ranking;
     }
 

--- a/EndersEcho/utils/helpers.js
+++ b/EndersEcho/utils/helpers.js
@@ -99,8 +99,24 @@ async function downloadBuffer(url) {
     });
 }
 
+/**
+ * Sortuje graczy malejąco po wyniku. Przy remisie (identyczny scoreValue)
+ * gracz, który zdobył wynik WCZEŚNIEJ (starszy timestamp), jest wyżej —
+ * ten kto powtórzył wynik jako drugi ląduje niżej.
+ * @param {{scoreValue: number, timestamp?: string}} a
+ * @param {{scoreValue: number, timestamp?: string}} b
+ * @returns {number}
+ */
+function compareByScoreThenTimestamp(a, b) {
+    if (b.scoreValue !== a.scoreValue) return b.scoreValue - a.scoreValue;
+    const aTime = a.timestamp ? new Date(a.timestamp).getTime() : Infinity;
+    const bTime = b.timestamp ? new Date(b.timestamp).getTime() : Infinity;
+    return aTime - bTime;
+}
+
 module.exports = {
     formatMessage,
     downloadFile,
-    downloadBuffer
+    downloadBuffer,
+    compareByScoreThenTimestamp
 };


### PR DESCRIPTION
## Summary
- **AI OCR — walidacja długości wyniku:** `normalizeScore()` (`aiOcrService.js`) obcinał wyniki z jednostką mające więcej niż 5 cyfr przed jednostką do 5 cyfr (`substring(0, 5)`), zamiast je odrzucać. Powodowało to zaniżanie poprawnie odczytanych wyników AI (np. `213769Q` → `21376Q`), co skutkowało błędnym "nie pobito rekordu" mimo faktycznego pobicia. Teraz taki przypadek jest traktowany jak podrobiony screen: zwracany jest `null` → `error: 'FAKE_PHOTO'`, tak samo jak przy nadmiarze miejsc po przecinku.
- **Ranking — remis wyniku:** dodano `compareByScoreThenTimestamp` (`utils/helpers.js`) — przy identycznym `scoreValue` gracz, który zdobył wynik **wcześniej**, jest wyżej w rankingu; ten kto powtórzył identyczny wynik jako drugi ląduje niżej. Zastosowane we wszystkich sortowaniach rankingowych: ranking serwera, ranking globalny, eksport `shared_data`, symulacje `/test`, ranking per-boss oraz pomocnicze wyliczenia pozycji „przed rekordem" w ogłoszeniach.
- Zaktualizowano `EndersEcho/CLAUDE.md` o opis obu zachowań.

## Test plan
- [ ] `/update` ze screenem, którego wynik ma ≤5 cyfr przed jednostką — zapisuje się normalnie
- [ ] `/update` ze screenem, którego AI odczyta wynik z >5 cyfr przed jednostką — zostaje odrzucony jako FAKE_PHOTO (czerwony embed) zamiast zapisać zaniżony wynik
- [ ] Dwóch graczy z identycznym wynikiem w rankingu serwera/globalnym — ten kto zdobył go wcześniej jest wyżej

https://claude.ai/code/session_01RH98Ua5DwRVtwYoAAiJPZg