### PR TITLE
Ranking bossów per serwer w EndersEcho + pozycja bossa na serwerze w ogłoszeniu rekordu

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -193,7 +193,8 @@
    - **Ogłoszenie rekordu — STOS 4 EMBEDÓW** (`rankingService.createRecordEmbeds` → zwraca `EmbedBuilder[]`):
      - Wszystkie embedy wysyłane w **jednej wiadomości** (`followUp({ embeds, files })`) — pojawiają się jednocześnie, atomowo (jeden `message.id`). Komponenty (przycisk CV „Zgłoś") renderują się pod całą wiadomością, czyli pod ostatnim (4.) embedem.
      - **Kolor jednolity** dla wszystkich 4 embedów wg pozycji gracza (`getPositionColor`): 🥇 złoty (TOP1), 🥈 srebrny (TOP2), 🥉 brązowy (TOP3), niebieski (TOP4-10), zielony (TOP11+ / brak pozycji)
-     - **Embed 1 — 🏆 Gratulacje (BEZ bossa):** tytuł `🏆 GRATULACJE!`, author = ikona+nazwa roli TOP, thumbnail = avatar gracza, opis = postęp (`stary ➜ nowy (+X)`) + **pozycja w klanie** (`medal #N (+awans)`) + **pozycje w rankingach ról** (🎖️) + czas od ostatniego rekordu; pola: `🎉 Nowe osiągnięcia`, `🔔 SUBSKRYPCJE: N`
+     - **Embed 1 — 🏆 Gratulacje (BEZ bossa):** tytuł `🏆 GRATULACJE!`, author = ikona+nazwa roli TOP, thumbnail = avatar gracza, opis = postęp (`stary ➜ nowy (+X)`) + **pozycja w klanie** (`medal #N (+awans)`) + **pozycja na serwerze w rankingu tego bossa** + **pozycje w rankingach ról** (🎖️) + czas od ostatniego rekordu; pola: `🎉 Nowe osiągnięcia`, `🔔 SUBSKRYPCJE: N`
+       - **Linijka pozycji bossa na serwerze** (`bossServerPosition` w `createRecordEmbeds`, klucz `recordBossServerPosition`): `👾 **Pozycja na serwerze (boss {bossName}):** #3 / 17` — pozycja i liczba graczy w rankingu tego bossa **wyłącznie na tym serwerze** (nie globalnie). Liczona helperem `_buildBossServerPosition(guildId, bossName, playerKey, opts)` przez `bossRecordService.getGlobalBossRanking([guildId], boss)` (`/test` → `simulateGlobalBossRanking`, żeby podgląd był identyczny jak po zapisie). Pokazywana **zawsze gdy boss jest znany** — także gdy rekord bossa nie został pobity (to aktualna pozycja, nie zmiana). Pomijana dla nieznanej nazwy bossa (`wasUnknownBoss`). W ścieżce cross-server (rekord bossa zostaje na poprzednim serwerze) liczona dla `sourceGuildId`, czyli serwera, na którym wynik faktycznie leży. Dotyczy wszystkich ogłoszeń rekordu: `/update`, `/test`, ścieżki „tylko rekord bossa", cross-server i panelu „Analizuj"
      - **Embed 2 — 🌍 Ranking globalny:** tytuł `globalRankingEmbedTitle`, opis = snippet globalny, **thumbnail = generowana grafika z numerem NOWEJ pozycji globalnej** (`services/positionIconService.js`, SVG→PNG przez sharp, plik `global_position.png` via `attachment://`; tiery: #1 złoty medal z koroną+laurem+czerwoną wstęgą, #2 srebrny medal z niebieską wstęgą, #3 brązowy medal z zieloną wstęgą, #4–10 blurple tarcza z gwiazdą, #11–30 fioletowy heksagon, #31–100 stalowy okrągły badge, #101+ grafitowy okrąg; fallback przy błędzie generowania = statyczna ikona CDN), `image` = wykres progresu (`score_history.png`, ten sam co w `/ranking`, gdy ≥2 wpisy historii), footer z ikoną globalną. Pozycja liczbowa pochodzi z `globalSnippetData.newGlobalPosition` (zwracana przez `globalTop10Service.buildSnippetFieldData`). Grafika generowana i dołączana w `/update`, `/test` (dryRun) i panelu „Analizuj"; DM subskrybentów odtwarza załącznik pod tą samą nazwą. **Pokazywany WYŁĄCZNIE gdy zmieniła się pozycja globalna** (`globalSnippetData != null`) — gdy brak zmiany, embed jest pomijany (a wykres nie jest generowany).
      - **Embed 3 — 👾 Ranking bossa:** tytuł `bossRankingEmbedTitle` z `{bossName}`, thumbnail = **ikona bossa** (`bossAliasService.getBossImagePath` → `data/boss_images/`, fallback ikona bota), opis = `👾 Rekord na bossie` (`stary ➜ nowy` / „pierwszy wynik") + snippet rankingu bossa. Pokazywany gdy pobito rekord bossa (`isNewBossRecord && bossName && !wasUnknownBoss`).
      - **Embed 4 — ℹ️ Informacje systemowe:** tytuł `systemInfoEmbedTitle`, `image` = **screenshot przesłany do analizy**, footer z timestampem. Opis (description) i pola (fields) zależą od sytuacji:
@@ -234,7 +235,11 @@
    - Ranking globalny wyróżniony kolorem niebieskim (0x5865f2), serwer złotym (0xffd700)
    - W rankingu globalnym każda linia zawiera nazwę serwera źródłowego
    - **Wyświetlany wynik = oryginalny string `score`** zapisany przy OCR (z fallbackiem na `formatScore(scoreValue)` dla starych wpisów). NIE odtwarzamy wyniku z `scoreValue` przez `formatScore()` w listach rankingowych — `formatScore` zaokrągla do 2 miejsc po przecinku, więc pobicie rekordu o małą wartość (np. wysokie wyniki typu `12345B` → `12.34T`) nie zmieniało wyświetlanej liczby mimo nowego rekordu (boss i data się zmieniały, sam wynik nie). Dotyczy `createRankingEmbed` (lista + statystyka "najwyższy wynik") oraz `globalTop10Service` (raport cykliczny + snippet w embeddzie rekordu). `scoreValue` nadal używany WYŁĄCZNIE do sortowania i porównań. Sumy klanów (`createGuildRankingEmbed` → `totalScore`) nadal przez `formatScore` — brak stringa źródłowego.
-   - Przycisk Powrót (`ranking_back`) w wierszu paginacji jako 5. przycisk (na końcu)
+   - **Układ przycisków w widoku rankingu SERWERA** (`createRankingButtons`, `mode: 'server'`):
+     - Rząd 1: `◀️ ranking_prev` · `🎯 Moja pozycja` · `▶️ ranking_next`
+     - Rząd 2: `🌐 Global` · `👾 Ranking bossów {nazwa serwera}` (`ranking_boss_srv_{guildId}`) · `↩️ Rankingi serwerów` (`ranking_back`, powrót do ekranu wyboru serwera)
+     - Rząd 3+: rankingi ról (`createRoleRankingButtons`)
+   - Tryby `global` / `guild_ranking` / `role` mają układ jak dotychczas (Powrót jako ostatni przycisk wiersza paginacji, w trybie global w osobnym rzędzie)
 
 6. **Rankingi Ról** - `roleRankingConfigService.js` + `interactionHandlers.js`:
    - Zarządzanie przez `/configure` krok 7 (admin) → przyciski: "Dodaj ranking roli" (RoleSelectMenu), "Usuń ranking roli" (StringSelectMenu), "Gotowe / Pomiń"
@@ -498,8 +503,10 @@
 | `boss_cfg_set_img` | Przycisk "🖼️ Przypisz zdjęcie" — otwiera select bossów |
 | `boss_cfg_img_boss_sel` | StringSelectMenu — wybrany boss → otwiera modal z polem na link do zdjęcia |
 | `boss_cfg_img_modal` | Modal z linkiem do zdjęcia (Discord CDN) → pobranie i zapis pliku |
-| `ranking_boss_list` | Przycisk "🎯 Ranking Bossów" w widoku global ranking |
+| `ranking_boss_list` | Przycisk "👾 Ranking Bossów" w widoku global ranking |
 | `ranking_boss_sel` | StringSelectMenu — wybrany boss → pokazuje per-boss ranking globalny |
+| `ranking_boss_srv_{guildId}` | Przycisk "👾 Ranking bossów {nazwa serwera}" w widoku rankingu serwera → lista bossów tego serwera |
+| `ranking_boss_ssel_{guildId}` | StringSelectMenu — wybrany boss → per-boss ranking zawężony do tego serwera |
 
 **9. System aliasów bossów** — `services/bossAliasService.js` + `data/boss_aliases.json`:
 - **Cel:** Normalizacja nazw bossów z różnych języków → jedna angielska nazwa (np. "Robak" PL → "Shardstone Bug" EN = jeden boss w osiągnięciach).
@@ -543,11 +550,18 @@
 - **Embed rekordu:** Pole `🎯 Rekord na bossie` (msgs.bossRecordField) pokazywane gdy `isNewBossRecord = true`, PRZED polem osiągnięć. Dla pobitego rekordu bossa bez globalnego — pole `🎯 Nowy rekord na bossie` (msgs.bossRecordUpdated) w zielonym embedzie.
 - **Struktura danych:** `data/guilds/{guildId}/boss_records.json` = `{ userId: { bossName: { score, scoreValue, timestamp, username } } }`. Write queue per-guild (`_enqueue`).
 - **Ranking Bossów (globalny):**
-  - Przycisk `🎯 Ranking Bossów` w widoku Global rankingu → `_handleRankingBossList` → StringSelectMenu z bossami mającymi ≥1 rekord (filtruje do znanych angielskich nazw)
-  - Wybór bossa → `_handleRankingBossShow` → globalny ranking per-boss embed (`createBossRankingEmbed`) z thumbnail zdjęcia bossa (jeśli ustawione)
+  - Przycisk `👾 Ranking Bossów` w widoku Global rankingu → `_handleRankingBossList(interaction)` → StringSelectMenu `ranking_boss_sel` z bossami mającymi ≥1 rekord (filtruje do znanych angielskich nazw)
+  - Wybór bossa → `_handleRankingBossShow(interaction)` → globalny ranking per-boss embed (`createBossRankingEmbed`, kolor blurple `0x5865F2`) z thumbnail zdjęcia bossa (jeśli ustawione)
   - Paginacja: `ranking_prev/next/mypos` (te same przyciski co standardowy ranking; routing przez `_bossRankings.has(messageId)`)
-  - Stan paginacji: `_bossRankings` Map (RAM, per messageId)
+  - Stan paginacji: `_bossRankings` Map (RAM, per messageId). **Wpis kasowany przy wyjściu z rankingu bossa** (`_handleRankingSelect`, `_handleRoleRankingSelect`, `_handleGuildRankingSelect`, `_handleRankingBack`) — bez tego routing paginacji (`_bossRankings.has(messageId)` sprawdzane PRZED `getActiveRanking`) po powrocie do rankingu serwera/global dalej przerysowywałby ranking bossa
   - Powrót: przyciski `📋 Lista bossów` i `🌐 Global` w `createBossRankingButtons`
+- **Ranking Bossów per SERWER:**
+  - Przycisk `👾 Ranking bossów {nazwa serwera}` (`ranking_boss_srv_{guildId}`) w rzędzie 2 widoku rankingu serwera → ta sama metoda `_handleRankingBossList(interaction, guildId)`, ale lista bossów liczona z **jednego** serwera (`getBossesWithRecords([guildId], …)`)
+  - Wybór bossa → StringSelectMenu `ranking_boss_ssel_{guildId}` → `_handleRankingBossShow(interaction, guildId)` → ranking zawężony do serwera (`getGlobalBossRanking([guildId], boss)`); embed **złoty** (`0xF1C40F`, jak ranking serwera), tytuł `👾 Ranking — {boss} · {serwer}`, bez tagu serwera przy wpisach (wszystkie z tego samego serwera)
+  - Wykres progresu graczy budowany wyłącznie z historii tego serwera (`_buildBossRankingChartAttachment` dostaje `[guildId]`)
+  - Nawigacja: `📋 Lista bossów` wraca do listy tego samego zakresu (serwerowej albo globalnej), ostatni przycisk to `↩️ {nazwa serwera}` (powrót do rankingu serwera) zamiast `🌐 Global`
+  - Zakres (`srvGuildId`, `guildName`, `allGuildIds`) trzymany w `_bossRankings` — paginacja nie gubi kontekstu serwera
+  - Wspólna implementacja z rankingiem globalnym: jedyna różnica to lista ID serwerów przekazana do `bossRecordService`
 - **Zdjęcia bossów:** Plik zapisywany w `data/boss_images/{safeName}.{ext}`. Ścieżka (tylko `{safeName}.{ext}`) przechowywana w `boss_aliases.json` jako `images["BossEN"]`. Używane jako thumbnail w `createBossRankingEmbed` (AttachmentBuilder + `attachment://filename`).
 - **Filtrowanie rankingów:** `getBossesWithRecords(allGuildIds, knownEnglishNames)` — pokazuje TYLKO bossów z angielską nazwą (admin musi zmapować alias). Nieznane surowe nazwy niewidoczne w UI dopóki nie zostają zmapowane.
 

--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -167,6 +167,7 @@ const pol = {
     recordProgress: '📈 Progres',
     recordRanking: '🏅 Pozycja',
     recordBossRanking: '👾 Pozycja (boss)',
+    recordBossServerPosition: '👾 Pozycja na serwerze (boss {bossName})',
     recordPromotionBy: 'awans o',
     recordNewEntry: 'nowy w rankingu',
     recordDateLabel: '📅 Data',
@@ -444,10 +445,12 @@ const pol = {
 
     // Ranking bossów / osiągnięć
     buttonBossRanking: 'Ranking Bossów',
+    buttonBossRankingServer: 'Ranking bossów {guildName}',
     buttonAchRanking: 'Ranking Osiągnięć',
     bossRankingTitle: '👾 Ranking',
     bossRankingSelectTitle: '👾 Wybierz bossa',
     bossRankingSelectDesc: 'Wybierz bossa z listy aby zobaczyć globalny ranking.',
+    bossRankingSelectDescServer: 'Wybierz bossa z listy aby zobaczyć ranking serwera **{guildName}**.',
     bossRankingSelectPlaceholder: 'Wybierz bossa...',
     bossRankingNoBosses: '📭 Brak wyników bossów do wyświetlenia.\nGracze muszą wysyłać screeny przez `/update` aby pojawili się w rankingu.',
     bossRankingBackList: 'Lista bossów',
@@ -653,6 +656,7 @@ const eng = {
     recordProgress: '📈 Progress',
     recordRanking: '🏅 Position',
     recordBossRanking: '👾 Position (boss)',
+    recordBossServerPosition: '👾 Server position (boss {bossName})',
     recordPromotionBy: 'promoted by',
     recordNewEntry: 'new entry',
     recordDateLabel: '📅 Date',
@@ -930,10 +934,12 @@ const eng = {
 
     // Boss / achievement rankings
     buttonBossRanking: 'Boss Rankings',
+    buttonBossRankingServer: 'Boss rankings {guildName}',
     buttonAchRanking: 'Achievement Ranking',
     bossRankingTitle: '👾 Ranking',
     bossRankingSelectTitle: '👾 Select a Boss',
     bossRankingSelectDesc: 'Choose a boss from the list to view the global ranking.',
+    bossRankingSelectDescServer: 'Choose a boss from the list to view the **{guildName}** server ranking.',
     bossRankingSelectPlaceholder: 'Choose a boss...',
     bossRankingNoBosses: '📭 No boss records to display yet.\nPlayers need to submit screenshots via `/update` to appear in the ranking.',
     bossRankingBackList: 'Boss list',

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -6270,6 +6270,12 @@ class InteractionHandler {
                     const safeUserNameCs = userName.replace(/[^a-zA-Z0-9]/g, '_');
                     const imageAttachmentCs = new AttachmentBuilder(tempImagePath, { name: `rekord_${safeUserNameCs}_${Date.now()}.${fileExtension}` });
 
+                    // Pozycja w rankingu bossa na serwerze, na którym wynik faktycznie leży (poprzedni serwer gracza)
+                    const csBossServerPosition = wasUnknownBossCs ? null : await this._buildBossServerPosition(
+                        sourceGuildId, bossName, playerKey,
+                        { dryRun, scoreValue: bossScoreValue, score: bestScore, username: userName }
+                    );
+
                     const _botUserCs = interaction.client.user;
                     const csEmbeds = await this.rankingService.createRecordEmbeds({
                         userName,
@@ -6288,6 +6294,7 @@ class InteractionHandler {
                         globalSnippetData: null, // brak Embedu 2 (ranking globalny niezmieniony)
                         bossRecordData: { isNewBossRecord: true, previousBossRecord: csPrevBossRecord, bossName },
                         bossSnippetData: csBossSnippet,
+                        bossServerPosition: csBossServerPosition,
                         bossName,
                         botName: _botUserCs?.username || null,
                         botIconUrl: _botUserCs?.displayAvatarURL() || null,
@@ -6642,6 +6649,12 @@ class InteractionHandler {
                     } catch { /* bez ikony bossa */ }
                 }
 
+                // Pozycja w rankingu bossa NA SERWERZE (Embed 1)
+                const bossOnlyServerPosition = wasUnknownBoss ? null : await this._buildBossServerPosition(
+                    guildId, bossName, playerKey,
+                    { dryRun, scoreValue: this.rankingService.parseScoreValue(bestScore), score: bestScore, username: userName }
+                );
+
                 const _botUserBoss = interaction.client.user;
                 const bossPublicEmbeds = await this.rankingService.createRecordEmbeds({
                     userName,
@@ -6660,6 +6673,7 @@ class InteractionHandler {
                     globalSnippetData: null, // brak Embedu 2
                     bossRecordData: { isNewBossRecord: true, previousBossRecord, bossName },
                     bossSnippetData: bossSnippetDataLocal,
+                    bossServerPosition: bossOnlyServerPosition,
                     bossName,
                     botName: _botUserBoss?.username || null,
                     botIconUrl: _botUserBoss?.displayAvatarURL() || null,
@@ -6816,6 +6830,14 @@ class InteractionHandler {
                 }
             }
 
+            // Pozycja w rankingu bossa NA SERWERZE (Embed 1) — pokazywana zawsze gdy boss jest znany
+            let bossServerPositionData = null;
+            if (bossName && !wasUnknownBoss) {
+                bossServerPositionData = await this._buildBossServerPosition(guildId, bossName, playerKey, {
+                    dryRun, scoreValue: _newScoreValue, score: bestScore, username: userName,
+                });
+            }
+
             // === Komunikaty systemowe (Embed 4) ===
             const systemNotices = [];
             if (wasUnknownBoss && isNewBossRecord && bossName) {
@@ -6936,6 +6958,7 @@ class InteractionHandler {
                 globalSnippetData,
                 bossRecordData: isNewBossRecord && !wasUnknownBoss ? { isNewBossRecord, previousBossRecord, bossName } : null,
                 bossSnippetData,
+                bossServerPosition: bossServerPositionData,
                 bossName,
                 botName: _botUser?.username || null,
                 botIconUrl: _botUser?.displayAvatarURL() || null,
@@ -8115,6 +8138,11 @@ class InteractionHandler {
                 await this._handleRankingBossList(interaction);
                 return;
             }
+            // Ranking bossów zawężony do jednego serwera
+            if (customId.startsWith('ranking_boss_srv_')) {
+                await this._handleRankingBossList(interaction, customId.replace('ranking_boss_srv_', ''));
+                return;
+            }
             if (customId === 'panel_ban_guild') {
                 if (!this._isHeadAdmin(interaction.user.id)) {
                     await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
@@ -8820,6 +8848,26 @@ class InteractionHandler {
         }
     }
 
+    /**
+     * Pozycja profilu w rankingu danego bossa NA SERWERZE (nie globalnie) — linijka w Embedzie 1.
+     * /test (dryRun) korzysta z symulacji, żeby podgląd był identyczny jak po zapisie.
+     * @returns {Promise<{position: number, total: number}|null>}
+     */
+    async _buildBossServerPosition(guildId, bossName, playerKey, opts = {}) {
+        if (!this.bossRecordService || !guildId || !bossName || !playerKey) return null;
+        const { dryRun = false, scoreValue = 0, score = null, username = null } = opts;
+        try {
+            const ranking = dryRun
+                ? await this.bossRecordService.simulateGlobalBossRanking([guildId], bossName, playerKey, scoreValue, score, username, guildId)
+                : await this.bossRecordService.getGlobalBossRanking([guildId], bossName);
+            const idx = ranking.findIndex(p => (p.playerKey || p.userId) === playerKey);
+            if (idx === -1) return null;
+            return { position: idx + 1, total: ranking.length };
+        } catch {
+            return null;
+        }
+    }
+
     // Buduje dane snippetu zmiany w rankingu bossa (format identyczny jak globalSnippetData).
     // Zwraca { title, description } lub null.
     async _buildBossSnippetData(playerKey, bossName, previousBossRecord, allGuildIds, msgs, client, bossRankingOverride = null) {
@@ -8861,6 +8909,9 @@ class InteractionHandler {
 
     async _handleRankingSelect(interaction, customId) {
         await interaction.deferUpdate();
+
+        // Wychodzimy z rankingu bossa — inaczej paginacja tej wiadomości wracałaby do bossa
+        this._bossRankings.delete(interaction.message.id);
 
         // Język użytkownika = język serwera, na którym kliknął przycisk
         const msgs = this.msgs(interaction.guildId);
@@ -9028,6 +9079,7 @@ class InteractionHandler {
      */
     async _handleRankingBack(interaction) {
         await interaction.deferUpdate();
+        this._bossRankings.delete(interaction.message.id);
         const msgs = this.msgs(interaction.guildId);
         const selectRows = this.rankingService.createServerSelectButtons(interaction.client, msgs, interaction.guildId, 0);
         await interaction.editReply({
@@ -9059,6 +9111,7 @@ class InteractionHandler {
      */
     async _handleRoleRankingSelect(interaction, customId) {
         await interaction.deferUpdate();
+        this._bossRankings.delete(interaction.message.id);
         const msgs = this.msgs(interaction.guildId);
 
         // customId: ranking_role_{guildId}_{roleId}
@@ -9143,6 +9196,8 @@ class InteractionHandler {
      */
     async _handleGuildRankingSelect(interaction) {
         await interaction.deferUpdate();
+        // Wychodzimy z rankingu bossa — inaczej paginacja tej wiadomości wracałaby do bossa
+        this._bossRankings.delete(interaction.message.id);
         const msgs = this.msgs(interaction.guildId);
 
         // Pobierz poprzedni stan — potrzebny parentGuildId
@@ -9904,6 +9959,11 @@ class InteractionHandler {
 
             if (customId === 'ranking_boss_sel') {
                 await this._handleRankingBossShow(interaction);
+                return;
+            }
+
+            if (customId.startsWith('ranking_boss_ssel_')) {
+                await this._handleRankingBossShow(interaction, customId.replace('ranking_boss_ssel_', ''));
                 return;
             }
 
@@ -11597,6 +11657,11 @@ class InteractionHandler {
                             } catch { /* bez ikony bossa */ }
                         }
 
+                        // Pozycja w rankingu bossa NA SERWERZE (Embed 1)
+                        const analyzeBossServerPosition = (aiResult.bossName && !analyzeWasUnknownBoss)
+                            ? await this._buildBossServerPosition(targetGuildId, aiResult.bossName, targetPlayerKey)
+                            : null;
+
                         const _analyzeBotUser = interaction.client.user;
                         const manualVerificationNote = formatMessage(targetMsgs.analyzeManualAnnouncement, {
                             userId: targetUserId,
@@ -11624,6 +11689,7 @@ class InteractionHandler {
                             globalSnippetData: analyzeGlobalSnippetData,
                             bossRecordData: isNewBossRecord && !analyzeWasUnknownBoss ? { isNewBossRecord, previousBossRecord, bossName: aiResult.bossName } : null,
                             bossSnippetData: analyzeBossSnippetData,
+                            bossServerPosition: analyzeBossServerPosition,
                             bossName: aiResult.bossName,
                             botName: _analyzeBotUser?.username || null,
                             botIconUrl: _analyzeBotUser?.displayAvatarURL() || null,
@@ -15119,27 +15185,36 @@ class InteractionHandler {
     // =========================================================================
 
     /** Wyświetla select menu z listą bossów mających rekordy */
-    async _handleRankingBossList(interaction) {
+    async _handleRankingBossList(interaction, srvGuildId = null) {
         await interaction.deferUpdate();
         const msgs = this.msgs(interaction.guildId);
         if (!this.bossRecordService) {
             await interaction.editReply({ content: msgs.rankingError, embeds: [], components: [] });
             return;
         }
-        const allGuildIds = this.guildConfigService?.getAllConfiguredGuildIds()
-            || Array.from(interaction.client.guilds.cache.keys());
+        // srvGuildId = ranking bossów zawężony do jednego serwera; null = ranking globalny
+        const rankGuildIds = srvGuildId
+            ? [srvGuildId]
+            : (this.guildConfigService?.getAllConfiguredGuildIds() || Array.from(interaction.client.guilds.cache.keys()));
+        const guildName = srvGuildId
+            ? (interaction.client.guilds.cache.get(srvGuildId)?.name || srvGuildId)
+            : null;
         const knownNames = this.bossAliasService?.getExtraEnglishNames() || [];
-        const bosses = await this.bossRecordService.getBossesWithRecords(allGuildIds, knownNames);
+        const bosses = await this.bossRecordService.getBossesWithRecords(rankGuildIds, knownNames);
+
+        const embedColor = srvGuildId ? 0xF1C40F : 0x5865F2;
+        const backBtn = srvGuildId
+            ? new ButtonBuilder().setCustomId(`ranking_select_server_${srvGuildId}`).setEmoji('↩️')
+                .setLabel((guildName || msgs.buttonBack || 'Powrót').substring(0, 70)).setStyle(ButtonStyle.Danger)
+            : new ButtonBuilder().setCustomId('ranking_select_global').setEmoji('🌐')
+                .setLabel(msgs.rankingGlobal || 'Global').setStyle(ButtonStyle.Secondary);
 
         if (!bosses.length) {
-            const backRow = new ActionRowBuilder().addComponents(
-                new ButtonBuilder().setCustomId('ranking_select_global').setEmoji('🌐').setLabel(msgs.rankingGlobal || 'Global').setStyle(ButtonStyle.Primary),
-            );
             await interaction.editReply({
-                embeds: [new EmbedBuilder().setColor(0x5865F2)
+                embeds: [new EmbedBuilder().setColor(embedColor)
                     .setTitle(msgs.bossRankingSelectTitle || '🎯 Ranking Bossów')
                     .setDescription(msgs.bossRankingNoBosses || '📭 Brak wyników bossów do wyświetlenia.')],
-                components: [backRow],
+                components: [new ActionRowBuilder().addComponents(backBtn)],
                 files: [],
                 attachments: [],
             });
@@ -15153,24 +15228,26 @@ class InteractionHandler {
                 .setDescription(`${b.totalPlayers} ${msgs.bossRankingPlayers || 'graczy'}`)
         );
         const select = new StringSelectMenuBuilder()
-            .setCustomId('ranking_boss_sel')
+            .setCustomId(srvGuildId ? `ranking_boss_ssel_${srvGuildId}` : 'ranking_boss_sel')
             .setPlaceholder(msgs.bossRankingSelectPlaceholder || 'Wybierz bossa...')
             .addOptions(options);
-        const backRow = new ActionRowBuilder().addComponents(
-            new ButtonBuilder().setCustomId('ranking_select_global').setEmoji('🌐').setLabel(msgs.rankingGlobal || 'Global').setStyle(ButtonStyle.Secondary),
-        );
+
+        const description = srvGuildId
+            ? formatMessage(msgs.bossRankingSelectDescServer || 'Wybierz bossa z listy aby zobaczyć ranking serwera **{guildName}**.', { guildName })
+            : (msgs.bossRankingSelectDesc || 'Wybierz bossa z listy aby zobaczyć globalny ranking.');
+
         await interaction.editReply({
-            embeds: [new EmbedBuilder().setColor(0x5865F2)
+            embeds: [new EmbedBuilder().setColor(embedColor)
                 .setTitle(msgs.bossRankingSelectTitle || '🎯 Ranking Bossów')
-                .setDescription(msgs.bossRankingSelectDesc || 'Wybierz bossa z listy aby zobaczyć globalny ranking.')],
-            components: [new ActionRowBuilder().addComponents(select), backRow],
+                .setDescription(description)],
+            components: [new ActionRowBuilder().addComponents(select), new ActionRowBuilder().addComponents(backBtn)],
             files: [],
             attachments: [],
         });
     }
 
-    /** Wyświetla globalny ranking dla wybranego bossa */
-    async _handleRankingBossShow(interaction) {
+    /** Wyświetla ranking dla wybranego bossa — globalny albo zawężony do jednego serwera */
+    async _handleRankingBossShow(interaction, srvGuildId = null) {
         await interaction.deferUpdate();
         const msgs = this.msgs(interaction.guildId);
         if (!this.bossRecordService) {
@@ -15178,8 +15255,12 @@ class InteractionHandler {
             return;
         }
         const bossName = interaction.values[0];
-        const allGuildIds = this.guildConfigService?.getAllConfiguredGuildIds()
-            || Array.from(interaction.client.guilds.cache.keys());
+        const guildName = srvGuildId
+            ? (interaction.client.guilds.cache.get(srvGuildId)?.name || srvGuildId)
+            : null;
+        const allGuildIds = srvGuildId
+            ? [srvGuildId]
+            : (this.guildConfigService?.getAllConfiguredGuildIds() || Array.from(interaction.client.guilds.cache.keys()));
         const players = await this.bossRecordService.getGlobalBossRanking(allGuildIds, bossName);
 
         const perPage = this.config.ranking.playersPerPage || 10;
@@ -15202,19 +15283,19 @@ class InteractionHandler {
             }
         }
 
-        // Wykres postępu graczy dla bossów — tylko wyniki z tego bossa
+        // Wykres postępu graczy dla bossów — tylko wyniki z tego bossa (i tylko z serwerów rankingu)
         let chartAttachment = null;
         try {
-            const allGuildIdsForChart = this.guildConfigService?.getAllConfiguredGuildIds()
-                || Array.from(interaction.client.guilds.cache.keys());
             const t = this._panelT(interaction.guildId);
-            chartAttachment = await this._buildBossRankingChartAttachment(players, 0, allGuildIdsForChart, bossName, t);
+            chartAttachment = await this._buildBossRankingChartAttachment(players, 0, allGuildIds, bossName, t);
         } catch { /* wykres opcjonalny */ }
 
         const embed = this.rankingService.createBossRankingEmbed(
-            bossName, players, 0, perPage, msgs, bossImageName, this._mainPlayerKey(interaction.user.id), interaction.client
+            bossName, players, 0, perPage, msgs, bossImageName, this._mainPlayerKey(interaction.user.id), interaction.client, guildName
         );
-        const buttons = this.rankingService.createBossRankingButtons(0, totalPages, userPage, false, msgs);
+        const buttons = this.rankingService.createBossRankingButtons(0, totalPages, userPage, false, msgs, {
+            guildId: srvGuildId, guildName
+        });
 
         const rankingData = {
             bossName,
@@ -15224,6 +15305,8 @@ class InteractionHandler {
             userId: interaction.user.id,
             userPage,
             allGuildIds,
+            srvGuildId,
+            guildName,
         };
         const reply = await interaction.fetchReply();
         this._bossRankings.set(reply.id, rankingData);
@@ -15283,9 +15366,12 @@ class InteractionHandler {
         } catch { /* wykres opcjonalny */ }
 
         const embed = this.rankingService.createBossRankingEmbed(
-            rankingData.bossName, rankingData.players, newPage, perPage, msgs, bossImageName, this._mainPlayerKey(interaction.user.id), interaction.client
+            rankingData.bossName, rankingData.players, newPage, perPage, msgs, bossImageName,
+            this._mainPlayerKey(interaction.user.id), interaction.client, rankingData.guildName || null
         );
-        const buttons = this.rankingService.createBossRankingButtons(newPage, rankingData.totalPages, rankingData.userPage, false, msgs);
+        const buttons = this.rankingService.createBossRankingButtons(newPage, rankingData.totalPages, rankingData.userPage, false, msgs, {
+            guildId: rankingData.srvGuildId || null, guildName: rankingData.guildName || null
+        });
 
         const files = [];
         const embeds = [embed];

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -725,20 +725,68 @@ class RankingService {
                 .setCustomId('ranking_next')
                 .setEmoji('▶️')
                 .setStyle(ButtonStyle.Secondary)
-                .setDisabled(disabled || page >= totalPages - 1),
-
-            switchBtn,
-            backBtn
+                .setDisabled(disabled || page >= totalPages - 1)
         );
+
+        if (mode === 'server') {
+            // Rząd 1: nawigacja (◀ 🎯 ▶) · Rząd 2: Global | Ranking bossów serwera | Rankingi serwerów
+            // Rząd 3+: rankingi ról
+            const bossSrvLabel = guildName
+                ? formatMessage(msgs.buttonBossRankingServer || 'Ranking bossów {guildName}', { guildName }).substring(0, 80)
+                : (msgs.buttonBossRanking || 'Ranking Bossów');
+
+            const modeRow = new ActionRowBuilder().addComponents(
+                switchBtn,
+                new ButtonBuilder()
+                    .setCustomId(`ranking_boss_srv_${guildId || ''}`)
+                    .setEmoji('👾')
+                    .setLabel(bossSrvLabel)
+                    .setStyle(ButtonStyle.Secondary)
+                    .setDisabled(disabled || !guildId),
+                backBtn
+            );
+
+            return [navRow, modeRow, ...roleRows];
+        }
+
+        navRow.addComponents(switchBtn, backBtn);
 
         return [navRow, ...roleRows];
     }
 
     /**
      * Tworzy przyciski nawigacji dla rankingu bossa (tryb 'boss').
+     * @param {object} options
+     * @param {string|null} options.guildId - ranking per-serwer (null = globalny)
+     * @param {string|null} options.guildName - nazwa serwera (etykieta przycisku powrotu)
      */
-    createBossRankingButtons(page, totalPages, userPage, disabled, messages) {
+    createBossRankingButtons(page, totalPages, userPage, disabled, messages, options = {}) {
         const msgs = messages || this.config.messages;
+        const { guildId = null, guildName = null } = options;
+
+        // Powrót do listy bossów — tej samej, z której wszedł użytkownik (globalna albo serwerowa)
+        const listBtn = new ButtonBuilder()
+            .setCustomId(guildId ? `ranking_boss_srv_${guildId}` : 'ranking_boss_list')
+            .setEmoji('📋')
+            .setLabel(msgs.bossRankingBackList || 'Lista bossów')
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(disabled);
+
+        // Wyjście z rankingu bossa — do rankingu serwera (tryb serwerowy) albo globalnego
+        const exitBtn = guildId
+            ? new ButtonBuilder()
+                .setCustomId(`ranking_select_server_${guildId}`)
+                .setEmoji('↩️')
+                .setLabel((guildName || msgs.buttonBack || 'Powrót').substring(0, 70))
+                .setStyle(ButtonStyle.Danger)
+                .setDisabled(disabled)
+            : new ButtonBuilder()
+                .setCustomId('ranking_select_global')
+                .setEmoji('🌐')
+                .setLabel(msgs.buttonGlobal || 'Global')
+                .setStyle(ButtonStyle.Danger)
+                .setDisabled(disabled);
+
         const navRow = new ActionRowBuilder().addComponents(
             new ButtonBuilder()
                 .setCustomId('ranking_prev')
@@ -759,27 +807,17 @@ class RankingService {
                 .setStyle(ButtonStyle.Secondary)
                 .setDisabled(disabled || page >= totalPages - 1),
 
-            new ButtonBuilder()
-                .setCustomId('ranking_boss_list')
-                .setEmoji('📋')
-                .setLabel(msgs.bossRankingBackList || 'Lista bossów')
-                .setStyle(ButtonStyle.Secondary)
-                .setDisabled(disabled),
-
-            new ButtonBuilder()
-                .setCustomId('ranking_select_global')
-                .setEmoji('🌐')
-                .setLabel(msgs.buttonGlobal || 'Global')
-                .setStyle(ButtonStyle.Danger)
-                .setDisabled(disabled)
+            listBtn,
+            exitBtn
         );
         return [navRow];
     }
 
     /**
-     * Tworzy embed rankingu bossa (globalny, tryb 'boss').
+     * Tworzy embed rankingu bossa (globalny lub per-serwer, tryb 'boss').
+     * @param {string|null} guildName - nazwa serwera; podana = ranking zawężony do tego serwera
      */
-    createBossRankingEmbed(bossName, players, page, perPage, messages, bossImageName = null, callerUserId = null, client = null) {
+    createBossRankingEmbed(bossName, players, page, perPage, messages, bossImageName = null, callerUserId = null, client = null, guildName = null) {
         const msgs = messages || this.config.messages;
         const startIdx = page * perPage;
         const pagePlayers = players.slice(startIdx, startIdx + perPage);
@@ -809,7 +847,8 @@ class RankingService {
                 ? `${date.getDate().toString().padStart(2, '0')}.${(date.getMonth() + 1).toString().padStart(2, '0')}`
                 : '—';
 
-            const guildTag = p.sourceGuildId
+            // W rankingu per-serwer wszystkie wpisy pochodzą z tego samego serwera — tag byłby szumem
+            const guildTag = (!guildName && p.sourceGuildId)
                 ? (this.config.getAllGuilds().find(g => g.id === p.sourceGuildId)?.tag || null)
                 : null;
             const tagSuffix = guildTag ? `  ·  ${guildTag.replace(/^<a?:([^:]+):\d+>$/, '$1')}` : '';
@@ -828,11 +867,16 @@ class RankingService {
             statsLines.push(formatMessage(msgs.rankingHighestScore, { score: players[0].score || this.formatScore(players[0].scoreValue) }));
         }
 
+        // Ranking per-serwer złoty (jak ranking serwera), globalny niebieski
         const embed = new EmbedBuilder()
-            .setColor(0x5865F2)
-            .setTitle(`${msgs.bossRankingTitle || '🎯 Ranking'} — ${bossName}`)
+            .setColor(guildName ? 0xF1C40F : 0x5865F2)
+            .setTitle(`${msgs.bossRankingTitle || '🎯 Ranking'} — ${bossName}${guildName ? ` · ${guildName}` : ''}`.substring(0, 256))
             .setDescription(rankingText)
-            .addFields({ name: msgs.rankingStatsGlobal || msgs.rankingStats || '📊 Statystyki', value: statsLines.join('\n'), inline: false })
+            .addFields({
+                name: (guildName ? (msgs.rankingStats || msgs.rankingStatsGlobal) : (msgs.rankingStatsGlobal || msgs.rankingStats)) || '📊 Statystyki',
+                value: statsLines.join('\n'),
+                inline: false
+            })
             .setFooter({ text: formatMessage(msgs.rankingPage, { current: page + 1, total: totalPages }) })
             .setTimestamp();
 
@@ -1083,6 +1127,7 @@ class RankingService {
             globalSnippetData = null,
             bossRecordData = null,
             bossSnippetData = null,
+            bossServerPosition = null, // { position, total } — pozycja w rankingu bossa NA SERWERZE (Embed 1)
             bossName = null,
             botName = null,
             botIconUrl = null,
@@ -1184,6 +1229,15 @@ class RankingService {
                 posLine += `  *(${msgs.recordNewEntry})*`;
             }
             descLines.push(posLine);
+        }
+        // Pozycja w rankingu danego bossa NA SERWERZE (nie globalnie) — jedna linijka
+        if (bossServerPosition?.position) {
+            const bossLabel = formatMessage(
+                msgs.recordBossServerPosition || '👾 Pozycja na serwerze (boss {bossName})',
+                { bossName: bossName || bossRecordData?.bossName || '' }
+            );
+            const totalSuffix = bossServerPosition.total ? ` / ${bossServerPosition.total}` : '';
+            descLines.push(`**${bossLabel}:** #${bossServerPosition.position}${totalSuffix}`);
         }
         if (rolePositions?.length > 0) {
             for (const rp of rolePositions) {


### PR DESCRIPTION
## Co zmienione

### 1. Pozycja na serwerze w rankingu bossa — Embed 1 ogłoszenia po `/update`

Nowa linijka w pierwszym embedzie, zaraz pod pozycją w klanie:

```
👾 Pozycja na serwerze (boss Shardstone Bug): #3 / 17
```

- liczona helperem `_buildBossServerPosition(guildId, bossName, playerKey)` przez `bossRecordService.getGlobalBossRanking([guildId], boss)` — czyli **tylko z tego serwera**, nie globalnie
- `/test` (dryRun) używa `simulateGlobalBossRanking`, żeby podgląd był identyczny z realnym zapisem
- pokazywana **zawsze gdy boss jest znany**, także gdy rekord bossa nie został pobity (to aktualna pozycja, nie zmiana); pomijana przy nierozpoznanej nazwie bossa
- podpięta we wszystkich ścieżkach ogłoszenia rekordu: `/update`, `/test`, „tylko rekord bossa", cross-server (tam liczona dla `sourceGuildId`, bo tam wynik faktycznie leży) i panel „Analizuj"
- nowy klucz `recordBossServerPosition` w obu językach

### 2. Ranking bossów per serwer

- nowy przycisk `👾 Ranking bossów {nazwa serwera}` (`ranking_boss_srv_{guildId}`) w widoku rankingu serwera
- klik → lista bossów mających rekordy **na tym serwerze** → select `ranking_boss_ssel_{guildId}` → ranking zawężony do serwera
- embed złoty (`0xF1C40F`, jak ranking serwera) zamiast blurple, tytuł `👾 Ranking — {boss} · {serwer}`, bez tagów serwera przy wpisach (wszystkie z tego samego)
- wykres progresu graczy budowany tylko z historii tego serwera
- nawigacja: `📋 Lista bossów` wraca do listy tego samego zakresu, ostatni przycisk to `↩️ {nazwa serwera}` zamiast `🌐 Global`
- zakres (`srvGuildId`, `guildName`) trzymany w `_bossRankings`, więc paginacja nie gubi kontekstu
- wspólna implementacja z rankingiem globalnym — różnica to wyłącznie lista ID serwerów przekazana do `bossRecordService`

### 3. Nowy układ przycisków w widoku rankingu serwera

| Rząd | Przyciski |
|---|---|
| 1 | `◀️` · `🎯 Moja pozycja` · `▶️` |
| 2 | `🌐 Global` · `👾 Ranking bossów {serwer}` · `↩️ Rankingi serwerów` |
| 3+ | rankingi ról |

Tryby `global` / `guild_ranking` / `role` zostają bez zmian.

### 4. Przy okazji — naprawiony błąd stanu paginacji

Wpis w `_bossRankings` nigdy nie był kasowany, a routing paginacji sprawdza go **przed** `getActiveRanking`. Po wyjściu z rankingu bossa (dotąd: do Global; teraz także: do rankingu serwera) kliknięcie ◀️/▶️ przerysowywało ranking bossa zamiast aktualnego widoku. Wpis jest teraz kasowany w `_handleRankingSelect`, `_handleRoleRankingSelect`, `_handleGuildRankingSelect` i `_handleRankingBack`.

## Testy

- `node --check` na wszystkich zmienionych plikach
- render przycisków dla trybów server/global/role/boss w obu językach (m.in. ucinanie długiej nazwy serwera do limitu 80 znaków etykiety)
- render linijki pozycji bossa w Embedzie 1
- test `bossRecordService` na tymczasowych danych (2 serwery, 2 bossy): ranking globalny `Cezar, Bob, Ala` vs ranking G1 `Bob, Ala`; ten sam gracz `#2/2` na serwerze i `#3` globalnie; lista bossów poprawnie zawężona per serwer

Nie testowano na żywym Discordzie — bot działa na produkcji, więc interakcje warto sprawdzić po deployu.

## Dokumentacja

`EndersEcho/CLAUDE.md` zaktualizowany: opis Embedu 1, sekcja rankingu bossów (nowy podpunkt „per SERWER"), układ przycisków rankingu serwera, tabela customIDs, notka o kasowaniu `_bossRankings`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgDQZHTyLRu2XCjAsLesww)_