### PR TITLE
Naprawa błędu select menu przy pustych nazwach szablonów + zachowanie szablonu po przypomnieniu jednorazowym

### DIFF
--- a/Wydarzynier/CLAUDE.md
+++ b/Wydarzynier/CLAUDE.md
@@ -80,6 +80,11 @@
 **Funkcjonalność Przypomnień:**
 - **Szablony:** Tworzenie szablonów wiadomości (tekst lub embed) z nazwą, treścią, ikoną i obrazem
   - **Opis embed jest opcjonalny** - pusty opis jest zamieniany na zero-width space (`safeEmbedDescription` w `przypominienHandlers.js`, analogiczny guard w `harmonogram.js`), bo `EmbedBuilder.setDescription` wymaga 1-4096 znaków i pusty string rzucał błąd walidacji przy podglądzie/wysyłce
+  - **Nazwa szablonu jest opcjonalna, ale nigdy nie bywa pusta** - pole `Nazwa szablonu` w modalu to `setRequired(false)`, a pusta nazwa łamała walidację select menu (`addOptions` → `Received one or more errors`, bo Discord wymaga etykiety 1-100 znaków). Pusta nazwa jest zamieniana na `Szablon <id>`:
+    - `sanitizeTemplateName()` w `przypomnieniaMenedzer.js` - przy `createTemplate` i `updateTemplate`
+    - Migracja przy starcie w `loadData()` - naprawia stare szablony bez nazwy zapisane w `przypomnienia.json`
+    - `safeSelectLabel()` w `przypominienHandlers.js` - zabezpieczenie przy budowaniu opcji select menu (szablony, zaplanowane przypomnienia, eventy); dodatkowo opis opcji jest przycinany do 100 znaków, a `value` rzutowane na string
+  - **Analogiczny guard dla eventów** - `sanitizeEventName()` w `eventMenedzer.js` (`createEvent`, `updateEvent` + migracja w `loadData()`) zamienia pustą nazwę na `Event <id>`
 - **Zaplanowane:** Ustawianie przypomień na podstawie szablonów z:
   - Pierwszym wyzwoleniem (data + czas)
   - Interwałem powtarzania (1s, 1m, 1h, 1d do max 90d, lub "ee" dla specjalnego wzorca)
@@ -91,6 +96,7 @@
   - Przyciski: Wstrzymaj/Wznów, Edytuj, Usuń
   - Auto-update co minutę
   - Panel kontrolny na dole z przyciskami zarządzania
+- **Przypomnienia jednorazowe NIE kasują szablonu** - po wyzwoleniu (lub wygaśnięciu wstrzymanego/wznowionego) usuwany jest tylko wpis `scheduled` i embed z tablicy, a szablon zostaje do ponownego użycia (`harmonogram.js` → `checkScheduled`, `przypomnieniaMenedzer.js` → `resumeScheduled`). Szablon kasuje wyłącznie ręczne potwierdzenie usunięcia (`handleConfirmDeleteTemplate`)
 - **Harmonogram:** Sprawdzanie co 30s i auto-wysyłanie przypomnień + czyszczenie starych wiadomości typu 1 (po 23h 50min)
 - **Strefa Czasowa:** Hardcoded `Europe/Warsaw` (brak możliwości zmiany przez UI)
 

--- a/Wydarzynier/handlers/przypominienHandlers.js
+++ b/Wydarzynier/handlers/przypominienHandlers.js
@@ -280,9 +280,9 @@ async function showTemplateSelectPage(interaction, sharedState, page, totalPages
     const pageTemplates = templates.slice(start, end);
 
     const options = pageTemplates.map(t => ({
-        label: t.name.substring(0, 100),
-        description: `${t.type === 'text' ? '📝 Text' : '📋 Embed'} - Utworzono ${new Date(t.createdAt).toLocaleDateString('pl-PL')}`,
-        value: t.id
+        label: safeSelectLabel(t.name, `Szablon ${t.id}`),
+        description: `${t.type === 'text' ? '📝 Text' : '📋 Embed'} - Utworzono ${new Date(t.createdAt).toLocaleDateString('pl-PL')}`.substring(0, 100),
+        value: String(t.id)
     }));
 
     const selectMenu = new StringSelectMenuBuilder()
@@ -1505,6 +1505,15 @@ function safeEmbedDescription(description) {
     return (description && description.trim() !== '') ? description : '​';
 }
 
+// Zwraca bezpieczną etykietę opcji select menu - Discord wymaga 1-100 znaków,
+// a nazwy szablonów/eventów są opcjonalne w modalach, więc pusta nazwa
+// wywoływała błąd walidacji przy addOptions() ("Received one or more errors")
+function safeSelectLabel(name, fallback = 'Bez nazwy') {
+    const trimmed = typeof name === 'string' ? name.trim() : '';
+    const label = trimmed !== '' ? trimmed : fallback;
+    return label.substring(0, 100);
+}
+
 async function showTemplatePreview(interaction, data, sessionId) {
     let previewContent = '**Template Preview:**\n\n';
     previewContent += `📝 **Name:** ${data.name}\n`;
@@ -2032,12 +2041,12 @@ async function showScheduledSelectPage(interaction, sharedState, page, list, mod
 
     const options = pageItems.map(s => {
         const template = przypomnieniaMenedzer.getTemplate(s.templateId);
-        const templateName = template ? template.name : 'Nieznany';
+        const templateName = safeSelectLabel(template?.name, template ? `Szablon ${template.id}` : 'Nieznany');
         const channel = interaction.guild?.channels.cache.get(s.channelId);
         const channelName = channel ? channel.name : s.channelId;
         return {
-            label: `${templateName} — #${channelName}`.substring(0, 100),
-            value: s.id
+            label: safeSelectLabel(`${templateName} — #${channelName}`, `Przypomnienie ${s.id}`),
+            value: String(s.id)
         };
     });
 
@@ -2816,9 +2825,9 @@ async function handleDeleteEvent(interaction, sharedState) {
 
     // Show select menu with events
     const options = events.map(e => ({
-        label: e.name.substring(0, 100),
-        description: `Następny: ${new Date(e.nextTrigger).toLocaleDateString('pl-PL')}`,
-        value: e.id
+        label: safeSelectLabel(e.name, `Event ${e.id}`),
+        description: `Następny: ${new Date(e.nextTrigger).toLocaleDateString('pl-PL')}`.substring(0, 100),
+        value: String(e.id)
     }));
 
     const selectMenu = new StringSelectMenuBuilder()
@@ -2850,9 +2859,9 @@ async function handleEditEvent(interaction, sharedState) {
 
     // Show select menu with events
     const options = events.map(e => ({
-        label: e.name.substring(0, 100),
-        description: `Następny: ${new Date(e.nextTrigger).toLocaleDateString('pl-PL')}`,
-        value: e.id
+        label: safeSelectLabel(e.name, `Event ${e.id}`),
+        description: `Następny: ${new Date(e.nextTrigger).toLocaleDateString('pl-PL')}`.substring(0, 100),
+        value: String(e.id)
     }));
 
     const selectMenu = new StringSelectMenuBuilder()

--- a/Wydarzynier/services/eventMenedzer.js
+++ b/Wydarzynier/services/eventMenedzer.js
@@ -48,6 +48,20 @@ class EventMenedzer {
         try {
             const fileContent = await fs.readFile(this.dataPath, 'utf8');
             this.data = JSON.parse(fileContent);
+
+            // Migracja danych - uzupełnij puste nazwy eventów (łamały walidację select menu)
+            let fixedNames = 0;
+            for (const event of (this.data.events || [])) {
+                const safeName = this.sanitizeEventName(event.name, event.id);
+                if (event.name !== safeName) {
+                    event.name = safeName;
+                    fixedNames++;
+                }
+            }
+            if (fixedNames > 0) {
+                await this.saveData();
+                this.logger.info(`Migracja danych: uzupełniono nazwy ${fixedNames} eventów bez nazwy`);
+            }
         } catch (error) {
             if (error.code === 'ENOENT') {
                 // Plik nie istnieje, utwórz domyślną strukturę
@@ -87,6 +101,12 @@ class EventMenedzer {
 
     // ==================== EVENTY ====================
 
+    // Zwraca nazwę eventu bezpieczną dla select menu (Discord wymaga 1-100 znaków)
+    sanitizeEventName(name, eventId) {
+        const trimmed = typeof name === 'string' ? name.trim() : '';
+        return (trimmed !== '' ? trimmed : `Event ${eventId}`).substring(0, 100);
+    }
+
     // Utwórz event
     async createEvent(creatorId, name, firstTrigger, interval) {
         const id = this.generateId();
@@ -117,7 +137,8 @@ class EventMenedzer {
 
         const event = {
             id: `evt_${id}`,
-            name,
+            // Nazwa jest opcjonalna w modalu - pusta nazwa łamała walidację select menu
+            name: this.sanitizeEventName(name, `evt_${id}`),
             creator: creatorId,
             createdAt: new Date().toISOString(),
             firstTrigger: new Date(firstTrigger).toISOString(),
@@ -217,10 +238,12 @@ class EventMenedzer {
     async updateEvent(id, updates) {
         const index = this.data.events.findIndex(e => e.id === id);
         if (index !== -1) {
-            this.data.events[index] = {
+            const merged = {
                 ...this.data.events[index],
                 ...updates
             };
+            merged.name = this.sanitizeEventName(merged.name, id);
+            this.data.events[index] = merged;
             await this.saveData();
             this.logger.info(`Zaktualizowano event: ${id}`);
             return true;

--- a/Wydarzynier/services/harmonogram.js
+++ b/Wydarzynier/services/harmonogram.js
@@ -57,12 +57,11 @@ class Harmonogram {
                 const isOneTime = !sch.interval || sch.interval === null || sch.isOneTime;
 
                 if (isOneTime) {
-                    // Jednorazowe - usuń embed z tablicy, usuń scheduled i szablon, odśwież panel
+                    // Jednorazowe - usuń embed z tablicy i scheduled, ale ZOSTAW szablon do ponownego użycia
                     await this.tablicaMenedzer.deleteEmbed(sch);
                     await this.przypomnieniaMenedzer.deleteScheduled(sch.id);
-                    await this.przypomnieniaMenedzer.deleteTemplate(sch.templateId);
                     await this.tablicaMenedzer.ensureControlPanel();
-                    this.logger.info(`Wyzwolono jednorazowe przypomnienie: ${sch.id} - usunięto scheduled, szablon i embed`);
+                    this.logger.info(`Wyzwolono jednorazowe przypomnienie: ${sch.id} - usunięto scheduled i embed (szablon zachowany)`);
                 } else {
                     // Cykliczne - zaktualizuj następne wyzwolenie i embed tablicy
                     await this.przypomnieniaMenedzer.updateNextTrigger(sch.id);
@@ -82,9 +81,8 @@ class Harmonogram {
             if (now >= nextTriggerTime) {
                 await this.tablicaMenedzer.deleteEmbed(sch);
                 await this.przypomnieniaMenedzer.deleteScheduled(sch.id);
-                await this.przypomnieniaMenedzer.deleteTemplate(sch.templateId);
                 await this.tablicaMenedzer.ensureControlPanel();
-                this.logger.info(`Jednorazowe wstrzymane przypomnienie ${sch.id} wygasło - usunięto`);
+                this.logger.info(`Jednorazowe wstrzymane przypomnienie ${sch.id} wygasło - usunięto (szablon zachowany)`);
             }
         }
     }

--- a/Wydarzynier/services/przypomnieniaMenedzer.js
+++ b/Wydarzynier/services/przypomnieniaMenedzer.js
@@ -73,6 +73,20 @@ class PrzypomnieniaMenedzer {
                 await this.saveData();
                 this.logger.info('Migracja danych: dodano pole messagesToDelete');
             }
+
+            // Migracja danych - uzupełnij puste nazwy szablonów (łamały walidację select menu)
+            let fixedNames = 0;
+            for (const template of (this.data.templates || [])) {
+                const safeName = this.sanitizeTemplateName(template.name, template.id);
+                if (template.name !== safeName) {
+                    template.name = safeName;
+                    fixedNames++;
+                }
+            }
+            if (fixedNames > 0) {
+                await this.saveData();
+                this.logger.info(`Migracja danych: uzupełniono nazwy ${fixedNames} szablonów bez nazwy`);
+            }
         } catch (error) {
             if (error.code === 'ENOENT') {
                 // Plik nie istnieje, utwórz domyślną strukturę
@@ -110,12 +124,19 @@ class PrzypomnieniaMenedzer {
 
     // ==================== SZABLONY ====================
 
+    // Zwraca nazwę szablonu bezpieczną dla select menu (Discord wymaga 1-100 znaków)
+    sanitizeTemplateName(name, templateId) {
+        const trimmed = typeof name === 'string' ? name.trim() : '';
+        return (trimmed !== '' ? trimmed : `Szablon ${templateId}`).substring(0, 100);
+    }
+
     // Utwórz szablon (Tekst lub Embed)
     async createTemplate(creatorId, name, type, content) {
         const id = this.generateId();
         const template = {
             id: `tpl_${id}`,
-            name,
+            // Nazwa jest opcjonalna w modalu - pusta nazwa łamała walidację select menu
+            name: this.sanitizeTemplateName(name, `tpl_${id}`),
             type, // 'text' lub 'embed'
             creator: creatorId,
             createdAt: new Date().toISOString(),
@@ -148,10 +169,12 @@ class PrzypomnieniaMenedzer {
     async updateTemplate(id, updates) {
         const index = this.data.templates.findIndex(t => t.id === id);
         if (index !== -1) {
-            this.data.templates[index] = {
+            const merged = {
                 ...this.data.templates[index],
                 ...updates
             };
+            merged.name = this.sanitizeTemplateName(merged.name, id);
+            this.data.templates[index] = merged;
             await this.saveData();
             this.logger.info(`Zaktualizowano szablon: ${id}`);
             return true;
@@ -381,8 +404,7 @@ class PrzypomnieniaMenedzer {
         // nextTrigger minął podczas wstrzymania
         if (scheduled.isOneTime || !scheduled.interval) {
             await this.deleteScheduled(id);
-            await this.deleteTemplate(scheduled.templateId);
-            this.logger.info(`Jednorazowe przypomnienie ${id} wygasło podczas wstrzymania - usunięto`);
+            this.logger.info(`Jednorazowe przypomnienie ${id} wygasło podczas wstrzymania - usunięto (szablon zachowany)`);
             return { deleted: true };
         }
 


### PR DESCRIPTION
## Problem

1. **`board_set_reminder` rzucał `Received one or more errors`** — stack trace prowadził do `StringSelectMenuBuilder.addOptions` w `showTemplateSelectPage` (`Wydarzynier/handlers/przypominienHandlers.js:291`). Pole `Nazwa szablonu` w modalu jest `setRequired(false)`, więc dało się zapisać szablon z pustą nazwą. Discord wymaga etykiety opcji o długości 1–100 znaków, więc `label: t.name.substring(0, 100)` = `''` wywalało walidację shapeshift i cały przycisk przestawał działać.
2. **Szablon znikał po ustawieniu przypomnienia jako jednorazowe** — po wyzwoleniu (a także po wygaśnięciu wstrzymanego / wznowieniu po terminie) kasowany był nie tylko wpis `scheduled`, ale i sam szablon.

## Zmiany

**Puste nazwy (fix błędu):**
- `przypomnieniaMenedzer.js` — `sanitizeTemplateName()` używane w `createTemplate` i `updateTemplate`; pusta nazwa → `Szablon <id>`
- `eventMenedzer.js` — analogiczne `sanitizeEventName()` w `createEvent` / `updateEvent`; pusta nazwa → `Event <id>`
- Migracja przy starcie w `loadData()` obu menedżerów — naprawia szablony/eventy bez nazwy zapisane już w `przypomnienia.json` / `eventy.json`
- `przypominienHandlers.js` — `safeSelectLabel()` jako zabezpieczenie przy budowaniu opcji select menu (szablony, zaplanowane przypomnienia, eventy), opis opcji przycięty do 100 znaków, `value` rzutowane na string

**Przypomnienia jednorazowe:**
- `harmonogram.js` (`checkScheduled`, 2 miejsca) i `przypomnieniaMenedzer.js` (`resumeScheduled`) — usuwany jest tylko wpis `scheduled` i embed z tablicy, szablon zostaje do ponownego użycia
- Szablon kasuje teraz wyłącznie ręczne potwierdzenie usunięcia (`handleConfirmDeleteTemplate`)

**Dokumentacja:** zaktualizowany `Wydarzynier/CLAUDE.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WExjN26wHMK9chT8Q4qo14)_