### PR TITLE
Nagłówek rankingu bossa na serwerze bez nazwy serwera (EndersEcho)

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -557,7 +557,7 @@
   - Powrót: przyciski `📋 Lista bossów` i `🌐 Global` w `createBossRankingButtons`
 - **Ranking Bossów per SERWER:**
   - Przycisk `👾 Ranking bossów {nazwa serwera}` (`ranking_boss_srv_{guildId}`) w rzędzie 2 widoku rankingu serwera → ta sama metoda `_handleRankingBossList(interaction, guildId)`, ale lista bossów liczona z **jednego** serwera (`getBossesWithRecords([guildId], …)`)
-  - Wybór bossa → StringSelectMenu `ranking_boss_ssel_{guildId}` → `_handleRankingBossShow(interaction, guildId)` → ranking zawężony do serwera (`getGlobalBossRanking([guildId], boss)`); embed **złoty** (`0xF1C40F`, jak ranking serwera), tytuł `👾 Ranking — {boss} · {serwer}`, bez tagu serwera przy wpisach (wszystkie z tego samego serwera)
+  - Wybór bossa → StringSelectMenu `ranking_boss_ssel_{guildId}` → `_handleRankingBossShow(interaction, guildId)` → ranking zawężony do serwera (`getGlobalBossRanking([guildId], boss)`); embed **złoty** (`0xF1C40F`, jak ranking serwera), tytuł `👾 Ranking — {boss}` (**bez nazwy serwera** — zakres widać po kolorze, przycisku powrotu i nagłówku statystyk), bez tagu serwera przy wpisach (wszystkie z tego samego serwera), nagłówek statystyk `📊 Statystyki` zamiast `📊 Statystyki globalne`
   - Wykres progresu graczy budowany wyłącznie z historii tego serwera (`_buildBossRankingChartAttachment` dostaje `[guildId]`)
   - Nawigacja: `📋 Lista bossów` wraca do listy tego samego zakresu (serwerowej albo globalnej), ostatni przycisk to `↩️ {nazwa serwera}` (powrót do rankingu serwera) zamiast `🌐 Global`
   - Zakres (`srvGuildId`, `guildName`, `allGuildIds`) trzymany w `_bossRankings` — paginacja nie gubi kontekstu serwera

--- a/EndersEcho/services/rankingService.js
+++ b/EndersEcho/services/rankingService.js
@@ -870,7 +870,7 @@ class RankingService {
         // Ranking per-serwer złoty (jak ranking serwera), globalny niebieski
         const embed = new EmbedBuilder()
             .setColor(guildName ? 0xF1C40F : 0x5865F2)
-            .setTitle(`${msgs.bossRankingTitle || '🎯 Ranking'} — ${bossName}${guildName ? ` · ${guildName}` : ''}`.substring(0, 256))
+            .setTitle(`${msgs.bossRankingTitle || '🎯 Ranking'} — ${bossName}`.substring(0, 256))
             .setDescription(rankingText)
             .addFields({
                 name: (guildName ? (msgs.rankingStats || msgs.rankingStatsGlobal) : (msgs.rankingStatsGlobal || msgs.rankingStats)) || '📊 Statystyki',


### PR DESCRIPTION
## Zmiana

Tytuł embeda rankingu bossa zawężonego do serwera:

```
przed:  👾 Ranking — Frontier Terminator · Kraken Community
po:     👾 Ranking — Frontier Terminator
```

Jedna linia w `createBossRankingEmbed` — `guildName` nie trafia już do `setTitle()`.

## Co dalej odróżnia ten widok od globalnego

`guildName` nadal steruje resztą, więc zakres pozostaje czytelny:
- złoty kolor `0xF1C40F` zamiast blurple
- nagłówek statystyk `📊 Statystyki` zamiast `📊 Statystyki globalne`
- brak tagów serwera przy wpisach
- przycisk powrotu z nazwą serwera zamiast `🌐 Global`

## Dokumentacja

`EndersEcho/CLAUDE.md` — opis tytułu zaktualizowany wraz z notką, po czym poznać zakres rankingu.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgDQZHTyLRu2XCjAsLesww)_