### PR TITLE
EndersEcho: wysyłka rankingów TOP 10 na stronę

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -704,6 +704,21 @@
 - Panel Admina (tryb Admin): Administrator Discord lub moderator gry → usuń gracza, odblokuj, tokeny
 - Panel Admina (tryb Head Admin): `ENDERSECHO_BLOCK_OCR_USER_IDS` → wszystko + info, OCR toggle, limit
 
+## Rankingi TOP 10 na stronie (endersecho.thashar.dev)
+
+**Plik:** `services/webRankingSyncService.js` · **Stan:** `data/web_sync.json` · **Odbiornik:** `POST /api/ee-rankings` w workerze repo `thashar.dev`
+
+- **Kierunek jest jeden: bot → strona.** Strona NIGDY nie odpytuje bota, więc serwer produkcyjny zostaje zamknięty na świat, a ranking na stronie działa nawet gdy bot jest zrestartowany (Worker oddaje ostatni snapshot z Durable Object)
+- **Co jedzie:** nazwa serwera, tag, liczba graczy (osób, `countPeople`) i TOP 10 — pozycja, nick (`formatProfileDisplayName`, więc profile dodatkowe mają `②`), wynik, boss i data. **ŚWIADOMIE bez ID Discorda i avatarów** — nick wystarcza do rankingu, a ID dałoby się połączyć z kontem
+- **Kiedy:**
+  - przy starcie bota → `syncAll(client)`: pełny snapshot wszystkich skonfigurowanych serwerów, na których bot jest obecny, z flagą `replaceAll` (Worker kasuje wtedy serwery, których bot już nie obsługuje — inaczej wisiałyby na stronie z zamrożonym rankingiem)
+  - po każdym zapisanym wyniku → `syncGuild(guildId, client)` **tylko gdy TOP 10 faktycznie się zmienił** (porównanie skrótu SHA-1 listy: pozycja + nick + wynik + boss). Zwykłe `/update`, które nie rusza czołówki, nie generuje żadnego ruchu
+  - dodatkowo po cofnięciu rekordu (`rec_undo_*`) i po `🧹 Usuń wynik` — obie akcje mogą zmienić czołówkę
+- **Persistencja skrótów:** `data/web_sync.json` — po restarcie bot nie wysyła wszystkiego ponownie tylko dlatego, że zapomniał, co już wysłał (pełny `syncAll` przy starcie i tak odświeża stronę)
+- **Wyłączone bez konfiguracji:** brak `ENDERSECHO_WEB_SYNC_URL` lub `ENDERSECHO_WEB_SYNC_TOKEN` → `isEnabled()` zwraca `false` i serwis nic nie robi (żadnych błędów w logach)
+- **Błędy nie przerywają flow** — wysyłka jest fire-and-forget, a niepowodzenie ląduje jako `warn` w logu
+- **Po stronie strony:** kafelki klanów w sekcji „COMMUNITIES USING THE BOT" renderowane są z tych danych i dopiero wtedy stają się klikalne; klik otwiera nakładkę z embedem TOP 10 w stylu bota. Gdy API nie odpowie, zostaje statyczna, nieklikalna lista z HTML-a
+
 **Struktura danych:**
 ```
 EndersEcho/data/
@@ -961,6 +976,12 @@ Po **pierwszej** konfiguracji serwera (`!wasAlreadyConfigured`) bot **automatycz
 **Konfiguracja (zmienna env):**
 ```env
 ENDERSECHO_ADMIN_PANEL_CHANNEL_ID=id_kanalu_head_admina
+
+# Rankingi TOP 10 na stronie (opcjonalne) — bez tych zmiennych wysyłka jest wyłączona
+# URL endpointu workera + sekret ustawiony po stronie Cloudflare (wrangler secret put EE_RANKING_TOKEN)
+ENDERSECHO_WEB_SYNC_URL=https://endersecho.thashar.dev/api/ee-rankings
+ENDERSECHO_WEB_SYNC_TOKEN=ten_sam_sekret_co_w_cloudflare
+ENDERSECHO_WEB_SYNC_TOP=10
 ```
 
 **Działanie:** Panel to **7 osobnych wiadomości** (każda: 1 embed + własne rzędy przycisków) na kanale head admina. Edytowane automatycznie po każdym zdarzeniu. Kolejność sekcji = `SECTION_KEYS` w `adminPanelService.js`: `system, users, servers, bosses, stats, costs, tools`. Przy zmianie układu sekcji stare wiadomości są usuwane (iteracja po `Object.values(_messageIds)` — także osierocone klucze starych układów) i wysyłane od nowa. Wszystkie dynamiczne pola przycinane helperem `capField()` (limit 1024/pole, 4096/opis) — zabezpieczenie przed crashem.

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -125,7 +125,7 @@ function buildGeminiUsage(aiResult) {
 }
 
 class InteractionHandler {
-    constructor(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService, roleRankingConfigService, usageLimitService, tokenUsageService, _botOps, guildConfigService, ocrBlockService, updateCooldownService, testerService, achievementService, communityVerificationService, scoreHistoryService = null, chartService = null, guildBanService = null, globalTop10Service = null, bossAliasService = null, ocrStatsService = null, bossRecordService = null, adminPanelService = null, commandUsageService = null, milestoneService = null, profileRegistryService = null, recordRevertService = null) {
+    constructor(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService, roleRankingConfigService, usageLimitService, tokenUsageService, _botOps, guildConfigService, ocrBlockService, updateCooldownService, testerService, achievementService, communityVerificationService, scoreHistoryService = null, chartService = null, guildBanService = null, globalTop10Service = null, bossAliasService = null, ocrStatsService = null, bossRecordService = null, adminPanelService = null, commandUsageService = null, milestoneService = null, profileRegistryService = null, recordRevertService = null, webRankingSyncService = null) {
         this.config = config;
         this.ocrService = ocrService;
         this.aiOcrService = aiOcrService;
@@ -155,6 +155,7 @@ class InteractionHandler {
         this.milestoneService = milestoneService;
         this.profileRegistryService = profileRegistryService;
         this.recordRevertService = recordRevertService;
+        this.webRankingSyncService = webRankingSyncService;
         this.profileService = new ProfileService({
             rankingService,
             bossRecordService,
@@ -3976,6 +3977,7 @@ class InteractionHandler {
                 interaction.member?.displayName || interaction.user.username).catch(() => {});
             this._ccAudit(interaction, `🧹 Usunięto wynik ${removed?.score || ''} gracza ${oldUsername}`);
             this.adminPanelService?.refresh();
+            this.webRankingSyncService?.syncGuild(targetGuildId, interaction.client).catch(() => {});
             const guildName = interaction.client.guilds.cache.get(targetGuildId)?.name;
             const serverNote = guildName ? ` (${guildName})` : '';
             let desc = t(
@@ -5163,6 +5165,8 @@ class InteractionHandler {
             }
             this.ocrStatsService?.recordReverted().catch(() => {});
             this.adminPanelService?.refresh();
+            // Cofnięcie mogło zmienić TOP 10 — odśwież ranking na stronie
+            this.webRankingSyncService?.syncGuild(session.guildId, interaction.client).catch(() => {});
 
             // Ogłoszenie dostaje notkę i nieaktywny czerwony przycisk: „Cofnął właściciel" albo „Cofnął admin"
             await this._applyRevertVisuals(interaction.client, session, by, actorName, {
@@ -6472,6 +6476,8 @@ class InteractionHandler {
                     this.adminPanelService.setLastRecord(userName, bestScore, bossName, guildId);
                     this.adminPanelService.refresh();
                 }
+                // TOP 10 na stronie — wysyłka tylko gdy czołówka serwera faktycznie się zmieniła
+                this.webRankingSyncService?.syncGuild(guildId, interaction.client).catch(() => {});
             }
 
             // Per-boss rekord (zawsze po pozytywnym OCR, niezależnie od isNewRecord)

--- a/EndersEcho/index.js
+++ b/EndersEcho/index.js
@@ -45,6 +45,7 @@ const KingBumChatService = require('./services/kingBumChatService');
 const { createLlmAdapter } = require('../utils/llmAdapter');
 const cron = require('node-cron');
 const AdminPanelService = require('./services/adminPanelService');
+const WebRankingSyncService = require('./services/webRankingSyncService');
 const CommandUsageService = require('./services/commandUsageService');
 
 const logger = createBotLogger('EndersEcho');
@@ -142,9 +143,11 @@ const adminPanelService = new AdminPanelService(config.ranking.dataDir, config, 
     commandUsageService,
     profileRegistryService,
 });
+// Wysyłka TOP 10 na stronę (endersecho.thashar.dev) — kierunek bot → strona
+const webRankingSyncService = new WebRankingSyncService(config, logger, { rankingService, guildConfigService });
 // Globalne liczniki zapytań API AI (requests/rejected/fullFailures) — zapisywane przez OcrStatsService
 aiOcrService.setStatsService(ocrStatsService);
-const interactionHandler = new InteractionHandler(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService, roleRankingConfigService, usageLimitService, tokenUsageService, null, guildConfigService, ocrBlockService, updateCooldownService, testerService, achievementService, communityVerificationService, scoreHistoryService, chartService, guildBanService, globalTop10Service, bossAliasService, ocrStatsService, bossRecordService, adminPanelService, commandUsageService, milestoneService, profileRegistryService, recordRevertService);
+const interactionHandler = new InteractionHandler(config, ocrService, aiOcrService, rankingService, logService, roleService, notificationService, userBlockService, roleRankingConfigService, usageLimitService, tokenUsageService, null, guildConfigService, ocrBlockService, updateCooldownService, testerService, achievementService, communityVerificationService, scoreHistoryService, chartService, guildBanService, globalTop10Service, bossAliasService, ocrStatsService, bossRecordService, adminPanelService, commandUsageService, milestoneService, profileRegistryService, recordRevertService, webRankingSyncService);
 
 /**
  * Inicjalizuje bota EndersEcho
@@ -216,6 +219,12 @@ async function initializeBot() {
         await adminPanelService.load();
         if (adminPanelService.isConfigured()) {
             adminPanelService.refresh();
+        }
+
+        // Pełny snapshot rankingów TOP 10 na stronę (potem już tylko zmiany po /update)
+        if (webRankingSyncService.isEnabled()) {
+            await webRankingSyncService.load();
+            webRankingSyncService.syncAll(client).catch(() => {});
         }
 
         // Dzienna wiadomość na nieskonfigurowanych serwerach (co dzień o 10:00 UTC)

--- a/EndersEcho/services/webRankingSyncService.js
+++ b/EndersEcho/services/webRankingSyncService.js
@@ -1,0 +1,181 @@
+'use strict';
+
+const fs = require('fs').promises;
+const path = require('path');
+const crypto = require('crypto');
+const { formatProfileDisplayName, getProfileIndex } = require('../utils/helpers');
+
+/**
+ * Wysyłka rankingów TOP 10 na stronę (endersecho.thashar.dev).
+ *
+ * Kierunek jest jeden: bot → strona. Strona nigdy nie odpytuje bota, więc serwer
+ * produkcyjny zostaje zamknięty na świat, a ranking działa nawet gdy bot leży
+ * (Worker oddaje ostatni zapisany snapshot).
+ *
+ * Co jedzie na stronę: nazwa serwera, tag, pozycja, nick gracza, wynik, boss i data.
+ * ŚWIADOMIE NIE wysyłamy ID Discorda ani avatarów — nick w zupełności wystarcza
+ * do rankingu, a ID jest identyfikatorem, który dałoby się połączyć z kontem.
+ *
+ * Kiedy wysyłamy:
+ *   • przy starcie bota — pełny snapshot wszystkich serwerów (`syncAll`),
+ *   • po każdym zapisanym wyniku — tylko ten serwer i tylko gdy TOP 10 faktycznie
+ *     się zmienił (`syncGuild`, porównanie po skrócie SHA-1 listy).
+ * Dzięki temu zwykłe `/update`, które nie rusza czołówki, nie generuje ruchu.
+ *
+ * Persystencja skrótów: `data/web_sync.json` — po restarcie bot nie wysyła
+ * wszystkiego ponownie tylko dlatego, że zapomniał, co już wysłał.
+ */
+class WebRankingSyncService {
+    /**
+     * @param {Object} config - config bota (getAllGuilds, ranking.dataDir)
+     * @param {Object} logger
+     * @param {Object} deps - { rankingService, guildConfigService }
+     */
+    constructor(config, logger, deps = {}) {
+        this.config = config;
+        this.logger = logger;
+        this.rankingService = deps.rankingService || null;
+        this.guildConfigService = deps.guildConfigService || null;
+
+        this.url = process.env.ENDERSECHO_WEB_SYNC_URL || null;
+        this.token = process.env.ENDERSECHO_WEB_SYNC_TOKEN || null;
+        this.topCount = parseInt(process.env.ENDERSECHO_WEB_SYNC_TOP || '10', 10) || 10;
+
+        this.stateFile = path.join(config.ranking?.dataDir || path.join(__dirname, '../data'), 'web_sync.json');
+        this._hashes = {};          // guildId → skrót ostatnio wysłanego TOP 10
+        this._queue = Promise.resolve(); // serializacja zapisów pliku stanu
+    }
+
+    /** Czy wysyłka jest w ogóle skonfigurowana (brak zmiennych = funkcja wyłączona). */
+    isEnabled() {
+        return !!(this.url && this.token && this.rankingService);
+    }
+
+    async load() {
+        try {
+            const raw = await fs.readFile(this.stateFile, 'utf8');
+            const data = JSON.parse(raw);
+            this._hashes = data?.hashes || {};
+        } catch {
+            this._hashes = {};
+        }
+    }
+
+    async _saveState() {
+        this._queue = this._queue.then(async () => {
+            try {
+                await fs.mkdir(path.dirname(this.stateFile), { recursive: true });
+                await fs.writeFile(this.stateFile, JSON.stringify({ hashes: this._hashes }, null, 2), 'utf8');
+            } catch (err) {
+                this.logger.warn(`⚠️ Nie udało się zapisać stanu wysyłki rankingów: ${err.message}`);
+            }
+        }).catch(() => {});
+        return this._queue;
+    }
+
+    /**
+     * Buduje TOP N jednego serwera w formacie, który rozumie strona.
+     * @returns {Promise<Object|null>} null gdy serwer nie ma jeszcze żadnego wyniku
+     */
+    async buildGuildPayload(guildId, client) {
+        const players = await this.rankingService.getSortedPlayers(guildId);
+        if (!players.length) return null;
+
+        const guild = client?.guilds?.cache?.get(guildId) || null;
+        const cfg = this.config.getAllGuilds().find(g => g.id === guildId) || null;
+        const guildName = guild?.name
+            || this.guildConfigService?.getConfig(guildId)?.guildName
+            || guildId;
+
+        const top = players.slice(0, this.topCount).map((p, idx) => ({
+            rank: idx + 1,
+            name: formatProfileDisplayName(p.username || 'Unknown', p.profileIndex || getProfileIndex(p.playerKey)),
+            score: p.score || this.rankingService.formatScore(p.scoreValue),
+            bossName: p.bossName || null,
+            date: p.timestamp || null,
+        }));
+
+        return {
+            id: guildId,
+            name: guildName,
+            tag: cfg?.tag || null,
+            totalPlayers: this.rankingService.countPeople(players),
+            top,
+        };
+    }
+
+    /** Skrót TOP 10 — porównanie decyduje, czy w ogóle wysyłać. */
+    _hashTop(payload) {
+        const material = JSON.stringify(payload.top.map(p => [p.rank, p.name, p.score, p.bossName]));
+        return crypto.createHash('sha1').update(material).digest('hex');
+    }
+
+    async _post(body) {
+        const res = await fetch(this.url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${this.token}`,
+            },
+            body: JSON.stringify(body),
+        });
+        if (!res.ok) {
+            const text = await res.text().catch(() => '');
+            throw new Error(`HTTP ${res.status}${text ? ` — ${text.slice(0, 200)}` : ''}`);
+        }
+        return res;
+    }
+
+    /**
+     * Pełny snapshot wszystkich skonfigurowanych serwerów, na których bot jest obecny.
+     * Wołane przy starcie bota — strona dostaje komplet, nawet jeśli coś umknęło
+     * przy poprzednim uruchomieniu.
+     */
+    async syncAll(client) {
+        if (!this.isEnabled()) return;
+        try {
+            const ids = (this.guildConfigService?.getAllConfiguredGuildIds() || [])
+                .filter(id => client.guilds.cache.has(id));
+            const guilds = [];
+            for (const id of ids) {
+                const payload = await this.buildGuildPayload(id, client);
+                if (payload) guilds.push(payload);
+            }
+            if (!guilds.length) return;
+
+            await this._post({ guilds, replaceAll: true });
+            for (const g of guilds) this._hashes[g.id] = this._hashTop(g);
+            await this._saveState();
+            this.logger.info(`🌐 Wysłano rankingi na stronę: ${guilds.length} serwer(ów)`);
+        } catch (err) {
+            this.logger.warn(`⚠️ Błąd wysyłki rankingów na stronę: ${err.message}`);
+        }
+    }
+
+    /**
+     * Wysyła TOP 10 jednego serwera, ale tylko gdy czołówka faktycznie się zmieniła.
+     * Wołane po każdym zapisanym wyniku (fire-and-forget).
+     * @returns {Promise<boolean>} czy wysłano
+     */
+    async syncGuild(guildId, client) {
+        if (!this.isEnabled() || !guildId) return false;
+        try {
+            const payload = await this.buildGuildPayload(guildId, client);
+            if (!payload) return false;
+
+            const hash = this._hashTop(payload);
+            if (this._hashes[guildId] === hash) return false; // TOP 10 bez zmian — nic nie wysyłamy
+
+            await this._post({ guilds: [payload] });
+            this._hashes[guildId] = hash;
+            await this._saveState();
+            this.logger.info(`🌐 Zaktualizowano ranking serwera "${payload.name}" na stronie`);
+            return true;
+        } catch (err) {
+            this.logger.warn(`⚠️ Błąd wysyłki rankingu serwera na stronę: ${err.message}`);
+            return false;
+        }
+    }
+}
+
+module.exports = WebRankingSyncService;


### PR DESCRIPTION
Część botowa funkcji „rankingi klanów na stronie". Druga połowa (endpoint + widok) jest w PR-ze w repo `thashar.dev`.

## Jak to działa

Nowy `services/webRankingSyncService.js` wysyła snapshot TOP 10 na `POST /api/ee-rankings`. **Kierunek jest jeden: bot → strona.** Strona nigdy nie odpytuje bota, więc serwer produkcyjny zostaje zamknięty na świat, a ranking działa nawet gdy bot jest zrestartowany.

**Kiedy wysyłamy:**
- przy starcie bota — `syncAll()`, pełny snapshot wszystkich skonfigurowanych serwerów z flagą `replaceAll` (strona kasuje wtedy serwery, których bot już nie obsługuje)
- po każdym zapisanym wyniku — `syncGuild()`, **tylko gdy TOP 10 faktycznie się zmienił** (skrót SHA-1 z pozycji, nicków, wyników i bossów). `/update`, które nie rusza czołówki, nie generuje żadnego ruchu
- dodatkowo po cofnięciu rekordu i po `🧹 Usuń wynik` — obie akcje mogą zmienić czołówkę

**Co jedzie:** nazwa serwera, tag, liczba graczy i TOP 10 (pozycja, nick, wynik, boss, data). **Bez ID Discorda i avatarów** — nick wystarcza do rankingu, a ID dałoby się połączyć z kontem.

**Persistencja:** `data/web_sync.json` trzyma skróty ostatnio wysłanych czołówek, więc restart nie powoduje lawiny wysyłek.

**Wyłączone bez konfiguracji:** brak `ENDERSECHO_WEB_SYNC_URL` / `ENDERSECHO_WEB_SYNC_TOKEN` → serwis nic nie robi i nie hałasuje w logach. Wysyłka jest fire-and-forget, błąd ląduje jako `warn` i nie przerywa flow `/update`.

## Wymagane po wdrożeniu

W `.env` bota:
```
ENDERSECHO_WEB_SYNC_URL=https://endersecho.thashar.dev/api/ee-rankings
ENDERSECHO_WEB_SYNC_TOKEN=<ten sam sekret co w Cloudflare>
```

## Uwaga o prywatności

To pierwszy raz, kiedy nicki i wyniki graczy opuszczają Discorda i trafiają na publiczną stronę. Polityka prywatności (`endersecho.thashar.dev/privacy`) tego jeszcze nie opisuje — warto ją uzupełnić przed włączeniem zmiennych, a docelowo rozważyć opt-out per serwer w `/configure`.

## Testy

`node --check` na zmienionych plikach; endpoint po stronie workera przetestowany osobno (patrz PR w `thashar.dev`). Samej wysyłki nie dało się sprawdzić bez produkcyjnego bota — logika budowania payloadu i skrótów jest jednak czysto lokalna i pokryta testem endpointu (payload w tym samym formacie przeszedł walidację workera).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgDQZHTyLRu2XCjAsLesww)_