### PR TITLE
EndersEcho: ogłoszenie czasowej blokady gracza na serwerze jego najlepszego wyniku

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -555,6 +555,7 @@
 - Zablokowany użytkownik przy próbie `/update` widzi komunikat o blokadzie i konieczności kontaktu z adminem
 - `/unblock` (admin) — lista zablokowanych posortowana od najkrótszej kary do permanentnych, select menu do odblokowania; jeśli `blockedByHeadAdmin: true` — zwykły Admin nie może odblokować
 - Panel Admina → **🔒 Zablokuj gracza** (Head Admin) — cross-server wyszukiwanie + blokada z `blockedByHeadAdmin: true`
+- **Ogłoszenie czasowej blokady** (`_announceUserBlock(client, targetUserId, blockedUntil, adminName)`): gdy admin nakłada blokadę CZASOWĄ (podany czas trwania), bot wysyła systemową wiadomość (czerwony embed, klucze `userBlockAnnouncementTitle`/`userBlockAnnouncement`) na kanał bota (`allowedChannelId`) serwera, na którym gracz ma swój najlepszy globalny wynik (`getGlobalRanking()` → `sourceGuildId`), w języku tego serwera: „Użytkownik @wzmianka został zablokowany na okres **X** przez administratora **nick**". Wywoływane fire-and-forget z obu ścieżek blokady adminem: panel admina (`_handlePanelBlockModal`) i raport odrzuconego screena (modal czasu blokady). NIE ogłaszane: blokady permanentne (puste pole czasu), automatyczna blokada 24h z weryfikacji społeczności oraz permanentna blokada z akcji CV `cv_admin_block`. Gdy gracz nie ma wyniku w żadnym rankingu — brak ogłoszenia.
 - Persistencja przeżywa restart bota
 
 **GuildConfigService** — `services/guildConfigService.js`:

--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -312,6 +312,10 @@ const pol = {
     configureTagTooLong: '❌ Tag może mieć maksymalnie 4 znaki.',
     configureTagEmpty: '❌ Tag nie może być pusty.',
 
+    // Ogłoszenie czasowej blokady gracza (kanał bota serwera z jego najlepszym wynikiem)
+    userBlockAnnouncementTitle: '🔒 Blokada gracza',
+    userBlockAnnouncement: 'Użytkownik {userMention} został zablokowany na okres **{duration}** przez administratora **{adminName}**.',
+
     // Weryfikacja społeczności
     cvVoteButton: '⚠️ Zgłoś',
     cvReported: '⚠️ Zgłoszono',
@@ -695,6 +699,10 @@ const eng = {
     configureCancelled: '❌ Configuration cancelled. Previous settings remain unchanged.',
     configureTagTooLong: '❌ The tag can have a maximum of 4 characters.',
     configureTagEmpty: '❌ The tag cannot be empty.',
+
+    // Temporary player block announcement (bot channel of the server with their best score)
+    userBlockAnnouncementTitle: '🔒 Player Blocked',
+    userBlockAnnouncement: 'User {userMention} has been blocked for **{duration}** by administrator **{adminName}**.',
 
     // Community verification
     cvVoteButton: '⚠️ Report',

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -3853,6 +3853,7 @@ class InteractionHandler {
                 ? this.userBlockService.formatTimeRemaining(blockedUntil, { permanent: t('∞ Permanentnie', '∞ Permanent'), expired: t('Wygasła', 'Expired') })
                 : t('∞ Permanentnie', '∞ Permanent');
             logger.info(`🔒 Head Admin zablokował ${username} (${targetUserId}) na serwerze ${guildName} — ${timeLabel}`);
+            this._announceUserBlock(interaction.client, targetUserId, blockedUntil, interaction.member?.displayName || interaction.user.username);
             await interaction.editReply({
                 embeds: [new EmbedBuilder().setColor(0x57F287)
                     .setTitle(t('✅ Gracz zablokowany', '✅ Player Blocked'))
@@ -3867,6 +3868,42 @@ class InteractionHandler {
         } catch (err) {
             logger.error(`Błąd _handlePanelBlockModal (serwer "${interaction.client.guilds.cache.get(targetGuildId)?.name || targetGuildId}", gracz ID ${targetUserId}):`, err);
             await interaction.editReply({ content: t('❌ Błąd blokowania gracza.', '❌ Error blocking player.'), embeds: [], components: [] });
+        }
+    }
+
+    /**
+     * Ogłasza CZASOWĄ blokadę gracza nałożoną przez admina — systemowa wiadomość na kanale bota
+     * serwera, na którym gracz ma swój najlepszy (globalny) wynik. Fire-and-forget.
+     * Blokady permanentne (blockedUntil === null) i automatyczne (CV) nie są ogłaszane.
+     * @param {Client} client
+     * @param {string} targetUserId - ID zablokowanego gracza
+     * @param {number|null} blockedUntil - timestamp końca blokady (null = permanentna)
+     * @param {string} adminName - nick administratora nakładającego blokadę
+     */
+    async _announceUserBlock(client, targetUserId, blockedUntil, adminName) {
+        try {
+            if (!blockedUntil) return; // permanentna — bez ogłoszenia
+            const globalRanking = await this.rankingService.getGlobalRanking();
+            const entry = globalRanking.find(p => p.userId === targetUserId);
+            if (!entry?.sourceGuildId) return; // gracz nie ma wyniku w żadnym rankingu
+            const channelId = this.guildConfigService?.getConfig(entry.sourceGuildId)?.allowedChannelId;
+            if (!channelId) return;
+            const channel = await client.channels.fetch(channelId).catch(() => null);
+            if (!channel) return;
+            const msgs = this.msgs(entry.sourceGuildId);
+            const duration = this.userBlockService.formatTimeRemaining(blockedUntil);
+            const embed = new EmbedBuilder()
+                .setColor(0xFF4444)
+                .setTitle(msgs.userBlockAnnouncementTitle)
+                .setDescription(msgs.userBlockAnnouncement
+                    .replace('{userMention}', `<@${targetUserId}>`)
+                    .replace('{duration}', duration)
+                    .replace('{adminName}', adminName))
+                .setTimestamp();
+            await channel.send({ embeds: [embed] });
+            this.logService._gl(entry.sourceGuildId).info(`🔒 Ogłoszono blokadę gracza ${this.logService.nickLink(entry.username || targetUserId, targetUserId)} (${duration}, przez ${adminName})`);
+        } catch (err) {
+            logger.warn(`⚠️ Nie udało się ogłosić blokady gracza ${targetUserId}: ${err.message}`);
         }
     }
 
@@ -8993,6 +9030,7 @@ class InteractionHandler {
         });
 
         logger.info(`🔒 Zablokowano ${targetUsername} (${targetUserId}) ${blockedUntil ? `do ${new Date(blockedUntil).toISOString()}` : 'permanentnie'} przez ${adminName}`);
+        this._announceUserBlock(interaction.client, targetUserId, blockedUntil, adminName);
         this.adminPanelService?.refresh();
 
         if (crossUpdateGlobalMsgId) {


### PR DESCRIPTION
## Opis zmian

Gdy administrator nakłada na gracza **czasową** blokadę, bot publikuje systemową wiadomość na kanale bota serwera, na którym gracz ma swój **najlepszy globalny wynik**:

> 🔒 Użytkownik @wzmianka został zablokowany na okres **7d 0h** przez administratora **Nick**.

### Jak działa
- Nowy helper `_announceUserBlock(client, targetUserId, blockedUntil, adminName)` — fire-and-forget, błąd tylko logowany (warn), nie przerywa flow blokowania.
- Serwer docelowy: `rankingService.getGlobalRanking()` → wpis gracza → `sourceGuildId`; wiadomość idzie na `allowedChannelId` tego serwera, w jego języku (czerwony embed z timestampem).
- Czas blokady formatowany przez `userBlockService.formatTimeRemaining()` (np. `7d 0h`, `2h 30m`).

### Kiedy ogłaszane / kiedy nie
| Scenariusz | Ogłoszenie |
|---|---|
| Panel admina → 🔒 Zablokuj gracza (z czasem) | ✅ |
| Raport odrzuconego screena → Zablokuj (z czasem) | ✅ |
| Blokada permanentna (puste pole czasu) | ❌ |
| Automatyczna blokada 24h z weryfikacji społeczności | ❌ (nie pochodzi od admina) |
| CV: „Zablokuj permanentnie + usuń rekord" | ❌ (permanentna) |
| Gracz bez wyniku w żadnym rankingu | ❌ (brak serwera docelowego) |

### Dwujęzyczność
Nowe klucze `userBlockAnnouncementTitle` i `userBlockAnnouncement` dodane w obu sekcjach `messages.js` (pol + eng).

### Dokumentacja
Zaktualizowano `EndersEcho/CLAUDE.md` (sekcja „System blokowania per-użytkownik").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcGdjBQshipB71uEJcSpxR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcGdjBQshipB71uEJcSpxR)_