### PR TITLE
Naprawiono odnajdywanie i otwieranie wątków szkoleniowych

### DIFF
--- a/Szkolenia/CLAUDE.md
+++ b/Szkolenia/CLAUDE.md
@@ -5,9 +5,21 @@
 **Scheduling:** Sprawdzanie wątków codziennie o 18:00 (node-cron, strefa Europe/Warsaw)
 
 **Serwisy:**
-- `threadService.js` - Automatyzacja wątków (cron daily 18:00), dwufazowe zamykanie: pytanie po 7 dniach + auto-close po 14 dniach. Wątki już zablokowane (`thread.locked`) są pomijane na samym początku `processThread` (PRZED pobraniem wiadomości i PRZED threadOwner) — zapobiega odarchiwizowaniu i ponownemu wysyłaniu komunikatu o zamknięciu do dawno zamkniętych wątków przy restarcie. `lockThread` dodatkowo zabezpieczone przed ponownym zamykaniem zablokowanego wątku.
+- `threadService.js` - Automatyzacja wątków (cron daily 18:00), dwufazowe zamykanie: pytanie po 7 dniach + auto-close po 14 dniach. Wątki już zablokowane (`thread.locked`) są pomijane na samym początku `processThread` (PRZED pobraniem wiadomości i PRZED threadOwner) — zapobiega odarchiwizowaniu i ponownemu wysyłaniu komunikatu o zamknięciu do dawno zamkniętych wątków przy restarcie. `lockThread` dodatkowo zabezpieczone przed ponownym zamykaniem zablokowanego wątku. Eksportuje też `znajdzWatekUzytkownika`, `otworzWatek` i `pobierzArchiwalneWatki` — używane przez `reactionHandlers` (opis niżej).
 - `reminderStorageService.js` - Persistent JSON z danymi przypomień
 - `aiChatService.js` - AI Chat z trzema providerami: Anthropic (prosty prompt), Grok (web_search) i Perplexity (web search). Przełączanie przez `SZKOLENIA_AI_PROVIDER`
+
+**Odnajdywanie wątku przy reakcji (`reactionHandlers.js`):** Zanim bot założy nowy wątek, szuka istniejącego w czterech krokach — od źródeł pewnych i tanich do kosztownych:
+1. **Wątek wyrastający z tej samej wiadomości** — wątek utworzony z wiadomości ma **to samo ID co ta wiadomość**, więc przy `message.hasThread` wystarczy `threads.fetch(message.id)`. Jedno żądanie, niezależne od nazwy.
+2. **Zapisany `ownerId`** z `data/reminders.json` — wiąże wątek z użytkownikiem, nie z nickiem.
+3. **Aktywne wątki z API** (`fetchActive()`) — a NIE `channel.threads.cache`, bo discord.js sam sprząta cache wątków (sweeper `threads`, domyślnie co godzinę usuwa archiwalne starsze niż 4 h).
+4. **Archiwum ze stronicowaniem** (`pobierzArchiwalneWatki`, po 100 wątków na stronę, do 10 stron przy reakcji / 20 przy codziennym sprawdzaniu) — dopasowanie po nazwie.
+
+⚠️ **Dlaczego nie samo dopasowanie po nazwie:** nazwa wątku to nick z chwili jego założenia. Po zmianie nicku kroki 3-4 nie mają czego dopasować — ratują wyłącznie kroki 1-2. Dlatego **`ownerId` musi przetrwać zamknięcie wątku**: zamknięcie wywołuje `markThreadClosed` (flaga `closed: true`, zachowany `ownerId`), a nie `removeReminder`, który kasował cały wpis. Po odnalezieniu wątku ze starą nazwą bot wyrównuje ją do aktualnego nicku (`setName`).
+
+⚠️ **`fetchArchived()` zwraca JEDNĄ stronę wyników.** Bez stronicowania starszy wątek jest niewidoczny i bot zakłada DRUGI wątek o tej samej nazwie — a gdy reakcja pada pod tą samą wiadomością co stary wątek, Discord odrzuca tworzenie (wątek dla tej wiadomości już istnieje) i użytkownik nie dostaje nic. Z tego samego powodu `checkThreads` czyści osierocone przypomnienia **tylko gdy przejrzało całe archiwum** (`kompletna`); przy niepełnej liście skasowałoby stan (w tym `ownerId`) wątków, które nadal istnieją.
+
+**Otwieranie zamkniętego wątku:** `otworzWatek` zdejmuje archiwizację i blokadę **jednym** `edit({ archived: false, locked: false })`, z krokowym zapasem. Osobne `setArchived` + `setLocked` potrafią się wykluczać (zarchiwizowanego wątku nie da się edytować inaczej niż polem `archived`), a wcześniej oba błędy były tylko logowane i kod leciał dalej do `send()` — który wywracał się na zamkniętym wątku, przez co **regułka nie docierała**. Teraz nieudane otwarcie przerywa obsługę z jednoznacznym logiem, a wysyłka regułki ma własny log błędu.
 
 **Uprawnienia:**
 - Admin/moderator/specjalne role -> mogą otworzyć wątek każdemu (reakcja pod czyimkolwiek postem)
@@ -81,6 +93,7 @@ SZKOLENIA_PERPLEXITY_MODEL=sonar-pro
 - **Logger:** Używaj createBotLogger('Szkolenia')
 - **Scheduling:** Cron sprawdza wątki codziennie o 18:00 (Europe/Warsaw)
 - **Wątki:** Pytanie o zamknięcie po 7 dniach nieaktywności, automatyczne zamknięcie po 14 dniach. "Nie zamykaj" resetuje cykl. Reakcja na otwarty wątek -> komunikat "wątek jest wciąż otwarty"
+- **Wpis w `reminders.json`:** `{ lastReminder, threadCreated, reminderSent, ownerId, helpPingSent, closed }`. Wpis **przeżywa zamknięcie wątku** — trzyma `ownerId`, jedyne powiązanie wątku z użytkownikiem niezależne od nicku. Kasuje go dopiero `cleanupOrphanedReminders`, gdy wątek zniknie z Discorda (i tylko przy kompletnej liście archiwum). `setReminder` zdejmuje `closed` przy (ponownym) otwarciu.
 - **Persistencja:** Przypomnienia w JSON, cooldowny AI Chat w JSON — oba przez `utils/jsonStore` (cache-first): `data/reminders.json` i `data/ai_chat_cooldowns.json` czytane z dysku raz, przy pierwszym sięgnięciu, zapis idzie jednocześnie do pliku i pamięci, atomowo (plik tymczasowy + rename). Obsługa `ENOENT` zniknęła z serwisów — store sam oddaje wartość domyślną przy braku pliku. Zapisywanie promptów AI do `data/prompts/` zostało na zwykłym `fs` (pliki tekstowe, nie JSON)
 - **Odpowiedzi ephemeralne:** `flags: MessageFlags.Ephemeral`, **nie** `ephemeral: true` (przestarzałe w discord.js v14, przestanie działać w v15). Tylko przy pierwszej odpowiedzi — `reply()`, `deferReply()`, `followUp()`; `editReply()` flagi nie przyjmuje. Import `MessageFlags` jest w `index.js` i `handlers/interactionHandlers.js`
 - **AI Chat:** Trzy providery (Anthropic prosty prompt / Grok z web_search / Perplexity z web search). Przełączanie przez `SZKOLENIA_AI_PROVIDER` w .env. Grok/Perplexity: web search, cooldown 1440 min (24h) (admini bez limitu).

--- a/Szkolenia/handlers/interactionHandlers.js
+++ b/Szkolenia/handlers/interactionHandlers.js
@@ -66,7 +66,8 @@ async function handleLockThread(interaction, state, config) {
         components: []
     });
 
-    await reminderStorage.removeReminder(state.lastReminderMap, channel.id);
+    // Zachowujemy wpis (a w nim `ownerId`) — po zamknięciu wątek nadal musi dać się odnaleźć
+    await reminderStorage.markThreadClosed(state.lastReminderMap, channel.id);
 
     await delay(2000);
     try {

--- a/Szkolenia/handlers/reactionHandlers.js
+++ b/Szkolenia/handlers/reactionHandlers.js
@@ -1,5 +1,5 @@
 const { createBotLogger } = require('../../utils/consoleLogger');
-const { reminderStorage } = require('../services/threadService');
+const { reminderStorage, znajdzWatekUzytkownika, otworzWatek } = require('../services/threadService');
 
 const logger = createBotLogger('Szkolenia');
 /**
@@ -11,31 +11,44 @@ const logger = createBotLogger('Szkolenia');
  */
 
 /**
+ * Wysyła regułkę szkoleniową do wątku.
+ *
+ * ⚠️ Osobna funkcja z własnym logiem, bo to JEDYNA treść, po której użytkownik poznaje,
+ * co ma zrobić. Gdy wysyłka padała wewnątrz ogólnego `catch`, w logu zostawał tylko
+ * „Błąd podczas obsługi reakcji", a na Discordzie — pusty wątek.
+ */
+async function wyslijRegulke(watek, config, klikajacyId, wlascicielId) {
+    try {
+        await watek.send(config.messages.threadCreated(klikajacyId, config.roles.ping, wlascicielId));
+        return true;
+    } catch (error) {
+        logger.error(`❌ Nie udało się wysłać regułki do wątku ${watek.name}: ${error.message}`);
+        return false;
+    }
+}
+
+/**
+ * Dopasowuje nazwę wątku do aktualnego nicku właściciela.
+ * Wątek odnaleziony po `ownerId` albo po wiadomości startowej może nosić stary nick.
+ */
+async function wyrownajNazweWatku(watek, threadName) {
+    if (watek.name === threadName) return;
+
+    try {
+        await watek.setName(threadName, 'Aktualizacja nazwy wątku po zmianie nicku właściciela');
+        logger.info(`✏️ Zmieniono nazwę wątku na aktualny nick: ${threadName}`);
+    } catch (error) {
+        logger.warn(`⚠️ Nie udało się zmienić nazwy wątku ${watek.name}: ${error.message}`);
+    }
+}
+
+/**
  * Obsługa dodania reakcji
  * @param {MessageReaction} reaction - Reakcja Discord
  * @param {User} user - Użytkownik który dodał reakcję
  * @param {Object} state - Stan współdzielony aplikacji
  * @param {Object} config - Konfiguracja aplikacji
  */
-/**
- * Szuka zarchiwizowanego wątku o danej nazwie, przechodząc przez kolejne strony wyników.
- * Limit stron chroni przed długim odpytywaniem API na kanale z setkami wątków.
- */
-async function findArchivedThreadByName(channel, threadName, maxStron = 5) {
-    let before;
-
-    for (let strona = 0; strona < maxStron; strona++) {
-        const wynik = await channel.threads.fetchArchived(before ? { before } : {});
-        const znaleziony = wynik.threads.find(thread => thread.name === threadName);
-        if (znaleziony) return znaleziony;
-
-        if (!wynik.hasMore || wynik.threads.size === 0) return null;
-        before = wynik.threads.last();
-    }
-
-    return null;
-}
-
 async function handleReactionAdd(reaction, user, state, config) {
     try {
         if (reaction.partial) await reaction.fetch();
@@ -68,17 +81,16 @@ async function handleReactionAdd(reaction, user, state, config) {
         const targetMember = await guild.members.fetch(targetUser.id);
         const threadName = targetMember.displayName || targetUser.username;
 
-        // Sprawdź czy wątek już istnieje (szukaj także w zarchiwizowanych)
-        let existingThread = channel.threads.cache.find(thread => 
-            thread.name === threadName
-        );
-        
-        // Jeśli nie znaleziono w aktywnych, sprawdź zarchiwizowane.
-        // ⚠️ `fetchArchived()` zwraca tylko jedną stronę — bez stronicowania starszy
-        // wątek użytkownika bywał niewidoczny i bot zakładał DRUGI wątek o tej samej nazwie.
-        if (!existingThread) {
-            existingThread = await findArchivedThreadByName(channel, threadName);
-        }
+        // Szukanie istniejącego wątku: wiadomość startowa → zapisany ownerId → aktywne → archiwum.
+        // ⚠️ Samo dopasowanie po nazwie nie wystarcza: nazwa to nick z chwili założenia wątku,
+        // a wątek zarchiwizowany poza pierwszą stroną wyników jest niewidoczny bez stronicowania.
+        // Oba przypadki kończyły się założeniem DRUGIEGO wątku dla tej samej osoby.
+        const existingThread = await znajdzWatekUzytkownika(channel, {
+            message: reaction.message,
+            ownerId: targetUser.id,
+            threadName,
+            reminderMap: state.lastReminderMap
+        });
 
         if (existingThread) {
             // Sprawdź czy wątek jest już otwarty (nie zarchiwizowany i nie zablokowany)
@@ -91,55 +103,34 @@ async function handleReactionAdd(reaction, user, state, config) {
                 return;
             }
 
-            // WAŻNE: Kolejność operacji ma znaczenie!
-            // 1. Najpierw odarchiwizuj (archived: false)
-            // 2. Potem odblokuj (locked: false)
-            // Discord API wymaga aby wątek locked był archived, więc nie można odblokować przed odarchiwizowaniem
-
-            // Jeśli wątek jest zarchiwizowany, odarchiwizować
-            if (existingThread.archived) {
-                try {
-                    await existingThread.setArchived(false, 'Ponowne otwarcie wątku');
-                    logger.info(`📂 Odarchiwizowano wątek: ${existingThread.name}`);
-                } catch (error) {
-                    logger.error(`❌ Nie można odarchivizować wątku ${existingThread.name}:`, error);
-                }
+            // Odarchiwizowanie i odblokowanie jednym żądaniem; bez tego nie ma po co pisać
+            if (!await otworzWatek(existingThread)) {
+                logger.error(`❌ Nie otwarto wątku ${existingThread.name} - regułka nie została wysłana`);
+                return;
             }
 
-            // Jeśli wątek jest zamknięty, odblokować go
-            if (existingThread.locked) {
-                try {
-                    await existingThread.setLocked(false, 'Odblokowanie wątku na prośbę użytkownika');
-                    logger.info(`🔓 Odblokowano wątek: ${existingThread.name}`);
-                } catch (error) {
-                    logger.error(`❌ Nie można odblokować wątku ${existingThread.name}:`, error);
-                }
-            }
-
-            await existingThread.send(
-                config.messages.threadCreated(user.id, config.roles.ping, targetUser.id)
-            );
+            await wyrownajNazweWatku(existingThread, threadName);
+            await wyslijRegulke(existingThread, config, user.id, targetUser.id);
 
             // Zapisz właściciela wątku i zresetuj status przypomnienia oraz flagę pingu o pomoc
             const reopenNow = Date.now();
             await reminderStorage.setReminder(state.lastReminderMap, existingThread.id, reopenNow, null, targetUser.id);
             await reminderStorage.resetHelpPing(state.lastReminderMap, existingThread.id);
             await reminderStorage.resetReminderStatus(state.lastReminderMap, existingThread.id);
-        } else {
-            // Utwórz nowy wątek
-            const thread = await channel.threads.create({
-                name: threadName,
-                startMessage: reaction.message,
-            });
-
-            await thread.send(
-                config.messages.threadCreated(user.id, config.roles.ping, targetUser.id)
-            );
-
-            // Inicjalizuj czas utworzenia wątku w mapie (z właścicielem i wyzerowaną flagą pingu o pomoc)
-            const now = Date.now();
-            await reminderStorage.setReminder(state.lastReminderMap, thread.id, now, now, targetUser.id);
+            return;
         }
+
+        // Utwórz nowy wątek
+        const thread = await channel.threads.create({
+            name: threadName,
+            startMessage: reaction.message,
+        });
+
+        await wyslijRegulke(thread, config, user.id, targetUser.id);
+
+        // Inicjalizuj czas utworzenia wątku w mapie (z właścicielem i wyzerowaną flagą pingu o pomoc)
+        const now = Date.now();
+        await reminderStorage.setReminder(state.lastReminderMap, thread.id, now, now, targetUser.id);
 
     } catch (error) {
         logger.error('❌ Błąd podczas obsługi reakcji:', error);

--- a/Szkolenia/services/reminderStorageService.js
+++ b/Szkolenia/services/reminderStorageService.js
@@ -76,6 +76,35 @@ class ReminderStorageService {
     }
 
     /**
+     * Oznacza wątek jako zamknięty, ZACHOWUJĄC powiązanie z właścicielem.
+     *
+     * ⚠️ Wcześniej zamknięcie wątku kasowało cały wpis (`removeReminder`). Razem z nim
+     * ginął `ownerId`, czyli jedyne powiązanie wątku z użytkownikiem niezależne od nicku —
+     * po zmianie nicku bot nie potrafił już odnaleźć zamkniętego wątku i zakładał nowy.
+     * Zapis idzie na dysk tylko wtedy, gdy coś faktycznie się zmieniło: `processThread`
+     * przechodzi po zamkniętych wątkach przy każdym sprawdzeniu.
+     *
+     * @param {Map} reminderMap - Mapa z danymi przypomień
+     * @param {string} threadId - ID wątku
+     */
+    async markThreadClosed(reminderMap, threadId) {
+        const existingData = reminderMap.get(threadId);
+        if (!existingData) return;
+
+        const bezZmian = existingData.closed === true
+            && existingData.reminderSent === false
+            && existingData.helpPingSent === false;
+        if (bezZmian) return;
+
+        existingData.closed = true;
+        existingData.reminderSent = false;
+        existingData.helpPingSent = false;
+        reminderMap.set(threadId, existingData);
+        await this.saveReminders(reminderMap);
+        logger.info(`🔒 Oznaczono wątek jako zamknięty (właściciel zachowany): ${threadId}`);
+    }
+
+    /**
      * Dodaje/aktualizuje wpis o przypomnieniu
      * @param {Map} reminderMap - Mapa z danymi przypomień
      * @param {string} threadId - ID wątku
@@ -91,7 +120,9 @@ class ReminderStorageService {
             threadCreated: threadCreated || (existingData ? existingData.threadCreated : null),
             reminderSent: existingData ? existingData.reminderSent : false,
             ownerId: ownerId || (existingData ? existingData.ownerId : null),
-            helpPingSent: existingData ? (existingData.helpPingSent || false) : false
+            helpPingSent: existingData ? (existingData.helpPingSent || false) : false,
+            // Wpis żyje dalej po zamknięciu wątku (trzyma `ownerId`) — otwarcie zdejmuje flagę
+            closed: false
         };
 
         reminderMap.set(threadId, threadData);

--- a/Szkolenia/services/threadService.js
+++ b/Szkolenia/services/threadService.js
@@ -7,6 +7,162 @@ const reminderStorage = new ReminderStorageService();
 
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 
+// Ile wątków pobierać jednym żądaniem archiwum (maksimum akceptowane przez Discord to 100).
+const WATKOW_NA_STRONE = 100;
+// Ile stron archiwum wolno przejrzeć przy wyszukiwaniu wątku (reakcja użytkownika — musi być szybko).
+const MAKS_STRON_PRZY_SZUKANIU = 10;
+// Ile stron archiwum przechodzimy przy codziennym sprawdzaniu (raz dziennie, może potrwać dłużej).
+const MAKS_STRON_PRZY_SPRAWDZANIU = 20;
+
+/**
+ * Pobiera zarchiwizowane wątki kanału, przechodząc przez kolejne strony wyników.
+ *
+ * ⚠️ `fetchArchived()` zwraca tylko JEDNĄ stronę (domyślnie 50 wątków). Kanał szkoleń ma
+ * historię liczoną w setkach wątków, więc bez stronicowania starszy wątek użytkownika jest
+ * niewidoczny — bot zakłada wtedy DRUGI wątek o tej samej nazwie.
+ *
+ * @param {TextChannel} channel - Kanał szkoleń
+ * @param {Object} opcje
+ * @param {number} opcje.maxStron - Górny limit stron (zabezpieczenie przed zalewem żądań)
+ * @param {Function|null} opcje.dopasuj - Predykat; gdy zwróci true, przerywamy pobieranie
+ * @returns {Promise<{watki: Map, znaleziony: ?Object, kompletna: boolean}>}
+ *          `kompletna` = przejrzano CAŁE archiwum (Discord nie zgłasza już `hasMore`)
+ */
+async function pobierzArchiwalneWatki(channel, { maxStron = MAKS_STRON_PRZY_SPRAWDZANIU, dopasuj = null } = {}) {
+    const watki = new Map();
+    let before;
+
+    for (let strona = 0; strona < maxStron; strona++) {
+        const zapytanie = { limit: WATKOW_NA_STRONE };
+        if (before) zapytanie.before = before;
+
+        const wynik = await channel.threads.fetchArchived(zapytanie);
+
+        for (const [id, watek] of wynik.threads) {
+            watki.set(id, watek);
+            if (dopasuj && dopasuj(watek)) {
+                return { watki, znaleziony: watek, kompletna: false };
+            }
+        }
+
+        if (!wynik.hasMore || wynik.threads.size === 0) {
+            return { watki, znaleziony: null, kompletna: true };
+        }
+
+        before = wynik.threads.last();
+    }
+
+    return { watki, znaleziony: null, kompletna: false };
+}
+
+/**
+ * Pobiera wątek po ID i sprawdza, czy należy do wskazanego kanału.
+ * Zwraca null, gdy wątek został usunięty z Discorda.
+ */
+async function pobierzWatekPoId(channel, threadId) {
+    try {
+        const watek = await channel.threads.fetch(threadId);
+        if (watek && watek.parentId === channel.id) return watek;
+    } catch (error) {
+        // Wątek usunięty albo bez dostępu — traktujemy jak nieistniejący
+    }
+    return null;
+}
+
+/**
+ * Szuka wątku szkoleniowego danego użytkownika.
+ *
+ * Kolejność ma znaczenie — od źródeł pewnych i tanich do kosztownych:
+ *  1. wątek wyrastający z tej samej wiadomości (ID wątku = ID wiadomości startowej) —
+ *     niezależny od nazwy, więc działa też po zmianie nicku,
+ *  2. zapisany `ownerId` w `reminders.json` — wiąże wątek z użytkownikiem, nie z nickiem,
+ *  3. aktywne wątki pobrane z API (`fetchActive`), nie z cache,
+ *  4. archiwum ze stronicowaniem — dopasowanie po nazwie.
+ *
+ * ⚠️ Punkty 3 i 4 dopasowują po NAZWIE, więc po zmianie nicku zadziałają tylko punkty 1-2.
+ * Dlatego `ownerId` musi przetrwać zamknięcie wątku (patrz `markThreadClosed`).
+ *
+ * @returns {Promise<?ThreadChannel>}
+ */
+async function znajdzWatekUzytkownika(channel, { message, ownerId, threadName, reminderMap }) {
+    // 1. Wątek założony z tej samej wiadomości — ma to samo ID co wiadomość
+    if (message?.hasThread) {
+        const watek = await pobierzWatekPoId(channel, message.id);
+        if (watek) return watek;
+    }
+
+    // 2. Wątek zapisany dla tego właściciela
+    if (ownerId && reminderMap) {
+        for (const [threadId, dane] of reminderMap) {
+            if (!dane || dane.ownerId !== ownerId) continue;
+            const watek = await pobierzWatekPoId(channel, threadId);
+            if (watek) return watek;
+        }
+    }
+
+    // 3. Aktywne wątki — z API, bo cache bywa niekompletny (sprzątany przez discord.js)
+    try {
+        const aktywne = await channel.threads.fetchActive();
+        const znaleziony = aktywne.threads.find(watek => watek.name === threadName);
+        if (znaleziony) return znaleziony;
+    } catch (error) {
+        logger.warn(`⚠️ Nie udało się pobrać aktywnych wątków: ${error.message}`);
+    }
+
+    // 4. Archiwum po nazwie
+    try {
+        const { znaleziony } = await pobierzArchiwalneWatki(channel, {
+            maxStron: MAKS_STRON_PRZY_SZUKANIU,
+            dopasuj: watek => watek.name === threadName
+        });
+        if (znaleziony) return znaleziony;
+    } catch (error) {
+        logger.warn(`⚠️ Nie udało się przeszukać archiwum wątków: ${error.message}`);
+    }
+
+    return null;
+}
+
+/**
+ * Otwiera wątek: zdejmuje archiwizację i blokadę.
+ *
+ * ⚠️ Jednym żądaniem (`edit`), bo osobne `setArchived` + `setLocked` potrafią się wykluczać —
+ * zarchiwizowanego wątku nie da się edytować inaczej niż polem `archived`, więc odblokowanie
+ * po nieudanym odarchiwizowaniu też pada. Wcześniej oba błędy były tylko logowane, a kod leciał
+ * dalej do `send()`, który wywracał się na zamkniętym wątku — użytkownik nie dostawał regułki.
+ *
+ * @returns {Promise<boolean>} czy wątek jest gotowy do pisania
+ */
+async function otworzWatek(watek) {
+    if (!watek.archived && !watek.locked) return true;
+
+    try {
+        await watek.edit({
+            archived: false,
+            locked: false,
+            reason: 'Ponowne otwarcie wątku szkoleniowego'
+        });
+        logger.info(`📂 Otwarto ponownie wątek: ${watek.name}`);
+        return true;
+    } catch (error) {
+        logger.warn(`⚠️ Nie udało się otworzyć wątku ${watek.name} jednym żądaniem: ${error.message}`);
+    }
+
+    // Zapas: krok po kroku — najpierw archiwizacja, dopiero potem blokada
+    try {
+        if (watek.archived) {
+            await watek.setArchived(false, 'Ponowne otwarcie wątku szkoleniowego');
+        }
+        if (watek.locked) {
+            await watek.setLocked(false, 'Odblokowanie wątku na prośbę użytkownika');
+        }
+        return !watek.archived && !watek.locked;
+    } catch (error) {
+        logger.error(`❌ Nie można otworzyć wątku ${watek.name}: ${error.message}`);
+        return false;
+    }
+}
+
 async function checkThreads(client, state, config, isInitialCheck = false) {
     try {
         const guild = client.guilds.cache.first();
@@ -19,17 +175,17 @@ async function checkThreads(client, state, config, isInitialCheck = false) {
         const reminderThreshold = daysToMilliseconds(config.timing.threadReminderDays);
 
         const activeThreads = await channel.threads.fetchActive();
-        const archivedThreads = await channel.threads.fetchArchived();
-        const allThreads = new Map([...activeThreads.threads, ...archivedThreads.threads]);
+        const { watki: archiwalne, kompletna } = await pobierzArchiwalneWatki(channel);
+        const allThreads = new Map([...activeThreads.threads, ...archiwalne]);
 
-        // ⚠️ `fetchArchived()` zwraca tylko JEDNĄ stronę wyników — przy `hasMore` część
-        // zarchiwizowanych wątków jest poza listą. Czyszczenie "osieroconych" wpisów
-        // skasowałoby wtedy stan wątków, które nadal istnieją (m.in. flagę `reminderSent`),
-        // przez co przypomnienie poszłoby drugi raz zamiast zamknięcia wątku.
-        if (archivedThreads.hasMore) {
-            logger.info('ℹ️ Lista zarchiwizowanych wątków niekompletna — pomijam czyszczenie przypomnień');
-        } else {
+        // ⚠️ Czyścimy osierocone wpisy TYLKO gdy przejrzeliśmy całe archiwum. Przy niepełnej
+        // liście skasowalibyśmy stan wątków, które nadal istnieją (m.in. `reminderSent`
+        // i `ownerId`), przez co przypomnienie poszłoby drugi raz zamiast zamknięcia wątku,
+        // a bot zgubiłby powiązanie wątku z właścicielem.
+        if (kompletna) {
             await reminderStorage.cleanupOrphanedReminders(state.lastReminderMap, allThreads);
+        } else {
+            logger.info('ℹ️ Lista zarchiwizowanych wątków niekompletna — pomijam czyszczenie przypomnień');
         }
 
         for (const [id, thread] of allThreads) {
@@ -56,9 +212,7 @@ async function processThread(thread, guild, state, config, now, thresholds, isIn
     // dostawały ponownie komunikat o zamknięciu i były zamykane od nowa.
     // Sprawdzenie PRZED pobraniem wiadomości i PRZED threadOwner (działa też po zmianie nicku).
     if (thread.locked) {
-        if (state.lastReminderMap.has(thread.id)) {
-            await reminderStorage.removeReminder(state.lastReminderMap, thread.id);
-        }
+        await reminderStorage.markThreadClosed(state.lastReminderMap, thread.id);
         return;
     }
 
@@ -163,9 +317,7 @@ async function lockThread(thread, state, config) {
         // Zabezpieczenie: nie zamykaj ponownie wątku, który jest już zablokowany
         // (uniknij odarchiwizowania i ponownego wysłania komunikatu o zamknięciu).
         if (thread.locked) {
-            if (state.lastReminderMap.has(thread.id)) {
-                await reminderStorage.removeReminder(state.lastReminderMap, thread.id);
-            }
+            await reminderStorage.markThreadClosed(state.lastReminderMap, thread.id);
             return;
         }
 
@@ -177,7 +329,7 @@ async function lockThread(thread, state, config) {
         await thread.setLocked(true, `Wątek nieaktywny przez ${config.timing.threadLockDays} dni - automatycznie zamknięty`);
         await thread.setArchived(true, 'Zamknięcie wątku po okresie nieaktywności');
 
-        await reminderStorage.removeReminder(state.lastReminderMap, thread.id);
+        await reminderStorage.markThreadClosed(state.lastReminderMap, thread.id);
         logger.info(`🔒 Zamknięto wątek: ${thread.name}`);
     } catch (error) {
         logger.error(`❌ Błąd podczas zamykania wątku ${thread.name}:`, error);
@@ -187,5 +339,8 @@ async function lockThread(thread, state, config) {
 
 module.exports = {
     checkThreads,
-    reminderStorage
+    reminderStorage,
+    znajdzWatekUzytkownika,
+    otworzWatek,
+    pobierzArchiwalneWatki
 };


### PR DESCRIPTION
## Zgłoszony objaw

Bot Szkolenia przestał otwierać stare wątki — zakłada nowe, a użytkownik nie dostaje regułki.

## Przyczyny

**1. Wątek szukany wyłącznie po nazwie.** Nazwa wątku to nick z chwili jego założenia (`targetMember.displayName`). Po zmianie nicku nie ma czego dopasować — bot zakłada drugi wątek dla tej samej osoby.

**2. Aktywne wątki brane tylko z `channel.threads.cache`.** Kod nigdy nie wołał `fetchActive()`, a discord.js sam sprząta cache wątków (sweeper `threads` — domyślnie co godzinę usuwa archiwalne starsze niż 4 h).

**3. Archiwum przeszukiwane płytko.** Poprzednia poprawka dodała stronicowanie, ale ograniczone do 5 stron bez ustawionego `limit`, czyli ok. 250 najnowszych wątków. Kanał szkoleń ma ich znacznie więcej — starszy wątek nadal był niewidoczny.

**4. Zamknięcie wątku kasowało `ownerId`.** `processThread`/`lockThread`/przycisk „Zamknij szkolenie" wywoływały `removeReminder`, który usuwał cały wpis z `reminders.json` — razem z jedynym powiązaniem wątku z użytkownikiem niezależnym od nicku.

**5. Brak regułki.** Gdy bot znalazł wątek zarchiwizowany *i* zablokowany, robił osobno `setArchived(false)` i `setLocked(false)`. Te operacje potrafią się wykluczyć (zarchiwizowanego wątku nie da się edytować inaczej niż polem `archived`), oba błędy były tylko logowane, a kod leciał dalej do `send()` na wciąż zamkniętym wątku. Wyjątek ginął w ogólnym `catch` z komunikatem „Błąd podczas obsługi reakcji". Drugi wariant tego samego objawu: gdy reakcja pada pod tą samą wiadomością, z której wyrósł nieodnaleziony wątek, Discord odrzuca `threads.create` (wątek dla tej wiadomości już istnieje) i nie powstaje nic.

## Zmiany

- **`znajdzWatekUzytkownika`** (`threadService.js`) — cztery kroki, od pewnych i tanich do kosztownych:
  1. wątek wyrastający z tej samej wiadomości (ID wątku = ID wiadomości startowej) — jedno żądanie, działa mimo zmiany nicku,
  2. zapisany `ownerId` z `reminders.json`,
  3. `fetchActive()` z API zamiast cache,
  4. archiwum ze stronicowaniem po nazwie.
- **`pobierzArchiwalneWatki`** — po 100 wątków na stronę, do 10 stron przy reakcji i 20 przy codziennym sprawdzaniu; zwraca też informację, czy przejrzano całe archiwum. Czyszczenie osieroconych przypomnień działa tylko przy kompletnej liście.
- **`markThreadClosed`** zastępuje `removeReminder` przy zamykaniu wątku — wpis zostaje z flagą `closed`, `ownerId` przeżywa. Zapis na dysk tylko przy faktycznej zmianie. `setReminder` zdejmuje flagę przy ponownym otwarciu.
- **`otworzWatek`** — jeden `edit({ archived: false, locked: false })` z krokowym zapasem; nieudane otwarcie przerywa obsługę z jednoznacznym logiem zamiast pisać w zamknięty wątek.
- **`wyslijRegulke`** — własny log błędu, żeby pusty wątek nie był już zagadką.
- Nazwa odnalezionego wątku wyrównywana do aktualnego nicku (`setName`).
- Zaktualizowano `Szkolenia/CLAUDE.md`.

## Testy

Testy jednostkowe na zamockowanym API Discorda (11 przypadków, wszystkie przechodzą): stronicowanie archiwum i wykrywanie kompletności listy, odnajdywanie wątku po wiadomości startowej przy zmienionym nicku, odnajdywanie zamkniętego wątku po `ownerId`, aktywny wątek spoza cache, brak wątku, otwieranie `archived+locked` jednym żądaniem, obsługa braku uprawnień, brak zbędnych żądań dla wątku już otwartego.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHbNKMPrD2n5s1VzTT9Snc)_