### PR TITLE
EndersEcho: ogłoszenie nowego serwera po odblokowaniu OCR /update

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -465,7 +465,7 @@
 | `cc_action_unblock` | Odblokuj gracza — modal wyszukiwania lub info "brak zablokowanych" (ephemeral) |
 | `cc_action_roles` | Przetwórz role TOP — **wybór serwera** (`cc_roles_sel`, paginacja `cc_roles_pg_{n}`), potem `_handlePanelProcessRoles(interaction, guildId)` na WYBRANYM serwerze. Head admin widzi wszystkie skonfigurowane serwery, zwykły admin tylko swój |
 | `cc_unconf_kick` | Kicknij bota z serwera — select nieskonfigurowanych (`cc_kick_sel`, paginacja `cc_kick_pg_{n}`) → potwierdzenie `cc_kick_ok_{guildId}` / `cc_kick_no` → `guild.leave()`. Dane serwera zostają nietknięte |
-| `cfg_ocr_en_{guildId}` | „🔓 Włącz OCR /update" pod powiadomieniem o konfiguracji serwera na kanale logów head admina — `ocrBlockService.unblock(guildId, ['update'])`, info na kanał bota tego serwera, przycisk zamienia się na wyszarzone potwierdzenie z nickiem klikającego |
+| `cfg_ocr_en_{guildId}` | „🔓 Włącz OCR /update" pod powiadomieniem o konfiguracji serwera na kanale logów head admina — `ocrBlockService.unblock(guildId, ['update'])`, info na kanał bota tego serwera, przycisk zamienia się na wyszarzone potwierdzenie z nickiem klikającego. **Wyzwala też ogłoszenie nowego serwera** (`_maybeAnnounceNewServer`), o ile jeszcze nie poszło |
 | `cc_action_tester` | Zarządzaj testerami — lista + przyciski Dodaj/Usuń (ephemeral) |
 | `cc_bcr_refresh` | Odśwież przyciski pod wszystkimi ogłoszeniami globalnymi (head admin, ephemeral) — patrz sekcja „Zbiorcze liczniki reakcji" |
 | `cc_action_tokens` | Zużycie tokenów globalnie (ephemeral, head admin) |
@@ -923,7 +923,7 @@ ENDERSECHO_COMMUNITY_CHANNEL_ID=channel_id
 
 # Użytkownicy uprawnieni do /ocr-on-off (ID rozdzielone przecinkami)
 # Komenda włącza/wyłącza /update i/lub /test per-guild (parametry: action, target, guild z autocomplete)
-# Stan per-guild persystowany w data/guild_configs.json (ocrBlocked[])
+# Stan per-guild persystowany w data/guild_configs.json (ocrBlocked[], newServerAnnounced)
 ENDERSECHO_BLOCK_OCR_USER_IDS=discord_user_id_1,discord_user_id_2
 
 # Jeśli true, komenda /configure dostępna WYŁĄCZNIE dla administratora serwera (head admin traci dostęp)
@@ -1039,20 +1039,33 @@ const label = this.config.getAllGuilds().find(g => g.id === guildId)?.tag || gui
 - Wysyłaj przez `logService.sendEmbed(embed)` lub `guildLogger.sendEmbed(embed)` — nie przez kanał Discord
 - Kanał Discord: `ENDERSECHO_SERVER_LOG_CHANNEL_ID`
 
-### Ogłoszenie nowego serwera (AUTOMATYCZNE)
+### Ogłoszenie nowego serwera (AUTOMATYCZNE — po odblokowaniu OCR `/update`)
 
-Po **pierwszej** konfiguracji serwera (`!wasAlreadyConfigured`) bot **automatycznie** wysyła ogłoszenie na `allowedChannelId` każdego skonfigurowanego serwera — bez żadnego przycisku ani potwierdzenia ze strony admina.
+Ogłoszenie leci **przy pierwszym odblokowaniu OCR `/update`** na danym serwerze, a **NIE** po zakończeniu konfiguracji. Powód: nowy serwer startuje z zablokowanym `/update` i `/test`, więc do momentu odblokowania nikt na nim nie zgłasza wyników i serwer faktycznie nie bierze udziału w rywalizacji — nie ma czego ogłaszać. Momentem realnego dołączenia jest decyzja head admina o odblokowaniu OCR.
 
 **Flow:**
-- `cfg_accept` → `_broadcastNewServerAnnouncement(client, guild)` (fire-and-forget, nie blokuje odpowiedzi)
+- `cfg_accept` (pierwsza konfiguracja) → zapis `ocrBlocked: ['update','test']` + `newServerAnnounced: false`. **Żadnego ogłoszenia.**
+- Head admin odblokowuje `/update` → `_maybeAnnounceNewServer(client, guildId, unlockedCommands)` → `_broadcastNewServerAnnouncement(client, guild)`
 - Broadcast na `allowedChannelId` wszystkich serwerów, embed w języku serwera (`pol`/`eng`)
 
+**Ścieżki odblokowania wyzwalające ogłoszenie** (wszystkie trzy wołają ten sam helper):
+- `cfg_ocr_en_{guildId}` — przycisk „🔓 Włącz OCR /update" pod powiadomieniem o konfiguracji (`_handleCfgOcrEnable`)
+- `panel_ocr_en_{update|both}_{guildId}` — Centrum Dowodzenia, OCR on/off (`_handlePanelOcrAction`)
+- `/block-ocr action:enable` — komenda head admina (`handleBlockOcrCommand`)
+
+Odblokowanie samego `/test` ogłoszenia **nie** wyzwala — liczy się wyłącznie `/update`.
+
+**Ochrona przed dublem — flaga `newServerAnnounced` w `data/guild_configs.json`:**
+- Ogłoszenie leci dokładnie raz na serwer; flaga jest **trwała**, więc przeżywa restart bota oraz ponowne wyłączenie i włączenie OCR
+- Flaga stawiana **PRZED** wysyłką broadcastu — częściowo nieudany broadcast jest mniejszym złem niż ogłoszenie tego samego serwera dwa razy
+- **Migracja przy starcie** (`GuildConfigService.load()`): serwerom skonfigurowanym przed tą zmianą, którym brakuje flagi, ustawiane jest `newServerAnnounced = !ocrBlocked.includes('update')`. Serwer z odblokowanym `/update` = już działa i już był ogłoszony; serwer wciąż zablokowany = ogłoszenie poleci przy odblokowaniu. Serwery importowane z `.env` dostają `newServerAnnounced: true` od razu
+
 **Zawartość embeda** (kolor `0xFFD700` — złoty, uroczysty):
-- Nazwa serwera, liczba członków, numer kolejny skonfigurowanego serwera w rywalizacji
+- Nazwa serwera, liczba członków, numer kolejny skonfigurowanego serwera w rywalizacji (liczony w momencie odblokowania OCR)
 - PL: "N. skonfigurowany serwer" · EN: "Nth configured server" (sufiks ordinalny przez `_enOrdinal()`)
 - Thumbnail: ikona serwera Discord
 
-**Metody:** `_buildNewServerAnnouncementEmbeds(guild, serverNumber)`, `_enOrdinal(n)`, `_broadcastNewServerAnnouncement(client, guild)`
+**Metody:** `_maybeAnnounceNewServer(client, guildId, unlockedCommands)`, `_buildNewServerAnnouncementEmbeds(guild, serverNumber)`, `_enOrdinal(n)`, `_broadcastNewServerAnnouncement(client, guild)` · `GuildConfigService.isNewServerAnnounced(guildId)` / `setNewServerAnnounced(guildId, value)`
 
 ---
 

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -2330,9 +2330,14 @@ class InteractionHandler {
                     configuredAt: new Date().toISOString(),
                 },
             };
-            // Nowy serwer domyślnie ma zablokowane OCR komendy
+            // Nowy serwer domyślnie ma zablokowane OCR komendy.
+            // Ogłoszenie o dołączeniu do rywalizacji NIE leci tutaj — poleci dopiero,
+            // gdy head admin odblokuje na tym serwerze OCR `/update` (patrz
+            // `_maybeAnnounceNewServer`). Do tego czasu serwer nic nie zgłasza,
+            // więc nie ma czego ogłaszać.
             if (!wasAlreadyConfigured) {
                 newData.ocrBlocked = ['update', 'test'];
+                newData.newServerAnnounced = false;
             }
 
             await this.guildConfigService.saveConfig(interaction.guildId, newData);
@@ -2392,13 +2397,6 @@ class InteractionHandler {
                 ],
                 components: []
             });
-
-            // Automatyczne ogłoszenie nowego serwera na wszystkich kanałach (fire-and-forget)
-            if (!wasAlreadyConfigured) {
-                this._broadcastNewServerAnnouncement(interaction.client, interaction.guild).catch(err =>
-                    logger.error(`Błąd automatycznego ogłoszenia nowego serwera: ${err.message}`)
-                );
-            }
 
             // Powiadomienie o skonfigurowanym serwerze — webhook logów lub fallback na kanał raportów
             try {
@@ -3199,6 +3197,9 @@ class InteractionHandler {
 
         this._ccAudit(interaction, `🔓 Włączono OCR /update — ${serverName}`);
         this.adminPanelService?.refresh();
+
+        // Serwer właśnie realnie dołączył do rywalizacji — czas na ogłoszenie
+        await this._maybeAnnounceNewServer(interaction.client, targetGuildId, ['update']);
     }
 
     /** Dopisuje wpis do dziennika akcji admina w Centrum Dowodzenia */
@@ -4992,10 +4993,12 @@ class InteractionHandler {
                     await ch.send({ content: formatMessage(guildMsgs.ocrBlockPerGuildDisabled, { commands: cmdLabel, serverName }) }).catch(() => {});
                 }
             }
+            await this._maybeAnnounceNewServer(interaction.client, targetGuildId, targetCommands);
         } else {
             await this.ocrBlockService.block(targetGuildId, targetCommands);
             logger.warn(`🔒 OCR zablokowany dla ${cmdLabel} na serwerze ${serverName} (panel)`);
         }
+
         const actionLabel = action === 'en' ? t('🔓 Odblokowano', '🔓 Unblocked') : t('🔒 Zablokowano', '🔒 Blocked');
         await interaction.editReply({
             embeds: [new EmbedBuilder()
@@ -11784,6 +11787,49 @@ class InteractionHandler {
     }
 
     /**
+     * Ogłasza nowy serwer, jeśli właśnie odblokowano na nim OCR `/update`.
+     *
+     * Ogłoszenie celowo NIE leci po zakończeniu konfiguracji: nowy serwer startuje
+     * z zablokowanym OCR, więc do momentu odblokowania nikt na nim nie zgłasza wyników
+     * i nie bierze udziału w rywalizacji. Momentem, w którym serwer naprawdę do niej
+     * dołącza, jest odblokowanie `/update` przez head admina — i to on wyzwala ogłoszenie.
+     *
+     * Wywoływana ze WSZYSTKICH ścieżek odblokowania (przycisk pod powiadomieniem
+     * o konfiguracji, panel admina, komenda `/block-ocr`). Flaga `newServerAnnounced`
+     * w `guild_configs.json` gwarantuje, że ogłoszenie poleci dokładnie raz — także
+     * po restarcie bota i po ponownym wyłączeniu i włączeniu OCR.
+     *
+     * @param {import('discord.js').Client} client
+     * @param {string} guildId - serwer, na którym odblokowano OCR
+     * @param {string[]} unlockedCommands - komendy objęte odblokowaniem
+     */
+    async _maybeAnnounceNewServer(client, guildId, unlockedCommands) {
+        try {
+            if (!Array.isArray(unlockedCommands) || !unlockedCommands.includes('update')) return;
+            if (!guildId || !this.guildConfigService) return;
+            if (!this.guildConfigService.isConfigured(guildId)) return;
+            if (this.guildConfigService.isNewServerAnnounced(guildId)) return;
+            // Zabezpieczenie na wypadek, gdyby odblokowanie się nie zapisało
+            if (this.ocrBlockService?.isBlocked(guildId, 'update')) return;
+
+            const guild = client.guilds.cache.get(guildId)
+                || await client.guilds.fetch(guildId).catch(() => null);
+            if (!guild) {
+                logger.error(`Ogłoszenie nowego serwera pominięte: serwer ${guildId} niedostępny`);
+                return;
+            }
+
+            // Flagę stawiamy PRZED wysyłką — częściowo nieudany broadcast jest mniejszym
+            // złem niż ogłoszenie tego samego serwera po raz drugi
+            await this.guildConfigService.setNewServerAnnounced(guildId, true);
+            logger.info(`📣 Ogłaszam nowy serwer "${guild.name}" — OCR /update właśnie odblokowany`);
+            await this._broadcastNewServerAnnouncement(client, guild);
+        } catch (err) {
+            logger.error(`Błąd ogłoszenia nowego serwera (${guildId}): ${err.message}`);
+        }
+    }
+
+    /**
      * Obsługuje przycisk "Wyślij" — wysyła embed na kanały wszystkich serwerów.
      */
     async _handleInfoSend(interaction) {
@@ -12189,6 +12235,7 @@ class InteractionHandler {
                     await ch.send({ content: formatMessage(guildMsgs.ocrBlockPerGuildDisabled, { commands: cmdLabel, serverName }) }).catch(() => {});
                 }
             }
+            await this._maybeAnnounceNewServer(interaction.client, targetGuildId, targetCommands);
         } else {
             await this.ocrBlockService.block(targetGuildId, targetCommands);
             logger.warn(`🔒 OCR zablokowany dla ${cmdLabel} na serwerze ${serverName}`);

--- a/EndersEcho/services/guildConfigService.js
+++ b/EndersEcho/services/guildConfigService.js
@@ -72,6 +72,8 @@ class GuildConfigService {
                     topRoles: envGuild.topRoles || null,
                     globalTopNotifications: true,
                     ocrBlocked: legacyBlockedCommands.length > 0 ? [...legacyBlockedCommands] : [],
+                    // Serwer z .env działa od dawna — ogłoszenie o nim już poszło
+                    newServerAnnounced: true,
                     importedFromEnv: true,
                 };
                 this._guilds.set(envGuild.id, entry);
@@ -86,7 +88,22 @@ class GuildConfigService {
             }
         }
 
-        if (didImport) {
+        // Migracja flagi ogłoszenia nowego serwera.
+        // Ogłoszenie leci przy odblokowaniu OCR `/update`, a nie po zapisie konfiguracji,
+        // więc serwery sprzed tej zmiany trzeba oznaczyć, żeby kolejne przełączenie OCR
+        // nie wywołało ogłoszenia po raz drugi. Serwer, który wciąż czeka na odblokowanie
+        // `/update`, zostaje nieoznaczony — ogłoszenie poleci przy odblokowaniu.
+        let didMigrate = false;
+        for (const cfg of this._guilds.values()) {
+            if (!cfg.configured || typeof cfg.newServerAnnounced === 'boolean') continue;
+            cfg.newServerAnnounced = !(cfg.ocrBlocked || []).includes('update');
+            didMigrate = true;
+        }
+        if (didMigrate) {
+            logger.info('🔄 Zmigrowano flagę newServerAnnounced dla serwerów sprzed zmiany');
+        }
+
+        if (didImport || didMigrate) {
             await this._persist();
         }
 
@@ -170,6 +187,29 @@ class GuildConfigService {
     async setOcrBlocked(guildId, commands) {
         const existing = this._guilds.get(guildId) || {};
         this._guilds.set(guildId, { ...existing, ocrBlocked: commands });
+        await this._persist();
+    }
+
+    /**
+     * Czy ogłoszenie o dołączeniu tego serwera do rywalizacji już poleciało.
+     * Ogłoszenie wysyłane jest przy pierwszym odblokowaniu OCR `/update`, nie po
+     * samym zapisie konfiguracji — serwer bez odblokowanego OCR nie bierze jeszcze
+     * udziału w rywalizacji, więc nie ma czego ogłaszać.
+     * @param {string} guildId
+     * @returns {boolean}
+     */
+    isNewServerAnnounced(guildId) {
+        return this._guilds.get(guildId)?.newServerAnnounced === true;
+    }
+
+    /**
+     * Oznacza serwer jako ogłoszony (flaga trwała — przeżywa restart bota).
+     * @param {string} guildId
+     * @param {boolean} [value=true]
+     */
+    async setNewServerAnnounced(guildId, value = true) {
+        const existing = this._guilds.get(guildId) || {};
+        this._guilds.set(guildId, { ...existing, newServerAnnounced: value === true });
         await this._persist();
     }
 


### PR DESCRIPTION
## Co się zmienia

Ogłoszenie o nowym serwerze w EndersEcho leciało zaraz po tym, jak admin serwera zakończył konfigurację (`cfg_accept`). Nowy serwer startuje jednak z zablokowanym OCR (`/update` i `/test`), więc w tym momencie nikt jeszcze nie zgłasza na nim wyników i serwer faktycznie nie bierze udziału w rywalizacji.

Teraz ogłoszenie leci dopiero wtedy, gdy **head admin odblokuje na tym serwerze OCR `/update`** — to jest moment realnego dołączenia do rywalizacji.

## Zmiany

**`EndersEcho/handlers/interactionHandlers.js`**
- `cfg_accept`: usunięty fire-and-forget broadcast; nowy serwer dostaje teraz `newServerAnnounced: false` obok `ocrBlocked: ['update','test']`
- Nowy helper `_maybeAnnounceNewServer(client, guildId, unlockedCommands)` — sprawdza warunki (serwer skonfigurowany, jeszcze nie ogłoszony, `/update` faktycznie odblokowany), stawia flagę i wywołuje istniejący `_broadcastNewServerAnnouncement`
- Helper podpięty do **wszystkich trzech** ścieżek odblokowania OCR:
  - `_handleCfgOcrEnable` — przycisk „🔓 Włącz OCR /update" pod powiadomieniem o konfiguracji
  - `_handlePanelOcrAction` — Centrum Dowodzenia, OCR on/off
  - `handleBlockOcrCommand` — komenda `/block-ocr action:enable`
- Odblokowanie samego `/test` ogłoszenia nie wyzwala

**`EndersEcho/services/guildConfigService.js`**
- Nowe API: `isNewServerAnnounced(guildId)` / `setNewServerAnnounced(guildId, value)`
- Flaga `newServerAnnounced` trzymana w `data/guild_configs.json` — przeżywa restart bota, więc ponowne wyłączenie i włączenie OCR nie wywoła ogłoszenia drugi raz
- Migracja przy starcie dla serwerów sprzed tej zmiany: brak flagi → `newServerAnnounced = !ocrBlocked.includes('update')`. Serwer z odblokowanym `/update` już działa i już był ogłoszony; serwer wciąż zablokowany dostanie ogłoszenie przy odblokowaniu
- Serwery importowane z `.env` dostają `newServerAnnounced: true` od razu

**`EndersEcho/CLAUDE.md`** — zaktualizowana sekcja „Ogłoszenie nowego serwera" (nowy flow, trzy ścieżki wyzwalające, ochrona przed dublem, migracja) oraz opis przycisku `cfg_ocr_en_{guildId}` w tabeli komponentów.

## Uwagi projektowe

- Flaga jest stawiana **przed** wysyłką broadcastu — częściowo nieudany broadcast jest mniejszym złem niż ogłoszenie tego samego serwera dwa razy
- Numer kolejny serwera w embedzie jest teraz liczony w momencie odblokowania OCR, a nie zapisu konfiguracji

## Testy

- `node --check` na obu zmienionych plikach — składnia OK
- Logika migracji flagi przetestowana na sztucznym stanie (serwer stary/działający, serwer czekający na odblokowanie, serwer z zablokowanym tylko `/test`, niedokończona konfiguracja, wpis już oznaczony) — wyniki zgodne z założeniem
- Pełnego uruchomienia bota nie robiłem: w tym środowisku brakuje `node_modules` (`dotenv` nierozwiązywalny), a boty i tak działają na serwerze produkcyjnym

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWT2MQn7SjGuDkutFDYoo6


---
_Generated by [Claude Code](https://claude.ai/code/session_01EWT2MQn7SjGuDkutFDYoo6)_