### PR TITLE
EndersEcho: liczba wszystkich serwerów z botem w payloadzie dla strony

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -718,6 +718,7 @@
 - **Persistencja skrótów:** `data/web_sync.json` — po restarcie bot nie wysyła wszystkiego ponownie tylko dlatego, że zapomniał, co już wysłał (pełny `syncAll` przy starcie i tak odświeża stronę)
 - **Wyłączone bez konfiguracji:** brak `ENDERSECHO_WEB_SYNC_URL` lub `ENDERSECHO_WEB_SYNC_TOKEN` → `isEnabled()` zwraca `false` i serwis nic nie robi (żadnych błędów w logach)
 - **Błędy nie przerywają flow** — wysyłka jest fire-and-forget, a niepowodzenie ląduje jako `warn` w logu
+- **Licznik społeczności:** payload niesie też `totalGuilds` — liczbę WSZYSTKICH serwerów z botem (także tych bez wyników). Strona pokazuje ją w napisie „N Discord communities…” nad listą kafelków; kafelek dostają tylko serwery z rankingiem, więc te dwie liczby mogą się różnić
 - **Po stronie strony:** kafelki klanów w sekcji „COMMUNITIES USING THE BOT" renderowane są z tych danych i dopiero wtedy stają się klikalne; klik otwiera nakładkę z embedem TOP 10 w stylu bota. Gdy API nie odpowie, zostaje statyczna, nieklikalna lista z HTML-a
 
 **Struktura danych:**

--- a/EndersEcho/services/webRankingSyncService.js
+++ b/EndersEcho/services/webRankingSyncService.js
@@ -164,7 +164,7 @@ class WebRankingSyncService {
             }
             if (!guilds.length) return;
 
-            await this._post({ guilds, replaceAll: true });
+            await this._post({ guilds, replaceAll: true, totalGuilds: ids.length });
             for (const g of guilds) this._hashes[g.id] = this._hashTop(g);
             this._lastSync = { at: new Date().toISOString(), kind: 'full', count: guilds.length, guildName: null };
             await this._saveState();
@@ -188,7 +188,11 @@ class WebRankingSyncService {
             const hash = this._hashTop(payload);
             if (this._hashes[guildId] === hash) return false; // TOP 10 bez zmian — nic nie wysyłamy
 
-            await this._post({ guilds: [payload] });
+            // totalGuilds liczymy też tutaj — nowy serwer bywa widoczny na stronie
+            // zanim padnie kolejny restart bota z pełnym snapshotem.
+            const activeCount = (this.guildConfigService?.getAllConfiguredGuildIds() || [])
+                .filter(id => client?.guilds?.cache?.has(id)).length;
+            await this._post({ guilds: [payload], totalGuilds: activeCount || undefined });
             this._hashes[guildId] = hash;
             this._lastSync = { at: new Date().toISOString(), kind: 'guild', count: 1, guildName: payload.name };
             await this._saveState();


### PR DESCRIPTION
Payload wysyłany na stronę niesie teraz `totalGuilds` – liczbę **wszystkich** serwerów z botem, także tych, które nie mają jeszcze żadnego wyniku.

Strona pokazuje ją w napisie „**N** Discord communities already run Ender's Echo…" nad listą kafelków (do tej pory było to `18` wpisane na sztywno w tłumaczeniach). Kafelek dostaje tylko serwer z rankingiem, więc obie liczby mogą się różnić – i tak ma być: napis mówi o społecznościach, kafelki o rankingach.

Liczba idzie zarówno z `syncAll` (pełny snapshot przy starcie), jak i z `syncGuild` – dzięki temu nowy serwer podbija licznik przy pierwszym wyniku, bez czekania na restart bota.

Część webowa jest w PR-ze w `thashar.dev`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgDQZHTyLRu2XCjAsLesww)_