### PR TITLE
Stronicowanie listy serwerów, normalizacja sortowania + fix ReferenceError przy usuwaniu danych serwera

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -1248,12 +1248,20 @@ Statusy: `pending` (czeka na odpowiedź) · `active` (trwa) · `finished` (rozst
 
 ### Wizard (ephemeral, wzorzec `/subscribe`)
 
-1. `chal_srv` — wybór serwera (`config.getAllGuilds()`)
+1. `chal_srv` — wybór serwera (`config.getAllGuilds()`, 25/stronę + przyciski zakresów liter `chal_spage_{offset}`). **⚠️ Wcześniej lista była ucinana** (`options.slice(0, 25)`) — przy większej liczbie serwerów reszty nie dało się wybrać, bez żadnego śladu w UI
 2. `chal_pl` — wybór gracza z rankingu tego serwera (25/stronę + przyciski zakresów liter `chal_page_{offset}`); **wszystkie własne profile odfiltrowane** (`getOwnerId` ≠ wywołujący)
 3. `chal_boss` — wybór bossa (`_getAllEnglishBossNames()`, 25/stronę, `chal_bpage_{n}`)
 4. Potwierdzenie z **miniaturą bossa** + zasady → `chal_ok` / `chal_no`
 
 Stan wizarda: `_challengeSessions` Map (RAM, TTL 15 min) — `guildId + playerKey + nazwa bossa` nie zmieszczą się w customId (limit 100 znaków). To sesja czysto UI, restart bota tylko ją zeruje.
+
+**⚠️ Kolejność alfabetyczna liczona z klucza ZNORMALIZOWANEGO** (`_normalizeSortName` / `_sortBucketLetter` / `_compareSortNames` w `interactionHandlers.js`) — wspólne dla list graczy i serwerów:
+- zdejmowane jest wszystko przed pierwszym znakiem **pisanym** (literą albo cyfrą), więc `🔥 Polski Squad` trafia pod `P`, a `❰ Zenith ❱` pod `Z`. Nicki i nazwy serwerów zaczynają się od emoji i ramek częściej niż od litery, a bez tego lista „alfabetyczna" alfabetyczna nie była: takie nazwy lądowały w koszu „nie-litera", a przycisk zakresu pokazywał `🔥 - ⭐` zamiast `A - K`
+- diakrytyki sprowadzane do liter bazowych (`Ą→A`, `Ż→Z`, `Ł→L`)
+- **`ł`/`Ł` NIE rozkłada się w NFD** (osobny punkt kodowy z kreską, nie litera ze znakiem łączącym) — dlatego jest mapa dla niego i garści podobnych liter z innych alfabetów (`ø đ ð þ æ œ ß ı`), których sam NFD też nie rozbije
+- kolejność: litery → cyfry → `#` (nazwy złożone wyłącznie ze znaków ozdobnych) na końcu
+- **przyciski zakresów buduje `_buildChallengeRangeButtons(items, activeOffset, prefix)`** — wspólne dla graczy (`chal_page_`) i serwerów (`chal_spage_`); etykiety liczone z klucza znormalizowanego, nie z surowej nazwy
+- ta sama normalizacja obowiązuje sortowanie w `_getNotifSortedPlayers`, więc dotyczy również listy graczy w `/subscribe`
 
 **Rekord powstaje dopiero po UDANEJ wysyłce DM.** Gdy przeciwnik ma zamknięte wiadomości prywatne, wpis jest kasowany (`discard`), a wyzywający dostaje `challengeErrDmClosed`.
 
@@ -1369,7 +1377,7 @@ Progi **1/3/5/10/20/50/100** dla rzuconych (`chal_sent_*`), przyjętych (`chal_a
 
 ### CustomIDs
 
-`chal_srv` | `chal_pl` | `chal_page_{offset}` | `chal_boss` | `chal_bpage_{n}` | `chal_bpage_info` | `chal_ok` | `chal_no` | `chal_acc_{id}` | `chal_rej_{id}` | `chal_share_{id}_{c|o}` | `chal_done_{id}` (nieaktywny znacznik)
+`chal_srv` | `chal_spage_{offset}` | `chal_pl` | `chal_page_{offset}` | `chal_boss` | `chal_bpage_{n}` | `chal_bpage_info` | `chal_ok` | `chal_no` | `chal_acc_{id}` | `chal_rej_{id}` | `chal_share_{id}_{c|o}` | `chal_done_{id}` (nieaktywny znacznik)
 
 **⚠️ Formy bezrodzajowe w komunikatach PL** — polska forma męska („przyjął", „Wygrałeś") misgenderuje każdego, kto nie jest mężczyzną. Dlatego: `podejmuje`/`odrzuca` zamiast `przyjął`/`odrzucił`, `Zwycięstwo!`/`Porażka.` zamiast `Wygrałeś!`/`Przegrałeś.`, `została zatwierdzona przez administrację` zamiast `Administrator zatwierdził`. Dokładając komunikat, nie wprowadzaj z powrotem form rodzajowych (ta sama zasada co w rzędzie „ostatnia reakcja" pod rozgłoszeniami).
 

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -11468,6 +11468,53 @@ class InteractionHandler {
     /**
      * Pobiera graczy z rankingu z display names i sortuje alfabetycznie (znaki specjalne na końcu).
      */
+    /**
+     * Klucz alfabetyczny nazwy — do sortowania i do etykiet zakresów liter.
+     *
+     * Nicki i nazwy serwerów na Discordzie zaczynają się od emoji, ramek i znaków
+     * ozdobnych częściej niż od litery. Bez normalizacji `🔥 Alicja` lądowała w koszu
+     * „nie-litera", a przycisk zakresu pokazywał `🔥` zamiast `A` — czyli lista
+     * alfabetyczna nie była alfabetyczna.
+     *
+     * Zdejmujemy więc wszystko przed pierwszym znakiem PISANYM (literą albo cyfrą)
+     * i sprowadzamy diakrytyki do liter bazowych: `Ą→A`, `Ż→Z`, `Ł→L`.
+     *
+     * ⚠️ `ł`/`Ł` NIE rozkłada się w NFD (to osobny punkt kodowy z kreską, nie litera
+     * ze znakiem łączącym) — dlatego jest mapa dla niego i garści podobnych liter
+     * z innych alfabetów (ø, đ, þ, æ, ß…), których sam NFD też nie rozbije.
+     */
+    _normalizeSortName(raw) {
+        const MAP = {
+            'ł': 'l', 'Ł': 'L', 'ø': 'o', 'Ø': 'O', 'đ': 'd', 'Đ': 'D', 'ð': 'd', 'Ð': 'D',
+            'þ': 't', 'Þ': 'T', 'æ': 'a', 'Æ': 'A', 'œ': 'o', 'Œ': 'O', 'ß': 's', 'ı': 'i',
+        };
+        const text = String(raw || '')
+            .replace(/[łŁøØđĐðÐþÞæÆœŒßı]/g, ch => MAP[ch] || ch)
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, ''); // znaki łączące (diakrytyki)
+        const first = text.search(/[\p{L}\p{N}]/u);
+        return first === -1 ? '' : text.slice(first);
+    }
+
+    /** Litera kosza alfabetycznego; `#` dla nazw złożonych wyłącznie ze znaków ozdobnych */
+    _sortBucketLetter(raw) {
+        const normalized = this._normalizeSortName(raw);
+        return normalized ? normalized[0].toUpperCase() : '#';
+    }
+
+    /** Porównanie nazw po kluczu alfabetycznym — litery przed resztą, `#` na końcu */
+    _compareSortNames(rawA, rawB) {
+        const a = this._normalizeSortName(rawA);
+        const b = this._normalizeSortName(rawB);
+        if (!a && !b) return String(rawA).localeCompare(String(rawB), 'pl', { sensitivity: 'base' });
+        if (!a) return 1;
+        if (!b) return -1;
+        const letterA = /^\p{L}/u.test(a);
+        const letterB = /^\p{L}/u.test(b);
+        if (letterA !== letterB) return letterA ? -1 : 1;
+        return a.localeCompare(b, 'pl', { sensitivity: 'base' });
+    }
+
     async _getNotifSortedPlayers(guildId, client) {
         const players = await this.rankingService.getSortedPlayers(guildId);
         const targetGuild = client.guilds.cache.get(guildId);
@@ -11483,16 +11530,7 @@ class InteractionHandler {
             // Profil dodatkowy → nick ze znacznikiem, żeby lista rozróżniała konta jednej osoby
             result.push({ ...player, displayName: formatProfileDisplayName(displayName, player.profileIndex || 1) });
         }
-        const isLetter = name => /^[a-zA-ZąćęłńóśźżĄĆĘŁŃÓŚŹŻ]/.test(name);
-        result.sort((a, b) => {
-            const nameA = a.displayName.toLowerCase();
-            const nameB = b.displayName.toLowerCase();
-            const letterA = isLetter(nameA);
-            const letterB = isLetter(nameB);
-            if (letterA && !letterB) return -1;
-            if (!letterA && letterB) return 1;
-            return nameA.localeCompare(nameB, 'pl', { sensitivity: 'base' });
-        });
+        result.sort((a, b) => this._compareSortNames(a.displayName, b.displayName));
         return result;
     }
 
@@ -16231,25 +16269,46 @@ class InteractionHandler {
             createdAt: Date.now(),
         });
 
-        const options = this.config.getAllGuilds().map(g =>
-            new StringSelectMenuOptionBuilder()
-                .setValue(g.id)
-                .setLabel(this._challengeGuildName(interaction.client, g.id).substring(0, 100))
-        );
-        if (options.length === 0) {
-            await interaction.reply({ content: msgs.challengeNoPlayers, flags: ['Ephemeral'] });
+        await this._renderChallengeServerPicker(interaction, 0, { initial: true });
+    }
+
+    /**
+     * Lista serwerów (25/stronę + przyciski zakresów liter).
+     *
+     * ⚠️ Wcześniej lista była **ucinana** do 25 pozycji (`options.slice(0, 25)`) — przy
+     * większej liczbie serwerów reszty po prostu nie dało się wybrać, bez żadnego śladu
+     * w UI. Stronicowanie jest tu więc naprawą, nie ozdobnikiem.
+     */
+    async _renderChallengeServerPicker(interaction, offset, { initial = false } = {}) {
+        const msgs = this.msgs(interaction.guildId);
+        const PAGE_SIZE = 25;
+
+        const servers = this.config.getAllGuilds()
+            .map(g => ({ id: g.id, label: this._challengeGuildName(interaction.client, g.id) }))
+            .sort((a, b) => this._compareSortNames(a.label, b.label));
+
+        if (servers.length === 0) {
+            const empty = { content: msgs.challengeNoPlayers, components: [] };
+            await (initial ? interaction.reply({ ...empty, flags: ['Ephemeral'] }) : interaction.editReply(empty));
             return;
         }
+
+        const safeOffset = Math.min(Math.max(0, offset), Math.max(0, (Math.ceil(servers.length / PAGE_SIZE) - 1) * PAGE_SIZE));
+        const page = servers.slice(safeOffset, safeOffset + PAGE_SIZE);
         const select = new StringSelectMenuBuilder()
             .setCustomId('chal_srv')
             .setPlaceholder(msgs.challengeSelectServerPlaceholder)
-            .addOptions(options.slice(0, 25));
+            .addOptions(page.map(s =>
+                new StringSelectMenuOptionBuilder().setValue(s.id).setLabel(s.label.substring(0, 100))
+            ));
+        const selectRow = new ActionRowBuilder().addComponents(select);
 
-        await interaction.reply({
-            content: msgs.challengeIntro,
-            components: [new ActionRowBuilder().addComponents(select)],
-            flags: ['Ephemeral'],
-        });
+        const components = servers.length <= PAGE_SIZE
+            ? [selectRow]
+            : [...this._buildChallengeRangeButtons(servers, safeOffset, 'chal_spage_'), selectRow];
+
+        const payload = { content: msgs.challengeIntro, components };
+        await (initial ? interaction.reply({ ...payload, flags: ['Ephemeral'] }) : interaction.editReply(payload));
     }
 
     /** Sesja wizarda (RAM, TTL 15 min) — customId nie pomieści guildId + playerKey + nazwy bossa */
@@ -16307,24 +16366,34 @@ class InteractionHandler {
 
         const components = sorted.length <= PAGE_SIZE
             ? [selectRow]
-            : [...this._buildChallengePageButtons(sorted, offset), selectRow];
+            : [...this._buildChallengeRangeButtons(
+                sorted.map(p => ({ label: p.displayName })), offset, 'chal_page_'), selectRow];
 
         await interaction.editReply({ content: msgs.challengeSelectPlayer, components });
     }
 
-    /** Przyciski zakresów liter dla listy graczy (analogicznie do `/subscribe`) */
-    _buildChallengePageButtons(players, activeOffset) {
+    /**
+     * Przyciski zakresów liter dla długiej listy (gracze, serwery) — select menu Discorda
+     * mieści 25 pozycji, więc dłuższa lista musi dać się przewijać alfabetycznie.
+     *
+     * Etykiety zakresów liczone są z **klucza znormalizowanego** (`_sortBucketLetter`),
+     * nie z surowej nazwy — inaczej przycisk pokazywałby `🔥 - ⭐` zamiast `A - K`.
+     *
+     * @param {Array<{label: string}>} items - lista posortowana tym samym kluczem
+     * @param {string} prefix - prefiks customId (`chal_page_` gracze, `chal_spage_` serwery)
+     */
+    _buildChallengeRangeButtons(items, activeOffset, prefix) {
         const PAGE_SIZE = 25;
         const rows = [];
         let currentRow = [];
-        for (let offset = 0; offset < players.length; offset += PAGE_SIZE) {
+        for (let offset = 0; offset < items.length; offset += PAGE_SIZE) {
             if (rows.length >= 4 && currentRow.length === 0) break;
-            const page = players.slice(offset, offset + PAGE_SIZE);
-            const first = (page[0].displayName || '?')[0].toUpperCase();
-            const last = (page[page.length - 1].displayName || '?')[0].toUpperCase();
+            const page = items.slice(offset, offset + PAGE_SIZE);
+            const first = this._sortBucketLetter(page[0].label);
+            const last = this._sortBucketLetter(page[page.length - 1].label);
             currentRow.push(
                 new ButtonBuilder()
-                    .setCustomId(`chal_page_${offset}`)
+                    .setCustomId(`${prefix}${offset}`)
                     .setLabel(first === last ? first : `${first} - ${last}`)
                     .setStyle(offset === activeOffset ? ButtonStyle.Success : ButtonStyle.Primary)
             );
@@ -16519,6 +16588,11 @@ class InteractionHandler {
                 return;
             }
             if (customId === 'chal_ok') { await this._handleChallengeConfirm(interaction); return; }
+            if (customId.startsWith('chal_spage_')) {
+                await interaction.deferUpdate();
+                await this._renderChallengeServerPicker(interaction, parseInt(customId.replace('chal_spage_', ''), 10) || 0);
+                return;
+            }
             if (customId.startsWith('chal_page_')) {
                 await interaction.deferUpdate();
                 await this._renderChallengePlayerPicker(interaction, parseInt(customId.replace('chal_page_', ''), 10) || 0);

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -6,6 +6,9 @@ const ProfileService = require('../services/profileService');
 const MESSAGES = require('../config/messages');
 const fs = require('fs').promises;
 const { createBotLogger } = require('../../utils/consoleLogger');
+// Cache plików JSON — `_handlePanelDeleteServerDataConfirm` wyrzuca z niego skasowane
+// dane serwera. Bez tego importu ta ścieżka leciała na `ReferenceError: store is not defined`
+const store = require('../../utils/jsonStore');
 
 const logger = createBotLogger('EndersEcho');
 


### PR DESCRIPTION
## 1. Fix: `store is not defined` przy usuwaniu danych serwera

Zgłoszony błąd produkcyjny. `_handlePanelDeleteServerDataConfirm` woła `store.forget(guildDataDir)`, ale **`interactionHandlers.js` w ogóle nie importował `jsonStore`** — ta ścieżka leciała na `ReferenceError`.

Skutek był gorszy niż sam komunikat o błędzie: wyjątek padał **po** `fs.rm` (pliki serwera już skasowane), a **przed** `invalidateGuildCache` i `deleteConfig`. Czyli:

- dane z dysku znikały, ale wpis w `guild_configs.json` zostawał,
- `rankingService._rankingCache` nadal trzymał skasowany ranking, a pierwszy zapis **odtworzyłby go na dysku** — dokładnie to, przed czym ostrzega komentarz dwie linijki niżej.

Błąd pochodzi z commita `7ac5350`, nie z tej gałęzi. Audyt całego projektu: to **jedyne** miejsce używające `store` bez importu — pozostałe 9 plików mają go poprawnie.

## 2. Błąd: lista serwerów była ucinana

Wybór serwera w `/challenge` budował opcje przez `options.slice(0, 25)`. Przy więcej niż 25 skonfigurowanych serwerach **reszty nie dało się wybrać** — bez paginacji, bez komunikatu, bez śladu w UI.

Teraz działa jak lista graczy: 25 pozycji na stronę + przyciski zakresów liter (`chal_spage_{offset}`).

## 3. Normalizacja znaków w kolejności alfabetycznej

Nicki i nazwy serwerów na Discordzie zaczynają się od emoji, ramek i znaków ozdobnych częściej niż od litery. Poprzednie sortowanie brało **surowy** pierwszy znak, więc `🔥 Polski Squad` lądowało w koszu „nie-litera" na końcu listy, a przycisk zakresu pokazywał `🔥 - ⭐` zamiast `A - K`. Lista „alfabetyczna" alfabetyczna nie była.

Nowe helpery (`_normalizeSortName`, `_sortBucketLetter`, `_compareSortNames`):

- zdejmują wszystko przed pierwszym znakiem **pisanym** (literą albo cyfrą)
- sprowadzają diakrytyki do liter bazowych: `Ą→A`, `Ż→Z`, `Ł→L`
- kolejność: litery → cyfry → `#` (nazwy złożone wyłącznie ze znaków ozdobnych) na końcu

**`ł`/`Ł` nie rozkłada się w NFD** — to osobny punkt kodowy z kreską, nie litera ze znakiem łączącym, więc sam `normalize('NFD')` by go nie rozbił. Stąd mapa dla niego i garści podobnych liter z innych alfabetów (`ø đ ð þ æ œ ß ı`).

Przyciski zakresów buduje wspólny `_buildChallengeRangeButtons(items, activeOffset, prefix)` — dla graczy (`chal_page_`) i serwerów (`chal_spage_`). Normalizacja trafiła też do `_getNotifSortedPlayers`, czyli **dotyczy również listy graczy w `/subscribe`** — to ten sam współdzielony helper, a rozjazd kolejności między komendami byłby gorszy niż spójna poprawa w obu.

## Testy

**Litera kosza:**

| Nazwa | Kosz |
|---|---|
| `🔥 Polski Squad` | `P` |
| `⭐⭐ Ąkademia` | `A` |
| `Łowcy Bossów` | `L` |
| `Żubry` | `Z` |
| `[PL] Chaos` | `P` |
| `❰ Zenith ❱` | `Z` |
| `Ørsted` | `O` |
| `ßeta` | `S` |
| `123 Legion` | `1` |
| `日本サーバー` | `日` |
| `🎮` (same emoji) | `#` |

**Sortowanie:** `Ąkademia · Alfa · ⭐ Beta · Ćma · Łowcy · Ørsted · [PL] Chaos · 🔥 Zenith · Żubry · 123 Legion · 🎮`

**Stronicowanie przy 60 serwerach:** trzy przyciski `A - K`, `K - U`, `U - Y`, wszystkie 60 pozycji osiągalne (wcześniej widocznych 25).

**Fix importu:** `node --check` + sprawdzenie, że `jsonStore.forget` jest funkcją i nie rzuca na nieistniejącej ścieżce.

Brak `node_modules` w środowisku, więc bez uruchomienia bota.

🤖 Generated with [Claude Code](https://claude.com/claude-code)