### PR TITLE
Dodatkowa rola uprawniona do kodów Habby w Stalkerze

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -906,6 +906,8 @@ STALKER_LME_CONFIRMATION_CHANNEL_1=channel_id
 STALKER_LME_CONFIRMATION_CHANNEL_2=channel_id
 STALKER_LME_CONFIRMATION_CHANNEL_MAIN=channel_id
 STALKER_LME_VACATION_CHANNEL_ID=channel_id
+# Kody Habby - dodatkowe role uprawnione poza rolami klanowymi (opcjonalne, lista ID po przecinku)
+STALKER_LME_GIFTCODE_EXTRA_ROLE=role_id1,role_id2
 # AI Chat (opcjonalne)
 ANTHROPIC_API_KEY=sk-ant-api03-xxxxxxxxxxxxx
 STALKER_LME_AI_CHAT_MODEL=claude-3-haiku-20240307

--- a/Stalker/CLAUDE.md
+++ b/Stalker/CLAUDE.md
@@ -80,7 +80,7 @@
 10. **Borixoning** - Auto-odpowiedź na reply "zbij bossa" na kanałach WARNING → komunikat "Wykryto zaawansowany Borixoning" z przyciskami Tak/Nie (ephemeral), cooldown raz dziennie per kanał (kasuje się o północy, persistencja w `data/boroxoning_cooldowns.json`)
 11. **Reakcja Stalker** - Gdy ktoś napisze słowo "stalker" (case-insensitive) w wiadomości na serwerze → bot dodaje reakcję `<a:PepeEvil2:1280068960787632130>` (bez cooldownu)
 14. **Kody Podarunkowe Habby** - `giftcodeService.js`: System zbierania ID graczy i masowej aktywacji kodów podarunkowych przez Habby API (bez captcha).
-   - **Zbieranie ID przez przycisk:** Na kanale `1191791557607690442` zawsze na samym dole widnieje zielony przycisk "🎮 Dodaj swoje ID". Po kliknięciu otwiera modal z polem tekstowym. Każdy użytkownik może zapisać tylko jedno ID. Wymagana rola klanowa (targetRoles). Po zapisaniu ID → automatyczna aktywacja kodów z ostatnich 30 dni.
+   - **Zbieranie ID przez przycisk:** Na kanale `1191791557607690442` zawsze na samym dole widnieje zielony przycisk "🎮 Dodaj swoje ID". Po kliknięciu otwiera modal z polem tekstowym. Każdy użytkownik może zapisać tylko jedno ID. Wymagana rola klanowa (`targetRoles`) lub dodatkowa rola z `STALKER_LME_GIFTCODE_EXTRA_ROLE` — obie listy łączy `config.giftcodeRoleIds`, używane przy dodawaniu ID, w `/giftcode` i w auto-aktywacji. Po zapisaniu ID → automatyczna aktywacja kodów z ostatnich 30 dni.
    - **Aktualizacja przycisku:** Przy każdej nowej wiadomości na kanale bot sprawdza czy ostatnia wiadomość to jego przycisk — jeśli nie, usuwa stary i postuje nowy na dole. MessageId zapisywany w `data/giftcode_button.json`.
    - `/remove-id` — administrator usuwa własne lub cudze ID (opcjonalny parametr `user`). Tylko administrator.
    - `/list-ids` — administrator widzi listę wszystkich zapisanych ID (ephemeral). Tylko administrator.
@@ -342,6 +342,9 @@ STALKER_LME_TARGET_ROLE_0=role_id
 STALKER_LME_TARGET_ROLE_1=role_id
 STALKER_LME_TARGET_ROLE_2=role_id
 STALKER_LME_TARGET_ROLE_MAIN=role_id
+
+# Kody Habby - dodatkowe role uprawnione poza rolami klanowymi (opcjonalne, lista ID po przecinku)
+STALKER_LME_GIFTCODE_EXTRA_ROLE=role_id1,role_id2
 
 # Kanały ostrzeżeń
 STALKER_LME_WARNING_CHANNEL_0=channel_id

--- a/Stalker/config/config.js
+++ b/Stalker/config/config.js
@@ -88,7 +88,14 @@ module.exports = {
         '2': process.env.STALKER_LME_TARGET_ROLE_2,
         'main': process.env.STALKER_LME_TARGET_ROLE_MAIN
     },
-    
+
+    // Dodatkowe role uprawnione do korzystania z kodów Habby (poza rolami klanowymi)
+    // Lista ID rozdzielona przecinkami, np. "123,456"
+    giftcodeExtraRoles: (process.env.STALKER_LME_GIFTCODE_EXTRA_ROLE || '')
+        .split(',')
+        .map(id => id.trim())
+        .filter(Boolean),
+
     // Nazwy wyświetlane ról
     roleDisplayNames: {
         '0': '🎮PolskiSquad⁰🎮',
@@ -198,3 +205,9 @@ module.exports = {
         sourceChannelId: process.env.STALKER_LME_NEWS_CHANNEL_ID || null
     }
 };
+
+// Wszystkie role uprawnione do kodów Habby: role klanowe + dodatkowe z .env
+module.exports.giftcodeRoleIds = [
+    ...Object.values(module.exports.targetRoles),
+    ...module.exports.giftcodeExtraRoles
+].filter(Boolean);

--- a/Stalker/handlers/interactionHandlers.js
+++ b/Stalker/handlers/interactionHandlers.js
@@ -2500,8 +2500,13 @@ function _isAdmin(member) {
     return member.permissions.has(PermissionFlagsBits.Administrator);
 }
 
-function _hasAnyClanRole(member, config) {
-    return Object.values(config.targetRoles).some(roleId => roleId && member.roles.cache.has(roleId));
+// Role klanowe + dodatkowe role z .env (STALKER_LME_GIFTCODE_EXTRA_ROLE)
+function _giftcodeRoleIds(config) {
+    return config.giftcodeRoleIds ?? Object.values(config.targetRoles).filter(Boolean);
+}
+
+function _hasGiftcodeRole(member, config) {
+    return _giftcodeRoleIds(config).some(roleId => member.roles.cache.has(roleId));
 }
 
 async function handleRemoveIdCommand(interaction, sharedState) {
@@ -2594,7 +2599,7 @@ async function handleGiftcodeCommand(interaction, sharedState) {
 
     // Filtruj gracze bez roli klanowej
     const guild = interaction.guild;
-    const targetRoleIds = Object.values(config.targetRoles).filter(Boolean);
+    const targetRoleIds = _giftcodeRoleIds(config);
     const eligibleEntries = [];
     const skippedEntries = [];
 
@@ -2736,7 +2741,7 @@ async function handleGiftcodeAddIdButton(interaction, sharedState) {
 
     const uidInput = new TextInputBuilder()
         .setCustomId(GIFTCODE_INPUT_ID)
-        .setLabel('Działa tylko dla członków klanu!')
+        .setLabel('Tylko dla klanowiczów i uprawnionych ról')
         .setStyle(TextInputStyle.Short)
         .setPlaceholder('np. 48676567 (same cyfry, 5–20 znaków)')
         .setMinLength(5)
@@ -2752,8 +2757,8 @@ async function handleGiftcodeAddIdButton(interaction, sharedState) {
 async function handleGiftcodeUidModalSubmit(interaction, sharedState) {
     const { config, giftcodeService } = sharedState;
 
-    if (!_hasAnyClanRole(interaction.member, config)) {
-        return interaction.reply({ content: '❌ Tylko klanowicze mogą dodać swoje ID.', flags: MessageFlags.Ephemeral });
+    if (!_hasGiftcodeRole(interaction.member, config)) {
+        return interaction.reply({ content: '❌ Nie masz uprawnień, aby dodać swoje ID.', flags: MessageFlags.Ephemeral });
     }
 
     const uid = interaction.fields.getTextInputValue(GIFTCODE_INPUT_ID).trim();

--- a/Stalker/index.js
+++ b/Stalker/index.js
@@ -180,7 +180,8 @@ async function autoRedeemFromMessage(code, message) {
         return;
     }
 
-    const targetRoleIds = Object.values(config.targetRoles).filter(Boolean);
+    // Role klanowe + dodatkowe role z .env (STALKER_LME_GIFTCODE_EXTRA_ROLE)
+    const targetRoleIds = config.giftcodeRoleIds ?? Object.values(config.targetRoles).filter(Boolean);
     const eligibleEntries = [];
     const skippedCount = { count: 0 };
     for (const [discordId, userData] of allEntries) {


### PR DESCRIPTION
## Co się zmienia

Do tej pory z systemu kodów Habby mogły korzystać wyłącznie osoby z rolami klanowymi (`config.targetRoles`). Ten PR dodaje możliwość wskazania **dodatkowych ról w `.env`**, które również są uprawnione.

## Zmiany

- `Stalker/config/config.js`
  - nowe pole `giftcodeExtraRoles` — parsuje `STALKER_LME_GIFTCODE_EXTRA_ROLE` (lista ID rozdzielona przecinkami, puste wartości pomijane)
  - nowe pole `giftcodeRoleIds` — role klanowe + dodatkowe, wyliczane raz przy starcie
- `Stalker/handlers/interactionHandlers.js`
  - `_hasAnyClanRole` → `_hasGiftcodeRole` + pomocnicze `_giftcodeRoleIds(config)` (z fallbackiem na same role klanowe)
  - `/giftcode` filtruje uprawnionych po `giftcodeRoleIds` zamiast po `targetRoles`
  - komunikat odmowy i etykieta w modalu nie mówią już wyłącznie o klanowiczach
- `Stalker/index.js`
  - auto-aktywacja wykrytego kodu również korzysta z `giftcodeRoleIds`
- dokumentacja: `CLAUDE.md` i `Stalker/CLAUDE.md` — opis nowej zmiennej środowiskowej

## Konfiguracja

```env
# opcjonalne, brak zmiennej = zachowanie jak dotychczas (tylko role klanowe)
STALKER_LME_GIFTCODE_EXTRA_ROLE=role_id1,role_id2
```

## Weryfikacja

- `node --check` na wszystkich trzech zmienionych plikach JS — bez błędów
- logika parsowania listy ról sprawdzona osobno (puste wartości, spacje, brak zmiennej → tylko role klanowe)
- pełnego uruchomienia bota nie da się wykonać w tym środowisku (brak `node_modules`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAW4wemc5wVkX9m2yTpYyu)_