### PR TITLE
EndersEcho: diagnostyka uprawnień — AddReactions i UseExternalEmojis dla auto-reakcji

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -494,6 +494,7 @@
     - Tekst, gołe cyfry, wiele emoji naraz i emotki niedostępne dla bota odrzucane z komunikatem ephemeral (PL/EN)
   - Stan wizarda: `autoReactionEmoji` (string|null) + `autoReactionDone` (bool) w RAM; persystencja w `guild_configs.json` jako `autoReactionEmoji` (null = wyłączona)
   - Dodawanie reakcji: `_addRecordAutoReaction(publicMsg, guildId)` — fire-and-forget po każdym `followUp` ogłoszenia rekordu w `_runUpdateFlow`; błąd reakcji tylko logowany (warn per-guild), nie przerywa flow
+  - **Wymagane uprawnienia bota:** `AddReactions` (dodanie reakcji pod ogłoszeniem) + `UseExternalEmojis` (gdy emotka customowa pochodzi z innego serwera niż ten, na którym publikowane jest ogłoszenie); oba sprawdzane w Diagnostyce uprawnień (`panel_diagnostics`) — na poziomie serwera i kanału bota
   - customIDs: `cfg_step_10`, `cfg_autoreact_enable`, `cfg_autoreact_disable` (wyłącz/pomiń), `cfg_autoreact_modal`
 - Zielony przycisk **✅ Zaakceptuj konfigurację!** pojawia się gdy wszystkie kroki ukończone; obok niego pojawia się wtedy też przycisk **🔍 Diagnostyka** (`panel_diagnostics`) — dostępny dla każdego administratora, sprawdza uprawnienia bota (serwer + kanały + hierarchia ról TOP)
 - Opis informuje o istnieniu `/manage` do zarządzania panelem admina

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -11139,6 +11139,8 @@ class InteractionHandler {
             [PermissionFlagsBits.ReadMessageHistory,  'ReadMessageHistory', t('wymagane do odczytu historii kanału', 'required to read channel history')],
             [PermissionFlagsBits.ViewChannel,         'ViewChannel',        t('wymagane do widzenia kanałów', 'required to see channels')],
             [PermissionFlagsBits.AttachFiles,         'AttachFiles',        t('wymagane do wysyłania plików', 'required to send files')],
+            [PermissionFlagsBits.AddReactions,        'AddReactions',       t('wymagane do auto-reakcji pod ogłoszeniami rekordów (/configure krok 10)', 'required for auto reactions under record announcements (/configure step 10)')],
+            [PermissionFlagsBits.UseExternalEmojis,   'UseExternalEmojis',  t('wymagane gdy auto-reakcja używa emotki customowej z innego serwera', 'required when the auto reaction uses a custom emote from another server')],
         ];
 
         const serverPermsHeader = t('🔐 **Uprawnienia serwera**', '🔐 **Server Permissions**');
@@ -11168,6 +11170,8 @@ class InteractionHandler {
                 [PermissionFlagsBits.EmbedLinks,         'EmbedLinks'],
                 [PermissionFlagsBits.ReadMessageHistory, 'ReadMessageHistory'],
                 [PermissionFlagsBits.AttachFiles,        'AttachFiles'],
+                [PermissionFlagsBits.AddReactions,       'AddReactions'],
+                [PermissionFlagsBits.UseExternalEmojis,  'UseExternalEmojis'],
             ];
             for (const [flag, name] of CHANNEL_PERMS) {
                 const hasGlobal = botMember.permissions.has(flag);


### PR DESCRIPTION
## Opis zmian

Uzupełnienie funkcji auto-reakcji (#1018): funkcja wymaga dodatkowych uprawnień bota, które nie były dotąd sprawdzane w Diagnostyce uprawnień (`panel_diagnostics`).

### Nowe pozycje na checkliście diagnostyki
- **`AddReactions`** — wymagane do dodania reakcji pod ogłoszeniem rekordu (`/configure` krok 10).
- **`UseExternalEmojis`** — wymagane, gdy skonfigurowana emotka customowa pochodzi z innego serwera niż ten, na którym publikowane jest ogłoszenie.

Oba uprawnienia sprawdzane w dwóch miejscach (spójnie z istniejącym wzorcem checklisty):
- **Kategoria „Uprawnienia serwera"** — z opisem powodu (PL/EN),
- **Kategoria „Uprawnienia w kanale bota"** — z rozróżnieniem „brak uprawnienia" vs „zablokowane przez override kanału".

`ViewChannel` i `ReadMessageHistory` (również potrzebne do reagowania) były już na checkliście — bez zmian.

### Dokumentacja
- Zaktualizowano `EndersEcho/CLAUDE.md` (sekcja kroku 10 — wymagane uprawnienia bota).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcGdjBQshipB71uEJcSpxR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcGdjBQshipB71uEJcSpxR)_