### PR TITLE
Ten sam wynik nie liczy się dwa razy do wyzwania

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -1270,8 +1270,11 @@ Wpięcie w `_runUpdateFlow` **tuż po ustaleniu `bestScore`/`bossName`/`userName
 - Liczą się wyłącznie wyniki z timestampem **po `respondedAt`** (akceptacji)
 - Uczestnik z kompletem 3 wyników nie przyjmuje kolejnych
 - Jeden wynik zalicza się do WSZYSTKICH aktywnych wyzwań tego profilu na tym bossie
+- **⚠️ TEN SAM WYNIK NIE LICZY SIĘ DWA RAZY.** Bez tej blokady wystarczyło wrzucić ten sam screen trzy razy, żeby wypełnić wszystkie sloty jednym rezultatem — wynik nierekordowy też jest zaliczany do wyzwania, więc powtórka nie odbijała się o żadną inną blokadę (cooldown `/update` tylko ją opóźnia). Porównujemy **`scoreValue`, nie napis** — `1000B` i `1T` to ten sam wynik. Zakres celowo **per UCZESTNIK**: przeciwnik może legalnie trafić tę samą wartość. Odrzucona powtórka wraca w `registerScore().duplicates` i gracz dostaje o niej komunikat (`challengeNoticeDuplicate`) — inaczej nie wiedziałby, czemu licznik nie drgnął. Po cofnięciu wyniku ta sama wartość może wejść ponownie (wypada z tablicy, więc blokada jej nie widzi)
 
 **Gdzie widać informację:**
+Komunikat składa `_challengeNoticeValue(notices, pending, msgs, duplicates)` — zaliczone wyniki i odrzucone powtórki lecą w jednym polu. Gdy **nic** nie zostało zaliczone (sama powtórka albo wynik czekający na zatwierdzenie bossa), DM dostaje żółty kolor i tytuł `challengeDmDroppedTitle` zamiast „Wynik zaliczony".
+
 - **Jest publiczne ogłoszenie** → pole `⚔️ Wyzwanie` dokładane do `systemNotices` → trafia do **Embeda 4 (ℹ️ Informacje systemowe)**, bez żadnych zmian w `rankingService`. Dotyczy wszystkich trzech wywołań `createRecordEmbeds` w `_runUpdateFlow` (duplikat cross-server, „tylko rekord bossa", nowy rekord)
 - **Brak rekordu ogólnego i brak rekordu bossa** (nic nie idzie publicznie) → linia w `reasonText` embeda `createNoRecordEmbeds` **oraz DM** do gracza (`_sendChallengeScoreDm`)
 
@@ -1283,7 +1286,8 @@ Doliczenie następuje dopiero, gdy admin zmapuje alias — `_resolveChallengePen
 - `_handleBossMapLangSel` — alert o nieznanym bossie (`boss_mapm_*`)
 - `_handleBossCfgAddLangSel` — panel `🎯 Konfiguracja bossów`
 
-Dopiero wtedy gracz dostaje DM (`challengeDmVerifiedTitle`). Wynik, który nie trafił do żadnego wyzwania, jest porzucany z DM-em wyjaśniającym **jednym z dwóch powodów**:
+Dopiero wtedy gracz dostaje DM (`challengeDmVerifiedTitle`). Wynik, który nie trafił do żadnego wyzwania, jest porzucany z DM-em wyjaśniającym **jednym z trzech powodów**:
+- `duplicate` — ten sam `scoreValue` jest już zaliczony do tego wyzwania
 - `too_late` — wyzwanie na tym bossie **było**, ale zdążyło się rozstrzygnąć (albo komplet wyników był już zebrany)
 - `no_challenge` — gracz nie ma i nie miał wyzwania na tym bossie
 

--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -546,12 +546,14 @@ const pol = {
     challengeNoticeField: '⚔️ Wyzwanie',
     challengeNoticeCounted: 'Wynik zaliczony do wyzwania z **{opponent}** (boss **{boss}**) — **{count}/{total}**.\nTwoja suma: **{sum}**.',
     challengeNoticePending: 'Nazwa bossa nie została rozpoznana, więc wynik **czeka na zatwierdzenie przez administratora**. Po weryfikacji zostanie doliczony do Twojego wyzwania.',
+    challengeNoticeDuplicate: 'Wynik **{score}** jest już zaliczony do wyzwania z **{opponent}** (boss **{boss}**) — ten sam rezultat nie liczy się drugi raz. Nadal masz **{count}/{total}**.',
     challengeDmCountedTitle: '⚔️ Wynik zaliczony do wyzwania',
     challengeDmVerifiedTitle: '⚔️ Administrator zatwierdził nazwę bossa',
     challengeDmVerifiedDesc: 'Administrator zatwierdził nazwę bossa **{boss}**. Twój wynik **{score}** został doliczony do wyzwania.',
     challengeDmDroppedTitle: '⚠️ Wynik nie został doliczony do wyzwania',
     challengeDmDroppedTooLate: 'Administrator zatwierdził nazwę bossa **{boss}**, ale Twoje wyzwanie zostało już w tym czasie rozstrzygnięte — wynik **{score}** nie został doliczony.',
     challengeDmDroppedNoChallenge: 'Administrator zatwierdził nazwę bossa **{boss}**, ale nie masz otwartego wyzwania na tym bossie — wynik **{score}** nie został doliczony.',
+    challengeDmDroppedDuplicate: 'Administrator zatwierdził nazwę bossa **{boss}**, ale wynik **{score}** jest już zaliczony do Twojego wyzwania — ten sam rezultat nie liczy się drugi raz.',
     challengeDmDroppedStale: 'Nazwa bossa z Twojego zgłoszenia nie została zatwierdzona przez administratora w ciągu 72 godzin — wynik **{score}** nie zostanie doliczony do wyzwania.',
 
     // ⚔️ Wyzwania — rezultat
@@ -1140,12 +1142,14 @@ const eng = {
     challengeNoticeField: '⚔️ Challenge',
     challengeNoticeCounted: 'Score counted towards your challenge with **{opponent}** (boss **{boss}**) — **{count}/{total}**.\nYour total: **{sum}**.',
     challengeNoticePending: 'The boss name was not recognised, so the score is **awaiting administrator approval**. Once verified, it will be counted towards your challenge.',
+    challengeNoticeDuplicate: 'Score **{score}** is already counted towards your challenge with **{opponent}** (boss **{boss}**) — the same result does not count twice. You still have **{count}/{total}**.',
     challengeDmCountedTitle: '⚔️ Score counted towards your challenge',
     challengeDmVerifiedTitle: '⚔️ Administrator approved the boss name',
     challengeDmVerifiedDesc: 'An administrator approved the boss name **{boss}**. Your score **{score}** has been counted towards your challenge.',
     challengeDmDroppedTitle: '⚠️ Score was not counted towards your challenge',
     challengeDmDroppedTooLate: 'An administrator approved the boss name **{boss}**, but your challenge had already been decided by then — score **{score}** was not counted.',
     challengeDmDroppedNoChallenge: 'An administrator approved the boss name **{boss}**, but you have no open challenge on that boss — score **{score}** was not counted.',
+    challengeDmDroppedDuplicate: 'An administrator approved the boss name **{boss}**, but score **{score}** is already counted towards your challenge — the same result does not count twice.',
     challengeDmDroppedStale: 'The boss name from your submission was not approved by an administrator within 72 hours — score **{score}** will not be counted towards your challenge.',
 
     // ⚔️ Challenges — result

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -6666,7 +6666,7 @@ class InteractionHandler {
             // brak rekordu / nowy rekord), żeby liczył się każdy pozytywnie zweryfikowany screen.
             // /test (dryRun) nie zalicza niczego. Nierozpoznana nazwa bossa nie jest zaliczana od razu —
             // wynik czeka na zmapowanie aliasu przez admina (_resolveChallengePendingBoss).
-            const _challengeResult = dryRun ? { notices: [], pending: false } : await this._registerChallengeScore(interaction, {
+            const _challengeResult = dryRun ? { notices: [], duplicates: [], pending: false } : await this._registerChallengeScore(interaction, {
                 playerKey,
                 bossName,
                 score: bestScore,
@@ -16635,41 +16635,54 @@ class InteractionHandler {
      * @returns {Promise<{ notices: Array, pending: boolean }>} notices → pole w Embedzie 4
      */
     async _registerChallengeScore(interaction, { playerKey, bossName, score, scoreValue, guildId, timestamp, wasUnknownBoss }) {
-        if (!this.challengeService || !bossName) return { notices: [], pending: false };
+        if (!this.challengeService || !bossName) return { notices: [], duplicates: [], pending: false };
         try {
             if (wasUnknownBoss) {
                 const parked = await this.challengeService.addPendingScore({
                     playerKey, guildId, rawBoss: bossName, score, scoreValue, timestamp,
                 });
-                return { notices: [], pending: parked };
+                return { notices: [], duplicates: [], pending: parked };
             }
-            const { notices, finished } = await this.challengeService.registerScore({
+            const { notices, duplicates, finished } = await this.challengeService.registerScore({
                 playerKey, bossName, score, scoreValue, guildId, timestamp,
             });
             if (finished.length > 0) await this._finishChallenges(interaction.client, finished);
-            return { notices, pending: false };
+            return { notices, duplicates, pending: false };
         } catch (err) {
             this.logService._gl(guildId).warn(`⚠️ Błąd zaliczania wyniku do wyzwania: ${err.message}`);
-            return { notices: [], pending: false };
+            return { notices: [], duplicates: [], pending: false };
         }
     }
 
-    /** Buduje pole `⚔️ Wyzwanie` do Embeda 4 / treść DM o zaliczeniu wyniku */
-    _challengeNoticeValue(notices, pending, msgs) {
+    /**
+     * Buduje pole `⚔️ Wyzwanie` do Embeda 4 / treść DM o zaliczeniu wyniku.
+     * Powtórzony wynik ma własny komunikat — gracz musi wiedzieć, że wrzucenie
+     * tego samego rezultatu drugi raz nie podbiło mu licznika.
+     */
+    _challengeNoticeValue(notices, pending, msgs, duplicates = []) {
         if (pending) return msgs.challengeNoticePending;
-        if (!notices.length) return null;
-        return notices.map(n => formatMessage(msgs.challengeNoticeCounted, {
+        const lines = notices.map(n => formatMessage(msgs.challengeNoticeCounted, {
             opponent: this.challengeService.participantName(n.opponent, msgs),
             boss: n.boss,
             count: n.count,
             total: n.total,
             sum: this.rankingService.formatScore(n.sum),
-        })).join('\n\n');
+        }));
+        for (const d of duplicates) {
+            lines.push(formatMessage(msgs.challengeNoticeDuplicate, {
+                score: d.score,
+                opponent: this.challengeService.participantName(d.opponent, msgs),
+                boss: d.boss,
+                count: d.count,
+                total: d.total,
+            }));
+        }
+        return lines.length ? lines.join('\n\n') : null;
     }
 
     /** Pole do `systemNotices` (Embed 4) albo null, gdy nie ma o czym informować */
     _challengeSystemNotice(result, msgs) {
-        const value = this._challengeNoticeValue(result?.notices || [], result?.pending, msgs);
+        const value = this._challengeNoticeValue(result?.notices || [], result?.pending, msgs, result?.duplicates || []);
         return value ? { name: msgs.challengeNoticeField, value } : null;
     }
 
@@ -16680,11 +16693,16 @@ class InteractionHandler {
      */
     async _sendChallengeScoreDm(client, userId, guildId, result) {
         const msgs = this.msgs(guildId);
-        const value = this._challengeNoticeValue(result?.notices || [], result?.pending, msgs);
+        const duplicates = result?.duplicates || [];
+        const value = this._challengeNoticeValue(result?.notices || [], result?.pending, msgs, duplicates);
         if (!value) return;
+        // Sama powtórka (nic nie zaliczono) to ostrzeżenie, nie potwierdzenie
+        const onlyDuplicate = duplicates.length > 0 && !(result?.notices || []).length;
         const embed = new EmbedBuilder()
-            .setColor(result?.pending ? 0xFEE75C : 0x5865F2)
-            .setTitle(msgs.challengeDmCountedTitle)
+            .setColor(result?.pending || onlyDuplicate ? 0xFEE75C : 0x5865F2)
+            // „Zaliczony" tylko gdy faktycznie coś weszło — powtórka i wynik czekający
+            // na zatwierdzenie nazwy bossa niczego nie doliczyły
+            .setTitle((result?.notices || []).length ? msgs.challengeDmCountedTitle : msgs.challengeDmDroppedTitle)
             .setDescription(value)
             .setTimestamp();
         await this._dmUser(client, userId, { embeds: [embed] });
@@ -16720,7 +16738,9 @@ class InteractionHandler {
                     .setColor(0xFEE75C)
                     .setTitle(msgs.challengeDmDroppedTitle)
                     .setDescription(formatMessage(
-                        item.reason === 'too_late' ? msgs.challengeDmDroppedTooLate : msgs.challengeDmDroppedNoChallenge,
+                        item.reason === 'duplicate' ? msgs.challengeDmDroppedDuplicate
+                            : item.reason === 'too_late' ? msgs.challengeDmDroppedTooLate
+                            : msgs.challengeDmDroppedNoChallenge,
                         { boss: englishBoss, score: item.score }
                     ))
                     .setTimestamp();

--- a/EndersEcho/services/challengeService.js
+++ b/EndersEcho/services/challengeService.js
@@ -269,10 +269,12 @@ class ChallengeService {
      *   finished = wyzwania rozstrzygnięte tym wynikiem (do rozesłania powiadomień)
      */
     async registerScore({ playerKey, bossName, score, scoreValue, guildId, timestamp }) {
-        if (!playerKey || !bossName) return { notices: [], finished: [] };
+        if (!playerKey || !bossName) return { notices: [], duplicates: [], finished: [] };
         const bossLc = String(bossName).toLowerCase();
         const ts = timestamp || new Date().toISOString();
+        const value = Number(scoreValue) || 0;
         const notices = [];
+        const duplicates = [];
         const finished = [];
 
         await this._mutate(draft => {
@@ -286,10 +288,31 @@ class ChallengeService {
                 // Liczą się WYŁĄCZNIE wyniki złożone po akceptacji wyzwania
                 if (ch.respondedAt && Date.parse(ts) < Date.parse(ch.respondedAt)) continue;
 
-                me.scores.push({ score, scoreValue: Number(scoreValue) || 0, timestamp: ts, guildId });
+                const other = ch[side === 'challenger' ? 'opponent' : 'challenger'];
+
+                // TEN SAM WYNIK NIE LICZY SIĘ DWA RAZY.
+                // Bez tego wystarczyło wrzucić ten sam screen trzy razy, żeby wypełnić
+                // wszystkie sloty jednym rezultatem — wynik nierekordowy też jest zaliczany
+                // do wyzwania, więc powtórka nie odbijała się od żadnej innej blokady.
+                // Porównujemy `scoreValue` (liczbę), nie napis: „1000B" i „1T" to ten sam wynik.
+                // Zakres celowo per UCZESTNIK — przeciwnik może legalnie trafić tę samą wartość.
+                if (me.scores.some(s => (Number(s.scoreValue) || 0) === value)) {
+                    duplicates.push({
+                        id: ch.id,
+                        boss: ch.boss,
+                        side,
+                        count: me.scores.length,
+                        total: SCORES_PER_SIDE,
+                        sum: me.sum,
+                        score,
+                        opponent: { ...other },
+                    });
+                    continue;
+                }
+
+                me.scores.push({ score, scoreValue: value, timestamp: ts, guildId });
                 this._recalcSum(me);
 
-                const other = ch[side === 'challenger' ? 'opponent' : 'challenger'];
                 notices.push({
                     id: ch.id,
                     boss: ch.boss,
@@ -307,7 +330,7 @@ class ChallengeService {
             }
         });
 
-        return { notices, finished };
+        return { notices, duplicates, finished };
     }
 
     /** Rozstrzyga wyzwanie (wołane wewnątrz `_mutate`) */
@@ -365,7 +388,7 @@ class ChallengeService {
         const finished = [];
 
         for (const [pid, pending] of matching) {
-            const { notices, finished: justFinished } = await this.registerScore({
+            const { notices, duplicates, finished: justFinished } = await this.registerScore({
                 playerKey: pending.playerKey,
                 bossName: englishBoss,
                 score: pending.score,
@@ -378,6 +401,9 @@ class ChallengeService {
             if (notices.length > 0) {
                 credited.push({ ...pending, boss: englishBoss, notices });
                 finished.push(...justFinished);
+            } else if (duplicates.length > 0) {
+                // Ten sam wynik jest już w wyzwaniu — zatwierdzenie nazwy bossa niczego nie zmienia
+                dropped.push({ ...pending, boss: englishBoss, reason: 'duplicate' });
             } else {
                 // Wynik nie wszedł do żadnego wyzwania. Rozróżniamy dwa powody, bo gracz
                 // dostaje o tym DM: „spóźniony" (wyzwanie na tym bossie było, ale zdążyło


### PR DESCRIPTION
## Problem

Wynik **nierekordowy też jest zaliczany do wyzwania** (to celowe — inaczej pojedynek dałoby się zablokować przez brak progresu), więc powtórzone wrzucenie tego samego screena nie odbijało się o żadną blokadę. Cooldown `/update` tylko je opóźniał. Wystarczyło wrzucić jeden dobry wynik trzy razy, żeby wypełnić nim wszystkie sloty wyzwania.

## Poprawka

`registerScore` odrzuca wynik, którego `scoreValue` już jest w tablicy tego uczestnika:

- **Porównujemy wartość liczbową, nie napis** — `1000B` i `1T` to ten sam rezultat, więc sama zmiana zapisu nie obejdzie blokady
- **Zakres per UCZESTNIK, nie per wyzwanie** — przeciwnik może legalnie trafić tę samą wartość i jego wynik musi się liczyć
- **Po cofnięciu wyniku ta sama wartość może wejść ponownie** — wypada z tablicy, więc blokada jej nie widzi (`↩️ Cofnij wynik`, panel `🧹 Usuń wynik`)

Odrzucona powtórka wraca w `registerScore().duplicates` i gracz dostaje o niej komunikat — bez tego nie wiedziałby, czemu licznik nie drgnął. Trafia w te same miejsca co potwierdzenie zaliczenia: Embed 4 przy publicznym ogłoszeniu, a przy braku rekordu do embeda odpowiedzi i na priv.

Ścieżka nierozpoznanej nazwy bossa ma nowy powód porzucenia `duplicate` (obok `too_late` i `no_challenge`) — zaparkowany wynik, który po zatwierdzeniu aliasu okazuje się powtórką, dostaje własny komunikat zamiast mylącego „nie masz takiego wyzwania".

Przy okazji, w tej samej linii: DM z tytułem „Wynik zaliczony do wyzwania" wychodził też wtedy, gdy **nic** nie zostało zaliczone — przy powtórce i przy wyniku czekającym na zatwierdzenie bossa. Teraz w obu przypadkach leci żółty embed z tytułem `challengeDmDroppedTitle`.

## Testy

Osiem przypadków na tymczasowym katalogu danych (brak `node_modules`, więc bez uruchomienia bota):

| # | Przypadek | Wynik |
|---|---|---|
| 1 | pierwszy wynik `5T` | zaliczony 1/3 |
| 2 | ten sam `5T` ponownie | odrzucony, licznik nadal 1/3 |
| 3 | `5000B` (ta sama wartość, inny napis) | odrzucony jako powtórka |
| 4 | inny wynik `6T` | zaliczony 2/3 |
| 5 | przeciwnik z wartością `5T` | zaliczony — dedup jest per uczestnik |
| 6 | stan tablicy A | `5T,6T`, suma 11T |
| 7 | zaparkowana powtórka po zatwierdzeniu bossa | porzucona z powodem `duplicate` |
| 8 | ta sama wartość po cofnięciu wyniku | wchodzi ponownie |

Do tego kontrola kluczy komunikatów (84 w `pol` i 84 w `eng`, zero rozbieżności, zero martwych) i `node --check` na zmienionych plikach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9TQHRKc9tG29q2UimiVPN)_