### PR TITLE
EndersEcho: podwójna weryfikacja wzorca — odrzucenie screena dopiero po dwóch negatywnych dopasowaniach

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -58,6 +58,7 @@
      - Zalety: 100% pewność walidacji, fallback na tradycyjny OCR
    - **Komenda /update (wszyscy, wymaga AI OCR):** Używa `analyzeTestImage()` — weryfikacja wzorcem + ekstrakcja:
      - **KROK 1:** Porównanie z wzorcem `files/Wzór.jpg` — jeden request z dwoma obrazami (10 tokenów) — **10 retry** przy błędzie API (429/500/503), delay cappowany na 10s
+       - **Podwójna weryfikacja negatywnego wyniku:** gdy AI odpowie NOK (screen niepodobny do wzorca), porównanie jest wykonywane **jeszcze raz** (drugi, niezależny request); screen odrzucany (`NOT_SIMILAR`) dopiero po DWÓCH negatywnych wynikach — chroni przed pojedynczą pomyłką modelu. Druga próba pozytywna → analiza kontynuowana normalnie. Powód odrzucenia = z drugiej próby (fallback: z pierwszej). Koszt tokenów obu prób sumowany w `tokenUsage`. Dotyczy `/update` i `/test` (wspólna implementacja `analyzeTestImage`)
      - **KROK 2:** Ekstrakcja danych (boss + score) — bez sprawdzania Victory i autentyczności (500 tokenów) — **10 retry** przy błędzie API, delay cappowany na 10s
      - Gdy screen niepodobny do wzorca → embed `testNotSimilarTitle/Description` (brak zapisu)
      - Po udanej weryfikacji: pełny flow — zapis do rankingu, aktualizacja ról TOP, snippet globalnego rankingu (gdy pozycja globalna się zmieniła), powiadomienia DM

--- a/EndersEcho/services/aiOcrService.js
+++ b/EndersEcho/services/aiOcrService.js
@@ -308,13 +308,23 @@ Odpowiedz WYŁĄCZNIE w tym formacie (3 linie, nic więcej):
             const mediaType = 'image/png';
 
             const onRetryTemplate = onRetry ? (attempt, total) => onRetry(attempt, total, 'template') : null;
-            const { isSimilar, rejectionReason, usage: u1 } = await this._compareWithTemplate(wzorBase64, uploadedBase64, mediaType, log, telemetryMeta, lang, onRetryTemplate);
+            let { isSimilar, rejectionReason, usage: u1 } = await this._compareWithTemplate(wzorBase64, uploadedBase64, mediaType, log, telemetryMeta, lang, onRetryTemplate);
             tokenUsage.promptTokens  += u1.promptTokens;
             tokenUsage.outputTokens  += u1.outputTokens;
             tokenUsage.thoughtTokens += u1.thoughtTokens;
 
+            // Negatywne dopasowanie wzorca — powtórz porównanie; dopiero DRUGI negatywny wynik odrzuca screen
             if (!isSimilar) {
-                return { bossName: null, score: null, isValidVictory: false, error: 'NOT_SIMILAR', rejectionReason, tokenUsage };
+                log.info('[AI Test] Negatywny wynik wzorca — powtarzam porównanie (próba 2/2)...');
+                const second = await this._compareWithTemplate(wzorBase64, uploadedBase64, mediaType, log, telemetryMeta, lang, onRetryTemplate);
+                tokenUsage.promptTokens  += second.usage.promptTokens;
+                tokenUsage.outputTokens  += second.usage.outputTokens;
+                tokenUsage.thoughtTokens += second.usage.thoughtTokens;
+                if (!second.isSimilar) {
+                    return { bossName: null, score: null, isValidVictory: false, error: 'NOT_SIMILAR', rejectionReason: second.rejectionReason || rejectionReason, tokenUsage };
+                }
+                log.info('[AI Test] Druga próba wzorca pozytywna — kontynuuję analizę');
+                isSimilar = true;
             }
 
             if (onProgress) await onProgress('extracting');


### PR DESCRIPTION
## Opis zmian

Gdy podczas `/update` porównanie screena z wzorcem (`files/Wzór.jpg`) da wynik negatywny (AI odpowie `NOK`), analiza jest **powtarzana jeszcze raz** — osobnym, niezależnym requestem do AI. Screen zostaje odrzucony jako `NOT_SIMILAR` dopiero po **dwóch negatywnych dopasowaniach** z rzędu.

### Zachowanie
- **1. próba OK** → bez zmian, przejście do ekstrakcji danych (zero dodatkowego kosztu w happy path).
- **1. próba NOK → 2. próba OK** → screen zaakceptowany, analiza kontynuowana normalnie (log: `Druga próba wzorca pozytywna — kontynuuję analizę`).
- **1. próba NOK → 2. próba NOK** → odrzucenie `NOT_SIMILAR`; powód odrzucenia z drugiej próby (fallback: z pierwszej).

### Szczegóły
- Zmiana w `aiOcrService.analyzeTestImage()` — wspólna implementacja, więc obejmuje `/update`, `/test` (dryRun) — podgląd pozostaje identyczny z realnym flow.
- Zużycie tokenów obu prób sumowane w `tokenUsage` (koszt podwójny tylko przy pierwotnym wyniku negatywnym; happy path bez zmian).
- Retry przy błędach API (10 prób, 429/500/503) działa niezależnie dla każdej z dwóch prób porównania — bez zmian w tej logice.
- Log informuje o powtórce: `[AI Test] Negatywny wynik wzorca — powtarzam porównanie (próba 2/2)...`

### Dokumentacja
- Zaktualizowano `EndersEcho/CLAUDE.md` (opis KROKU 1 w `/update`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcGdjBQshipB71uEJcSpxR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcGdjBQshipB71uEJcSpxR)_