### PR TITLE
Zaproszenie do powiadomień o party 30 s po zapełnieniu lobby

### DIFF
--- a/Wydarzynier/CLAUDE.md
+++ b/Wydarzynier/CLAUDE.md
@@ -14,6 +14,10 @@
    - Wiadomość powitalna w wątku (`messages.lobbyCreated`) wypisuje komendy właściciela (`/party-add`, `/party-kick`, `/party-close`) **oraz sekcję nagród** (`/rewards`, `/stats`) z krótkim opisem każdej
 3. **Repozytorium** - `repositionService.js`: 5min interval, repost ogłoszenia na górę, update licznika
 4. **Subskrypcje** - Toggle role notifications po zapełnieniu, ephemeral feedback
+   - **Zaproszenie do powiadomień** (`messages.lobbyFull` + przycisk `toggle_party_notifications`): wysyłane w wątku **30 sekund po zapełnieniu lobby** (`lobby.notificationInviteDelay`), a nie natychmiast. Planuje je `scheduleNotificationInvite` (z `handleFullLobby`), wysyła `sendNotificationInvite`
+   - **Persistencja:** `notificationInviteAt` i `notificationInviteSent` w `lobbies.json`; `restoreNotificationInvites` w `index.js` uzbraja timer po restarcie (timery żyją tylko w RAM, więc bez tego lobby zapełnione tuż przed restartem nie dostałoby wiadomości)
+   - **Wyrzucenie gracza przez właściciela** (`/party-kick`, gdy `isFull` spada na `false`) anuluje **niewysłane** zaproszenie (`cancelNotificationInvite`) - po ponownym zapełnieniu jest planowane od nowa. Zaproszenia już wysłanego nie powtarzamy
+   - **⚠️ Kroki w `handleFullLobby` są rozdzielone** - wcześniej wszystko siedziało w jednym `try`, zaczynając od `channels.fetch` i wysyłki wiadomości: jeden nieudany request zabierał ze sobą pytanie o nagrodę i 15-minutowy timer. Tak samo w `handleAcceptPlayer` i `/party-add` dodanie gracza do wątku ma własny `try` - wyjątek nie może pominąć sprawdzenia `isFull`, bo lobby zostawałoby pełne, ale bez wiadomości, pytania o nagrodę i timera
 8. **Nagrody specjalne (czerwone skrzynki)** - `nagrodyService.js`: Zliczanie nagród zdobytych w party, ranking `/stats`, korekta `/correct`
 
 **Funkcjonalność Nagród Specjalnych:**

--- a/Wydarzynier/config/config.js
+++ b/Wydarzynier/config/config.js
@@ -91,6 +91,7 @@ module.exports = {
     // Ustawienia lobby
     lobby: {
         maxPlayers: 7, // Założyciel + 6 osób
+        notificationInviteDelay: 30 * 1000, // 30 sekund od zapełnienia lobby - wiadomość z przyciskiem powiadomień o party
         rewardPromptDelay: 60 * 1000, // 1 minuta od zapełnienia lobby - pytanie o nagrodę specjalną
         discussionTime: 15 * 60 * 1000, // 15 minut w ms po zapełnieniu
         maxDuration: 15 * 60 * 1000, // 15 minut maksymalny czas trwania lobby

--- a/Wydarzynier/handlers/interactionHandlers.js
+++ b/Wydarzynier/handlers/interactionHandlers.js
@@ -447,33 +447,42 @@ class InteractionHandler {
             const added = sharedState.lobbyService.addPlayerToLobby(lobby.id, playerId);
             
             if (added) {
-                // Dodaj gracza do wątku
-                const thread = await interaction.guild.channels.fetch(lobby.threadId);
-                await thread.members.add(playerId);
-
-                // Wyślij wiadomość o dodaniu gracza
-                await thread.send(this.config.messages.playerAdded(playerId));
-
-                // Usuń oczekującą prośbę
-                sharedState.lobbyService.removePendingRequest(lobby.id, playerId);
-
-                // Aktualizuj wiadomość ogłoszeniową z nową liczbą graczy
-                await this.updateAnnouncementMessage(lobby, sharedState);
-
-                // Usuń wiadomość z prośbą bezpośrednio
+                // ⚠️ Gracz jest już w składzie, więc dalsze kroki nie mogą zabrać obsługi
+                // zapełnienia. Wcześniej dowolny nieudany request (dodanie do wątku, wiadomość
+                // powitalna, aktualizacja ogłoszenia) wyrzucał wyjątek PRZED sprawdzeniem
+                // `isFull` - lobby zostawało pełne, ale bez wiadomości o zapełnieniu,
+                // bez pytania o nagrodę i bez 15-minutowego timera.
                 try {
-                    await interaction.message.delete();
-                } catch (error) {
-                    // Jeśli nie można usunąć wiadomości, zaktualizuj ją.
-                    // Interakcja jest już potwierdzona (deferUpdate), więc edytujemy przez editReply
+                    // Dodaj gracza do wątku
+                    const thread = await interaction.guild.channels.fetch(lobby.threadId);
+                    await thread.members.add(playerId);
+
+                    // Wyślij wiadomość o dodaniu gracza
+                    await thread.send(this.config.messages.playerAdded(playerId));
+
+                    // Usuń oczekującą prośbę
+                    sharedState.lobbyService.removePendingRequest(lobby.id, playerId);
+
+                    // Aktualizuj wiadomość ogłoszeniową z nową liczbą graczy
+                    await this.updateAnnouncementMessage(lobby, sharedState);
+
+                    // Usuń wiadomość z prośbą bezpośrednio
                     try {
-                        await interaction.editReply({
-                            content: '✅ **Zaakceptowano**',
-                            components: []
-                        });
-                    } catch (updateError) {
-                        logger.error('❌ Błąd podczas aktualizacji wiadomości:', updateError);
+                        await interaction.message.delete();
+                    } catch (error) {
+                        // Jeśli nie można usunąć wiadomości, zaktualizuj ją.
+                        // Interakcja jest już potwierdzona (deferUpdate), więc edytujemy przez editReply
+                        try {
+                            await interaction.editReply({
+                                content: '✅ **Zaakceptowano**',
+                                components: []
+                            });
+                        } catch (updateError) {
+                            logger.error('❌ Błąd podczas aktualizacji wiadomości:', updateError);
+                        }
                     }
+                } catch (error) {
+                    logger.error(`❌ Błąd podczas dodawania gracza ${playerId} do wątku lobby ${lobby.id}:`, error);
                 }
 
                 // Sprawdź czy lobby jest pełne
@@ -589,27 +598,19 @@ class InteractionHandler {
      * @param {Object} sharedState - Współdzielony stan aplikacji
      */
     async handleFullLobby(lobby, sharedState) {
+        // ⚠️ Każdy krok osobno. Wcześniej wszystko siedziało w JEDNYM `try`, a zaczynało się od
+        // `channels.fetch(threadId)` i wysyłki wiadomości - jeden nieudany request (zanik sieci,
+        // wątek chwilowo niedostępny) zabierał ze sobą pytanie o nagrodę ORAZ 15-minutowy timer,
+        // czyli lobby zostawało bez zaproszenia do powiadomień i bez zamknięcia.
+        // Zaproszenie ma teraz własny, zapisywany termin, więc przeżywa też restart bota.
+
+        // Zaproszenie do powiadomień o party - 30 sekund po zapełnieniu lobby
+        await this.scheduleNotificationInvite(lobby, sharedState);
+
+        // Zaplanuj pytanie o nagrodę specjalną (1 minuta po zapełnieniu lobby)
+        await this.scheduleRewardPrompt(lobby, sharedState);
+
         try {
-            // Wyślij wiadomość o pełnym lobby z przyciskiem powiadomień
-            const thread = await sharedState.client.channels.fetch(lobby.threadId);
-            
-            // Utwórz przycisk do zarządzania rolą powiadomień
-            const notificationButton = new ActionRowBuilder()
-                .addComponents(
-                    new ButtonBuilder()
-                        .setCustomId('toggle_party_notifications')
-                        .setLabel('🔔 Powiadomienia o party')
-                        .setStyle(ButtonStyle.Success)
-                );
-
-            await thread.send({
-                content: this.config.messages.lobbyFull,
-                components: [notificationButton]
-            });
-
-            // Zaplanuj pytanie o nagrodę specjalną (1 minuta po zapełnieniu lobby)
-            await this.scheduleRewardPrompt(lobby, sharedState);
-
             // Ustaw nowy timer na 15 minut od zapełnienia
             const warningCallback = async (lobbyId) => {
                 await this.sendLobbyWarning(lobbyId, sharedState);
@@ -632,7 +633,105 @@ class InteractionHandler {
             );
 
         } catch (error) {
-            logger.error('❌ Błąd podczas obsługi pełnego lobby:', error);
+            logger.error('❌ Błąd podczas ustawiania timera pełnego lobby:', error);
+        }
+    }
+
+    /**
+     * Buduje przycisk zapisu na powiadomienia o party
+     * @returns {ActionRowBuilder[]} - Rząd z przyciskiem
+     */
+    buildNotificationInviteButtons() {
+        return [
+            new ActionRowBuilder()
+                .addComponents(
+                    new ButtonBuilder()
+                        .setCustomId('toggle_party_notifications')
+                        .setLabel('🔔 Powiadomienia o party')
+                        .setStyle(ButtonStyle.Success)
+                )
+        ];
+    }
+
+    /**
+     * Planuje zaproszenie do powiadomień o party (30 sekund po zapełnieniu lobby)
+     * @param {Object} lobby - Dane lobby
+     * @param {Object} sharedState - Współdzielony stan aplikacji
+     */
+    async scheduleNotificationInvite(lobby, sharedState) {
+        try {
+            // Nie planuj ponownie jeśli zaproszenie już poszło lub czeka w kolejce
+            if (lobby.notificationInviteSent || lobby.notificationInviteAt) return;
+
+            const delayMs = this.config.lobby.notificationInviteDelay;
+
+            lobby.notificationInviteAt = Date.now() + delayMs;
+            lobby.notificationInviteSent = false;
+            await sharedState.lobbyService.saveLobbies();
+
+            setTimeout(() => {
+                this.sendNotificationInvite(lobby.id, sharedState).catch(error => {
+                    logger.error(`❌ Błąd podczas wysyłania zaproszenia do powiadomień (${lobby.id}):`, error);
+                });
+            }, delayMs);
+
+        } catch (error) {
+            logger.error('❌ Błąd podczas planowania zaproszenia do powiadomień:', error);
+        }
+    }
+
+    /**
+     * Wysyła w wątku wiadomość o zapełnieniu lobby wraz z przyciskiem powiadomień o party
+     * @param {string} lobbyId - ID lobby
+     * @param {Object} sharedState - Współdzielony stan aplikacji
+     */
+    async sendNotificationInvite(lobbyId, sharedState) {
+        const lobby = sharedState.lobbyService.getLobby(lobbyId);
+        if (!lobby || lobby.notificationInviteSent) return;
+
+        // Zaproszenie zostało anulowane (właściciel kogoś wyrzucił)
+        if (!lobby.notificationInviteAt) return;
+
+        // Timer sprzed anulowania - po ponownym zapełnieniu obowiązuje nowy termin
+        if (Date.now() + 1000 < lobby.notificationInviteAt) return;
+
+        const thread = await sharedState.client.channels.fetch(lobby.threadId).catch(() => null);
+        if (!thread) {
+            logger.warn(`⚠️ Nie znaleziono wątku lobby ${lobbyId} - zaproszenie do powiadomień pominięte`);
+            return;
+        }
+
+        await thread.send({
+            content: this.config.messages.lobbyFull,
+            components: this.buildNotificationInviteButtons()
+        });
+
+        lobby.notificationInviteSent = true;
+        lobby.notificationInviteAt = null;
+        await sharedState.lobbyService.saveLobbies();
+
+        logger.info(`🔔 Wysłano zaproszenie do powiadomień o party w lobby ${lobbyId}`);
+    }
+
+    /**
+     * Anuluje zaplanowane (jeszcze niewysłane) zaproszenie do powiadomień.
+     * Wywoływane gdy właściciel wyrzuci gracza i lobby przestaje być pełne - wiadomość
+     * „Lobby zapełnione!" nie ma wtedy prawa się pojawić. Po ponownym zapełnieniu
+     * `handleFullLobby` zaplanuje ją od nowa. Raz wysłanego zaproszenia nie powtarzamy.
+     * @param {Object} lobby - Dane lobby
+     * @param {Object} sharedState - Współdzielony stan aplikacji
+     */
+    async cancelNotificationInvite(lobby, sharedState) {
+        try {
+            if (!lobby || lobby.notificationInviteSent || !lobby.notificationInviteAt) return;
+
+            lobby.notificationInviteAt = null;
+            await sharedState.lobbyService.saveLobbies();
+
+            logger.info(`🔕 Party ${lobby.id} przestało być pełne - anulowano zaproszenie do powiadomień`);
+
+        } catch (error) {
+            logger.error(`❌ Błąd podczas anulowania zaproszenia do powiadomień (${lobby?.id}):`, error);
         }
     }
 
@@ -2386,8 +2485,10 @@ class InteractionHandler {
             if (ownerLobby.isFull && ownerLobby.players.length < this.config.lobby.maxPlayers) {
                 ownerLobby.isFull = false;
 
-                // Właściciel wyrzucił gracza - pytanie o nagrodę znika do czasu ponownego zapełnienia
+                // Właściciel wyrzucił gracza - pytanie o nagrodę i zaproszenie do powiadomień
+                // znikają do czasu ponownego zapełnienia
                 await this.cancelRewardPrompt(ownerLobby, sharedState);
+                await this.cancelNotificationInvite(ownerLobby, sharedState);
             }
 
             // Zapisz zmiany
@@ -2792,15 +2893,21 @@ class InteractionHandler {
             const added = sharedState.lobbyService.addPlayerToLobby(ownerLobby.id, targetUser.id);
             
             if (added) {
-                // Dodaj gracza do wątku
-                const thread = await sharedState.client.channels.fetch(ownerLobby.threadId);
-                await thread.members.add(targetUser.id);
+                // Jak w ścieżce akceptacji: gracz jest już w składzie, więc nieudany request
+                // do Discorda nie może pominąć obsługi zapełnionego lobby
+                try {
+                    // Dodaj gracza do wątku
+                    const thread = await sharedState.client.channels.fetch(ownerLobby.threadId);
+                    await thread.members.add(targetUser.id);
 
-                // Wyślij wiadomość o dodaniu gracza
-                await thread.send(sharedState.config.messages.playerAdded(targetUser.id));
+                    // Wyślij wiadomość o dodaniu gracza
+                    await thread.send(sharedState.config.messages.playerAdded(targetUser.id));
 
-                // Aktualizuj wiadomość ogłoszeniową z nową liczbą graczy
-                await this.updateAnnouncementMessage(ownerLobby, sharedState);
+                    // Aktualizuj wiadomość ogłoszeniową z nową liczbą graczy
+                    await this.updateAnnouncementMessage(ownerLobby, sharedState);
+                } catch (error) {
+                    logger.error(`❌ Błąd podczas dodawania gracza ${targetUser.id} do wątku lobby ${ownerLobby.id}:`, error);
+                }
 
                 // Sprawdź czy lobby jest pełne
                 if (ownerLobby.isFull) {

--- a/Wydarzynier/index.js
+++ b/Wydarzynier/index.js
@@ -165,6 +165,7 @@ client.once(Events.ClientReady, async () => {
         const interactionHandler = new InteractionHandler(config, lobbyService, timerService, bazarService);
         await interactionHandler.registerSlashCommands(client);
 
+        restoreNotificationInvites(interactionHandler, sharedState);
         restoreRewardPrompts(interactionHandler, sharedState);
 
         startRepositionSystem(sharedState);
@@ -429,6 +430,31 @@ process.on('uncaughtException', error => {
     // ma własny handler, który przed wyjściem domyka zapisy w toku (`jsonStore.flush()`).
     // Wyjście stąd ubijało proces zanim flush zdążył się wykonać.
 });
+
+/**
+ * Przywraca zaplanowane zaproszenia do powiadomień o party po restarcie bota.
+ * Timery żyją tylko w pamięci, więc bez tego lobby zapełnione tuż przed restartem
+ * nigdy nie dostałoby wiadomości o zapełnieniu.
+ * @param {InteractionHandler} interactionHandler - Handler interakcji
+ * @param {Object} sharedState - Współdzielony stan aplikacji
+ */
+function restoreNotificationInvites(interactionHandler, sharedState) {
+    const lobbies = sharedState.lobbyService.getAllActiveLobbies();
+
+    for (const lobby of lobbies) {
+        if (lobby.notificationInviteSent || !lobby.notificationInviteAt) continue;
+
+        const remaining = Math.max(0, lobby.notificationInviteAt - Date.now());
+
+        setTimeout(() => {
+            interactionHandler.sendNotificationInvite(lobby.id, sharedState).catch(error => {
+                logger.error(`❌ Błąd podczas wysyłania przywróconego zaproszenia do powiadomień (${lobby.id}):`, error);
+            });
+        }, remaining);
+
+        logger.info(`🔔 Przywrócono zaproszenie do powiadomień dla lobby ${lobby.id} - za ${Math.round(remaining / 1000)}s`);
+    }
+}
 
 /**
  * Przywraca zaplanowane pytania o nagrodę specjalną po restarcie bota

--- a/Wydarzynier/services/lobbyService.js
+++ b/Wydarzynier/services/lobbyService.js
@@ -76,6 +76,12 @@ class LobbyService {
                 lobby.isFull = true;
             }
 
+            // Skład i flaga `isFull` muszą przetrwać restart - bez zapisu lobby wracało
+            // ze starą listą graczy (ścieżka `/party-add` nie zapisywała go w ogóle)
+            this.saveLobbies().catch(error => {
+                logger.error('❌ Błąd podczas zapisywania lobby po dodaniu gracza:', error);
+            });
+
             return true;
         }
 
@@ -250,6 +256,8 @@ class LobbyService {
                     createdAt: lobby.createdAt,
                     lastRepositionTime: lobby.lastRepositionTime || lobby.createdAt,
                     isExtended: lobby.isExtended || false,
+                    notificationInviteAt: lobby.notificationInviteAt || null, // Kiedy wysłać zaproszenie do powiadomień o party
+                    notificationInviteSent: lobby.notificationInviteSent || false,
                     rewardPromptAt: lobby.rewardPromptAt || null, // Kiedy wysłać pytanie o nagrodę specjalną
                     rewardPromptSent: lobby.rewardPromptSent || false,
                     rewardPromptMessageId: lobby.rewardPromptMessageId || null, // Aktualna wiadomość z pytaniem


### PR DESCRIPTION
## Problem

Wiadomość „Lobby zapełnione!" z przyciskiem **🔔 Powiadomienia o party** bywała pomijana — czasem nie pojawiała się w wątku w ogóle.

Powód: cała obsługa zapełnienia siedziała w **jednym** `try`, a wiadomość była wysyłana synchronicznie w środku ścieżki akceptacji gracza:

- `handleFullLobby` zaczynało od `channels.fetch(threadId)` i `thread.send(...)` — jeden nieudany request (zanik sieci, chwilowa niedostępność wątku) przerywał **wszystko**: zaproszenie, pytanie o nagrodę i 15-minutowy timer zamykający lobby;
- w `handleAcceptPlayer` i `/party-add` wyjątek z `thread.members.add` / `thread.send` / aktualizacji ogłoszenia leciał **przed** sprawdzeniem `isFull` — gracz był już w składzie, lobby było pełne, ale nie działo się nic więcej;
- wysyłka nie była nigdzie zapisywana, więc restart bota tuż po zapełnieniu gubił ją bezpowrotnie.

## Zmiany

- `Wydarzynier/config/config.js` — `lobby.notificationInviteDelay = 30 * 1000`
- `Wydarzynier/handlers/interactionHandlers.js`
  - zaproszenie jest **planowane** (`scheduleNotificationInvite`) i wysyłane **30 s po zapełnieniu** (`sendNotificationInvite`), analogicznie do pytania o nagrodę
  - `handleFullLobby` rozdzielone na niezależne kroki — błąd timera nie zabiera zaproszenia ani pytania o nagrodę
  - `handleAcceptPlayer` i `/party-add`: dodawanie gracza do wątku ma własny `try`, więc wyjątek nie pomija sprawdzenia `isFull`
  - `cancelNotificationInvite` — `/party-kick` anuluje **niewysłane** zaproszenie (po ponownym zapełnieniu planowane od nowa; wysłanego nie powtarzamy)
- `Wydarzynier/services/lobbyService.js` — `notificationInviteAt` / `notificationInviteSent` w `lobbies.json`, plus zapis lobby po dodaniu gracza (ścieżka `/party-add` nie zapisywała składu w ogóle)
- `Wydarzynier/index.js` — `restoreNotificationInvites` uzbraja timer po restarcie bota
- `Wydarzynier/CLAUDE.md` — opis nowego zachowania

## Weryfikacja

Testy na zaślepkach Discorda (`InteractionHandler` z podstawionym `client`/`lobbyService`/`timerService`), opóźnienie skrócone do 60 ms — wszystkie przeszły:

- brak wiadomości natychmiast po zapełnieniu, wysyłka dopiero po opóźnieniu, z właściwym `custom_id` przycisku
- zaproszenie leci mimo błędu przy tworzeniu timera
- `/party-kick` anuluje niewysłane zaproszenie; ponowne zapełnienie planuje je od nowa, bez duplikatu po kolejnym
- przywrócenie po restarcie (termin już minął) wysyła, a termin w przyszłości nie strzela przedwcześnie
- błąd `fetch` wątku w ścieżce akceptacji nie gubi obsługi pełnego lobby

Pełnego uruchomienia bota na Discordzie nie da się wykonać w tym środowisku (brak tokenów).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAW4wemc5wVkX9m2yTpYyu)_