### PR TITLE
Centrum Dowodzenia: efemeryczne odpowiedzi przycisków + nowa sekcja ⚔️ Wyzwania

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -346,7 +346,7 @@
    - **Usuń dane serwera (head admin):** lista skonfigurowanych serwerów, na których bota już nie ma (`configured=true` ale `!guilds.cache.has(guildId)`) → potwierdzenie → usuwa `data/guilds/{guildId}/` + wpis z `guild_configs.json`. Operacja nieodwracalna.
    - **Automatyczna retencja konfiguracji (30 dni)** — `guildDataRetentionService.js`: `guildDelete` zapisuje serwer do `data/pending_guild_deletions.json` (z nazwą, językiem i timestampem); sweep przy starcie + co 12 h usuwa po 30 dniach **WYŁĄCZNIE konfigurację serwera**: wpis w `guild_configs.json` + `data/guilds/{guildId}/role_rankings.json`. **Dane graczy zostają** (`ranking.json`, `wyniki/`, `achievements.json`, rekordy bossów) — należą do użytkowników i tylko oni decydują o ich usunięciu (autonomia; zasilają też profil/wykresy cross-server). **`data/token_usage.json` również nietykane** — statystyki tokenów AI do celów rozliczeniowych/statystycznych (sekcja 7 polityki prywatności). `guildCreate` anuluje oczekujące usunięcie (bot wrócił); sweep też anuluje wpisy serwerów obecnych w cache (osierocone przy downtime). Po faktycznym usunięciu — powiadomienie na kanał logów serwerowych (`sendAdminNotification`, ping do head admina) z listą co usunięto/zachowano, w języku zapamiętanym przy `guildDelete`. Błąd usuwania nie kasuje wpisu — retry przy kolejnym przebiegu. UWAGA: zakres CELOWO węższy niż panelowy przycisk „Usuń dane serwera" (który kasuje cały `data/guilds/{guildId}/`). Zgodne z deklaracją w polityce prywatności (endersecho.thashar.dev/privacy).
    - **Konfiguracja bossów (head admin):** zarządzaj angielskimi nazwami bossów i ich aliasami w innych językach — patrz sekcja poniżej.
-   - **Centrum Dowodzenia (head admin):** panel 6 embedów na dedykowanym kanale z 4 rzędami przycisków akcji, aktualizowany automatycznie po każdej analizie OCR i akcji admina — patrz sekcja poniżej.
+   - **Centrum Dowodzenia (head admin):** panel 8 embedów na dedykowanym kanale z 4 rzędami przycisków akcji, aktualizowany automatycznie po każdej analizie OCR i akcji admina — patrz sekcja poniżej.
 
 **Komendy slash (KOMPLETNA lista rejestrowana w `getSlashCommands()`):** `/challenge`, `/configure`, `/help`, `/manage`, `/profile`, `/ranking`, `/test`, `/update`
 
@@ -1146,7 +1146,7 @@ ENDERSECHO_WEB_SYNC_TOKEN=ten_sam_sekret_co_w_cloudflare
 ENDERSECHO_WEB_SYNC_TOP=10
 ```
 
-**Działanie:** Panel to **7 osobnych wiadomości** (każda: 1 embed + własne rzędy przycisków) na kanale head admina. Edytowane automatycznie po każdym zdarzeniu. Kolejność sekcji = `SECTION_KEYS` w `adminPanelService.js`: `system, users, servers, bosses, stats, costs, tools`. Przy zmianie układu sekcji stare wiadomości są usuwane (iteracja po `Object.values(_messageIds)` — także osierocone klucze starych układów) i wysyłane od nowa. Wszystkie dynamiczne pola przycinane helperem `capField()` (limit 1024/pole, 4096/opis) — zabezpieczenie przed crashem.
+**Działanie:** Panel to **8 osobnych wiadomości** (każda: 1 embed + własne rzędy przycisków) na kanale head admina. Edytowane automatycznie po każdym zdarzeniu. Kolejność sekcji = `SECTION_KEYS` w `adminPanelService.js`: `system, users, servers, bosses, challenges, stats, costs, tools`. Przy zmianie układu sekcji stare wiadomości są usuwane (iteracja po `Object.values(_messageIds)` — także osierocone klucze starych układów) i wysyłane od nowa. Wszystkie dynamiczne pola przycinane helperem `capField()` (limit 1024/pole, 4096/opis) — zabezpieczenie przed crashem.
 
 **⚠️ KAŻDY przycisk panelu odpowiada EFEMERYCZNIE** (nowa wiadomość widoczna tylko dla klikającego) albo otwiera modal. Sekcje panelu to **stałe, publiczne wiadomości współdzielone przez wszystkich head adminów** — `interaction.update()` nadpisałby taką sekcję prywatnym widokiem jednej osoby aż do najbliższego `refresh()`, więc reszta zamiast statystyk oglądałaby cudzy ekran.
 
@@ -1156,7 +1156,7 @@ Rozstrzyga to `_panelRespond(interaction, payload)` w `interactionHandlers.js`: 
 
 Dalsze kroki flow (select menu, potwierdzenia, przyciski stron) klikane są już w wiadomości efemerycznej, więc `interaction.update()` jest w nich poprawne i zostaje.
 
-**7 embedów panelu (każdy z własnymi przyciskami POD embedem):**
+**8 embedów panelu (każdy z własnymi przyciskami POD embedem):**
 
 | # | Embed | Kolor | Zawartość | Przyciski |
 |---|---|---|---|---|
@@ -1164,9 +1164,10 @@ Dalsze kroki flow (select menu, potwierdzenia, przyciski stron) klikane są już
 | 2 | 👥 Użytkownicy | `0x57F287` | Łącznie graczy, aktywne cooldowny, oczekujące CV, **👑 Lider globalny**, **🕐 Ostatni rekord** (relative timestamp), **🏆 TOP10 pobijających rekordy** (liczba wpisów historii wyników per gracz, cross-server — `getActivePlayersStats().topRecordSetters`), **👥 Dodatkowe profile** (ilu graczy ma kilka kont i po ile — `profileRegistryService.getUsersWithAltProfiles()`, max 10 + "i N więcej", `⏳ N` przy profilach czekających na usunięcie), lista zablokowanych (max 3 + "i N więcej") | Rząd 1: `🔒 panel_block`, `🔓 cc_action_unblock`, `🗑️ panel_remove`, `🧹 panel_remove_score`, `🏆 panel_ach_del` · Rząd 2: `🔍 cc_player_lookup`, `🧊 cc_clear_cooldown`, `🗳️ cc_pending_cv` |
 | 3 | 🖥️ Serwery | `0xEB459E` | Per serwer: OCR on/off, liczba graczy, język, tag + globalny limit/cooldown w nagłówku; **paginacja 25 serwerów/stronę** (`_serversPage` w RAM, footer `Strona X/Y`); sekcje nieskonfigurowane/brak bota (max 10 + licznik) | Rząd 1 (paginacja): `◀️ cc_srv_pg_prev`, `cc_srv_pg_info` (disabled, wskaźnik strony), `▶️ cc_srv_pg_next` · Rząd 2: `🔄 panel_ocr`, `🔁 cc_action_roles`, `📋 panel_guild_list`, `🚫 panel_ban_guild`, `🗑️ panel_delete_server_data` · Rząd 3: `⚠️ cc_unconfigured`, `🔍 cc_diag_server` |
 | 4 | 👾 Bossowie | `0x1ABC9C` | Bossy w bazie, z rekordami, boss okresu, **🎯 Najczęstszy boss rekordów** (z aktualnych rekordów globalnego rankingu), **nieznane nazwy do zmapowania** (`bossRecordService.getUnknownBossNames()`, lista `• \`nazwa\`` max 5 + licznik), **bossy bez zdjęcia** (ten sam format, ale PEŁNA lista bez ucinania — chroni tylko twardy limit 1024 znaków przez `capField()`) | `👾 cc_action_boss_cfg` (pełny panel konfiguracji bossów jako ephemeral) |
-| 5 | 📊 Statystyki | `0x5865F2` | Analizy łącznie/od resetu, Success Rate z paskami `[████░░]`, **Wzorzec OK za 2. razem**, odrzucone, interwencje admina, **🌩️ Zdrowie API** (globalne, nieresetowalne: odrzucone/wszystkie zapytania + %, pełne odrzuty po 10 retry), top odrzucani, aktywni/nowi gracze, przyrost miesięczny, **🔢 Użycia komend** (top 10 + suma, dawny przycisk scalony do embeda) | `📈 panel_player_growth` (przyciski Success Rate i Użycia komend usunięte — dane w embedzie; szczegóły/reset liczników nadal w `/manage → Statystyki`) |
-| 6 | 💰 Koszty & Limity | `0xFEE75C` | Dziś (requesty, tokeny IN/OUT, koszt), miesiąc + projekcja, **⚙️ Limity i alert** (limit dzienny, cooldown, próg alertu), top 3 serwery, top 5 użytkowników | `📊 cc_action_tokens`, `⚙️ panel_limit`, `🔔 cc_cost_alert` (modal progu USD/dzień) |
-| 7 | ⚙️ Narzędzia | `0x95A5A6` | **🧪 Testerzy z nickami** (nick serwerowy z serwera kanału panelu + username Discord z linkiem do profilu, `_resolveTestersDetailed()`), liczba serwerów z zablokowanym OCR per-guild, następny Global TOP10, **stan globalnego OCR**, **📤 Rankingi na stronie** (kiedy poszła ostatnia wysyłka TOP 10, czy był to pełny snapshot czy pojedynczy serwer, ile serwerów śledzonych; `⚪ Wyłączona` gdy brak `ENDERSECHO_WEB_SYNC_*`) | `🧪 cc_action_tester`, `📅 panel_top10_interval`, `🔁 cc_bcr_refresh`, `🛑/▶️ cc_global_ocr` (kill-switch z potwierdzeniem `cc_global_ocr_ok_{block\|unblock}`) |
+| 5 | ⚔️ Wyzwania | `0xE67E22` | **🏆 TOP 5 zwycięzców** i **💔 TOP 5 przegranych** bieżącego miesiąca (`monthlyStandings()` — miesiąc liczony po czasie **warszawskim**, remisy i nierozstrzygnięte nie liczą się nikomu), **⚔️ W toku** (wszystkie, `2/3 : 1/3` + termin `<t:…:R>`), **📜 Ostatnie rozstrzygnięte** (10) | `📜 cc_chal_history`, `🏁 cc_chal_finish` |
+| 6 | 📊 Statystyki | `0x5865F2` | Analizy łącznie/od resetu, Success Rate z paskami `[████░░]`, **Wzorzec OK za 2. razem**, odrzucone, interwencje admina, **🌩️ Zdrowie API** (globalne, nieresetowalne: odrzucone/wszystkie zapytania + %, pełne odrzuty po 10 retry), top odrzucani, aktywni/nowi gracze, przyrost miesięczny, **🔢 Użycia komend** (top 10 + suma, dawny przycisk scalony do embeda) | `📈 panel_player_growth` (przyciski Success Rate i Użycia komend usunięte — dane w embedzie; szczegóły/reset liczników nadal w `/manage → Statystyki`) |
+| 7 | 💰 Koszty & Limity | `0xFEE75C` | Dziś (requesty, tokeny IN/OUT, koszt), miesiąc + projekcja, **⚙️ Limity i alert** (limit dzienny, cooldown, próg alertu), top 3 serwery, top 5 użytkowników | `📊 cc_action_tokens`, `⚙️ panel_limit`, `🔔 cc_cost_alert` (modal progu USD/dzień) |
+| 8 | ⚙️ Narzędzia | `0x95A5A6` | **🧪 Testerzy z nickami** (nick serwerowy z serwera kanału panelu + username Discord z linkiem do profilu, `_resolveTestersDetailed()`), liczba serwerów z zablokowanym OCR per-guild, następny Global TOP10, **stan globalnego OCR**, **📤 Rankingi na stronie** (kiedy poszła ostatnia wysyłka TOP 10, czy był to pełny snapshot czy pojedynczy serwer, ile serwerów śledzonych; `⚪ Wyłączona` gdy brak `ENDERSECHO_WEB_SYNC_*`) | `🧪 cc_action_tester`, `📅 panel_top10_interval`, `🔁 cc_bcr_refresh`, `🛑/▶️ cc_global_ocr` (kill-switch z potwierdzeniem `cc_global_ocr_ok_{block\|unblock}`) |
 
 **Nowe akcje CC (wszystkie tylko head admin, ephemeral):**
 - `🔍 cc_player_lookup` → modal (`cc_player_lookup_modal`) → wyszukiwanie w globalnym rankingu → przy wielu trafieniach select `cc_player_lookup_sel` → embed szczegółów gracza: pozycja globalna, rekord+boss, serwer, blokada, aktywny cooldown, odrzucenia w bieżącym miesiącu, liczba osiągnięć
@@ -1178,6 +1179,28 @@ Dalsze kroki flow (select menu, potwierdzenia, przyciski stron) klikane są już
 - `📢 cc_top10_preview` → `globalTop10Service.buildOnDemandEmbed()` jako ephemeral (bez zapisu snapshotu/harmonogramu)
 - `🔔 cc_cost_alert` → modal (`cc_cost_alert_modal`) progu dziennego kosztu AI w USD (puste = wyłącz). Po przekroczeniu progu `_maybeCostAlert()` wysyła na kanał panelu ping do head adminów (raz dziennie, `lastAlertDate` w persist)
 - `🛑 cc_global_ocr` → globalny kill-switch OCR (tryb serwisowy): `adminPanelService.setGlobalOcrBlocked()` persystowany w `admin_panel.json`; `_runUpdateFlow` sprawdza `isGlobalOcrBlocked()` po per-guild blocku (head admin pomija). Stan i przycisk (Wyłącz/Włącz) widoczne w embedzie Narzędzia
+
+### Sekcja ⚔️ Wyzwania — historia i ręczne zamykanie
+
+**`📜 cc_chal_history` — pełna historia z podziałem na serwery** (dwa kroki, oba efemeryczne):
+1. lista serwerów, na których cokolwiek się rozegrało, z licznikiem wyzwań (25/stronę + przyciski zakresów liter `cc_chal_hsp_{offset}`, ta sama normalizacja co `/challenge`)
+2. `cc_chal_hsrv` → historia jednego serwera, 8/stronę (`cc_chal_hpg_{guildId}_{page}`): pary graczy, boss, wynik (`3/3 : 2/3`), werdykt, data i — przy pojedynku międzyserwerowym — `🔀 nazwa drugiego serwera`
+
+⚠️ **Pojedynek dwóch serwerów liczy się do OBU list** (`_ccChalGuildIds`). Head admin patrzy na historię pytaniem „co się działo u nich", a taki pojedynek działł się u jednych i u drugich — przypisanie go tylko jednej stronie ukrywałoby go przed drugą.
+
+⚠️ **`cc_chal_hpg_{guildId}_{page}` parsowany od OSTATNIEGO `_`** — guildId to same cyfry, więc `split('_')` rozjechałby się na pierwszym separatorze.
+
+**`🏁 cc_chal_finish` — ręczne zamknięcie wyzwania** (trzy kroki): lista wyzwań w toku (25/stronę, `cc_chal_fpg_{offset}`, kolejność **wg terminu**, nie alfabetycznie — stąd zwykłe `◀️/▶️` zamiast zakresów liter) → `cc_chal_fsel` → potwierdzenie → `cc_chal_fok_{id}`.
+
+`challengeService.forceFinish(id, adminName)` rozstrzyga po **aktualnych sumach**, tak samo jak komplet wyników: wyższa wygrywa, równe = remis, `finishedBy` zapamiętuje admina. **Wyjątek: gdy ŻADNA ze stron nie wrzuciła wyniku** → status `unresolved`, nie `finished` — „remis 0:0" byłby kłamstwem i przyznawałby osiągnięcia za pojedynek, którego nie było.
+
+Powiadomienia idą **tą samą drogą co przy naturalnym końcu**, bez własnej ścieżki: `finished` → `_finishChallenges` (osiągnięcia + DM z przyciskiem „pochwal się"), `unresolved` → `_handleChallengeSweep({ unresolved: [ch] })` (komunikat jak po 72 h). Akcja trafia do dziennika (`_ccAudit`) i odświeża panel.
+
+**`✖️ cc_chal_close`** zamyka widok efemeryczny (podmienia go krótkim potwierdzeniem, bez komponentów).
+
+**Metody serwisu:** `getAll()` · `getActive()` (wg terminu) · `getClosed()` (wg `finishedAt`) · `monthlyStandings(refDate)` · `ChallengeService.warsawMonth(date)` · `forceFinish(id, adminName)`. Stała `CLOSED_STATUSES` = `finished, unresolved, declined, expired, cancelled`.
+
+**Helper `capLines(lines, max, more)`** w `adminPanelService.js` — jak `capField`, ale tnie CAŁYMI liniami i dopisuje, ilu pozycji nie widać. `capField` ucina w połowie wiersza, co przy listach wyzwań dawało urwany nick bez wyniku.
 
 **Dziennik akcji admina (`logAdminAction`):** wpisy dodawane helperem `_ccAudit(interaction, action)` przy: blokadzie/odblokowaniu gracza, usunięciu gracza/wyniku, akcjach CV (approve/remove/block), analizie manualnej, cofnięciach wyniku (ocr_revert + analyze revert), zmianie limitów, toggle AI OCR per-guild, banie/odbanowaniu serwera, usunięciu danych serwera, czyszczeniu cooldownu, alercie kosztowym, global OCR. Max 10 wpisów (wszystkie widoczne w embedzie System), persystowane w `admin_panel.json`. **We wpisach są NICKI, nie ID i nie pingi** — `_ccName(interaction, idOrKey)` rozwiązuje `userId`/`playerKey` (znacznik profilu zostaje) przez: member serwera → nick z rankingu globalnego → `users.cache` → fallback na samo ID. Ping `<@id>` renderowałby się w embedzie panelu jako klikalna wzmianka, a surowe ID jest nieczytelne. Wpisy zapisane przed tą zmianą są odpingowywane przy renderowaniu (`adminPanelService._auditNoPings()`).
 
@@ -1390,6 +1413,8 @@ Progi **1/3/5/10/20/50/100** dla rzuconych (`chal_sent_*`), przyjętych (`chal_a
 - **Ikona bossa zwracana jako BUFOR** (`_challengeBossImage` → `{buffer, name, thumb}`), a `AttachmentBuilder` budowany osobno dla każdej wysyłki (`_challengeBossFiles`) — ten sam obrazek leci w DM do obu graczy i w ogłoszeniu na serwerze
 
 ### CustomIDs
+
+`cc_chal_history` | `cc_chal_hsp_{offset}` | `cc_chal_hsrv` | `cc_chal_hpg_{guildId}_{page}` | `cc_chal_finish` | `cc_chal_fpg_{offset}` | `cc_chal_fsel` | `cc_chal_fok_{id}` | `cc_chal_close` (Centrum Dowodzenia)
 
 `chal_srv` | `chal_spage_{offset}` | `chal_pl` | `chal_page_{offset}` | `chal_boss` | `chal_bpage_{n}` | `chal_bpage_info` | `chal_ok` | `chal_no` | `chal_acc_{id}` | `chal_rej_{id}` | `chal_share_{id}_{c|o}` | `chal_done_{id}` (nieaktywny znacznik)
 

--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -1148,6 +1148,14 @@ ENDERSECHO_WEB_SYNC_TOP=10
 
 **Działanie:** Panel to **7 osobnych wiadomości** (każda: 1 embed + własne rzędy przycisków) na kanale head admina. Edytowane automatycznie po każdym zdarzeniu. Kolejność sekcji = `SECTION_KEYS` w `adminPanelService.js`: `system, users, servers, bosses, stats, costs, tools`. Przy zmianie układu sekcji stare wiadomości są usuwane (iteracja po `Object.values(_messageIds)` — także osierocone klucze starych układów) i wysyłane od nowa. Wszystkie dynamiczne pola przycinane helperem `capField()` (limit 1024/pole, 4096/opis) — zabezpieczenie przed crashem.
 
+**⚠️ KAŻDY przycisk panelu odpowiada EFEMERYCZNIE** (nowa wiadomość widoczna tylko dla klikającego) albo otwiera modal. Sekcje panelu to **stałe, publiczne wiadomości współdzielone przez wszystkich head adminów** — `interaction.update()` nadpisałby taką sekcję prywatnym widokiem jednej osoby aż do najbliższego `refresh()`, więc reszta zamiast statystyk oglądałaby cudzy ekran.
+
+Rozstrzyga to `_panelRespond(interaction, payload)` w `interactionHandlers.js`: w Centrum Dowodzenia robi `reply({ flags: ['Ephemeral'] })`, w efemerycznym panelu `/manage` — `interaction.update()`. Rozpoznanie idzie przez `adminPanelService.isPanelMessage(interaction.message?.id)` (porównanie z `_messageIds`), **nie** przez customId — te same handlery obsługują oba wejścia. Dotyczy `panel_ocr`, `panel_ban_guild`, `panel_guild_list` i `panel_delete_server_data`; pozostałe przyciski panelu już wcześniej odpowiadały przez `reply`/`deferReply` z flagą `Ephemeral` albo modalem.
+
+**Jedyny wyjątek: `cc_srv_pg_prev` / `cc_srv_pg_next`** — paginacja sekcji Serwery działa NA panelu (`deferUpdate()` + `changeServersPage()` + `refresh()`), bo jej sensem jest przewinięcie wspólnej wiadomości, a nie pokazanie czegoś jednej osobie.
+
+Dalsze kroki flow (select menu, potwierdzenia, przyciski stron) klikane są już w wiadomości efemerycznej, więc `interaction.update()` jest w nich poprawne i zostaje.
+
 **7 embedów panelu (każdy z własnymi przyciskami POD embedem):**
 
 | # | Embed | Kolor | Zawartość | Przyciski |

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -4816,6 +4816,31 @@ class InteractionHandler {
         }
     }
 
+    /**
+     * Czy przycisk kliknięto w Centrum Dowodzenia (stałe, publiczne wiadomości panelu),
+     * czy w efemerycznym panelu `/manage`.
+     */
+    _isCcInteraction(interaction) {
+        return this.adminPanelService?.isPanelMessage?.(interaction.message?.id) === true;
+    }
+
+    /**
+     * Widok panelu: w `/manage` podmienia efemeryczną wiadomość, w Centrum Dowodzenia
+     * odpowiada NOWĄ wiadomością efemeryczną.
+     *
+     * ⚠️ Bez tego rozróżnienia `interaction.update()` nadpisywałby sekcję Centrum Dowodzenia —
+     * publiczną wiadomość współdzieloną przez wszystkich head adminów — prywatnym widokiem
+     * jednej osoby, aż do najbliższego `refresh()`. Panel wracał więc do siebie sam, ale przez
+     * ten czas pokazywał komuś innemu cudzy ekran zamiast statystyk.
+     */
+    async _panelRespond(interaction, payload) {
+        if (this._isCcInteraction(interaction)) {
+            await interaction.reply({ ...payload, flags: ['Ephemeral'] });
+            return;
+        }
+        await interaction.update(payload);
+    }
+
     async _handlePanelOcr(interaction) {
         const t = this._panelT(interaction.guildId);
         const guildIds = this.guildConfigService?.getAllConfiguredGuildIds() || [];
@@ -4838,7 +4863,7 @@ class InteractionHandler {
                 { name: t('🔓 /test włączone', '🔓 /test enabled'), value: testEnabled.length ? testEnabled.join('\n') : none, inline: true },
             );
 
-        await interaction.update({
+        await this._panelRespond(interaction, {
             embeds: [embed],
             components: [new ActionRowBuilder().addComponents(
                 new ButtonBuilder().setCustomId('panel_ocr_manage').setEmoji('🔍').setLabel(t('Zarządzaj OCR', 'Manage OCR')).setStyle(ButtonStyle.Primary),
@@ -15312,7 +15337,7 @@ class InteractionHandler {
         );
 
         if (guilds.length === 0) {
-            await interaction.update({
+            await this._panelRespond(interaction, {
                 embeds: [new EmbedBuilder().setColor(0xFF8C00)
                     .setTitle(t('📋 Serwery bota', '📋 Bot Servers'))
                     .setDescription(t('Bot nie jest na żadnym serwerze.', 'The bot is not on any server.'))],
@@ -15356,7 +15381,7 @@ class InteractionHandler {
         }
         components.push(backRow);
 
-        await interaction.update({ embeds: [embed], components });
+        await this._panelRespond(interaction, { embeds: [embed], components });
     }
 
     /**
@@ -15383,7 +15408,7 @@ class InteractionHandler {
         const backRow = new ActionRowBuilder().addComponents(backBtn);
 
         if (servers.length === 0) {
-            await interaction.update({
+            await this._panelRespond(interaction, {
                 embeds: [new EmbedBuilder().setColor(0xFF8C00)
                     .setTitle(t('🚫 Zablokuj serwer', '🚫 Block Server'))
                     .setDescription(t('Brak serwerów do zbanowania.', 'No servers available to ban.'))],
@@ -15424,7 +15449,7 @@ class InteractionHandler {
 
         const from = safeOffset + 1;
         const to = safeOffset + page.length;
-        await interaction.update({
+        await this._panelRespond(interaction, {
             embeds: [new EmbedBuilder().setColor(0xFF0000)
                 .setTitle(t('🚫 Wybierz serwer do zbanowania', '🚫 Select Server to Ban'))
                 .setDescription(t(
@@ -15512,7 +15537,7 @@ class InteractionHandler {
         const absentGuilds = configuredIds.filter(guildId => !interaction.client.guilds.cache.has(guildId));
 
         if (absentGuilds.length === 0) {
-            await interaction.update({
+            await this._panelRespond(interaction, {
                 embeds: [new EmbedBuilder()
                     .setColor(0x57F287)
                     .setTitle(t('🗑️ Usuń dane serwera', '🗑️ Delete Server Data'))
@@ -15537,7 +15562,7 @@ class InteractionHandler {
             };
         });
 
-        await interaction.update({
+        await this._panelRespond(interaction, {
             embeds: [new EmbedBuilder()
                 .setColor(0xFF6B35)
                 .setTitle(t('🗑️ Usuń dane serwera', '🗑️ Delete Server Data'))

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -7903,6 +7903,8 @@ class InteractionHandler {
         if (customId === 'panel_ban_guild') return 'Zbanuj serwer (lista)';
         if (customId.startsWith('panel_ban_page_')) return 'Zbanuj serwer (strona listy)';
         if (customId === 'panel_guild_list' || customId.startsWith('panel_guild_list_')) return 'Pokaż serwery bota';
+        if (customId === 'cc_chal_history' || customId.startsWith('cc_chal_h')) return 'CC: Historia wyzwań';
+        if (customId === 'cc_chal_finish' || customId.startsWith('cc_chal_f')) return 'CC: Zakończ wyzwanie';
         if (customId === 'panel_unban_guild') return 'Odbanuj serwer (lista)';
         if (customId.startsWith('panel_ban_guild_ok_')) return `Zbanuj serwer (potwierdź: ${customId.replace('panel_ban_guild_ok_', '')})`;
         if (customId === 'panel_delete_server_data') return 'Usuń dane serwera (panel)';
@@ -8684,6 +8686,47 @@ class InteractionHandler {
             if (customId === 'cc_action_ocr_stats') {
                 await this._handleCcActionOcrStats(interaction);
                 return;
+            }
+            if (customId.startsWith('cc_chal_')) {
+                if (!this._isHeadAdmin(interaction.user.id)) {
+                    await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+                    return;
+                }
+                if (customId === 'cc_chal_close') {
+                    const t = this._panelT(interaction.guildId);
+                    await interaction.update({
+                        embeds: [new EmbedBuilder().setColor(0x95A5A6).setDescription(t('Zamknięto.', 'Closed.'))],
+                        components: [],
+                    });
+                    return;
+                }
+                if (customId === 'cc_chal_history') {
+                    await this._handleCcChallengeHistory(interaction);
+                    return;
+                }
+                if (customId.startsWith('cc_chal_hsp_')) {
+                    await this._handleCcChallengeHistory(interaction, parseInt(customId.replace('cc_chal_hsp_', ''), 10) || 0);
+                    return;
+                }
+                if (customId.startsWith('cc_chal_hpg_')) {
+                    // `cc_chal_hpg_{guildId}_{page}` — guildId to same cyfry, więc tniemy od OSTATNIEGO `_`
+                    const rest = customId.replace('cc_chal_hpg_', '');
+                    const cut = rest.lastIndexOf('_');
+                    await this._handleCcChallengeHistoryGuild(interaction, rest.slice(0, cut), parseInt(rest.slice(cut + 1), 10) || 0);
+                    return;
+                }
+                if (customId === 'cc_chal_finish') {
+                    await this._handleCcChallengeFinish(interaction);
+                    return;
+                }
+                if (customId.startsWith('cc_chal_fpg_')) {
+                    await this._handleCcChallengeFinish(interaction, parseInt(customId.replace('cc_chal_fpg_', ''), 10) || 0);
+                    return;
+                }
+                if (customId.startsWith('cc_chal_fok_')) {
+                    await this._handleCcChallengeFinishConfirm(interaction, customId.replace('cc_chal_fok_', ''));
+                    return;
+                }
             }
             if (customId === 'cc_srv_pg_prev' || customId === 'cc_srv_pg_next') {
                 if (!this._isHeadAdmin(interaction.user.id)) {
@@ -11211,6 +11254,15 @@ class InteractionHandler {
 
             if (customId === 'panel_ocr_guild_select') {
                 await this._handlePanelOcrGuildSelect(interaction);
+                return;
+            }
+            if (customId === 'cc_chal_hsrv' || customId === 'cc_chal_fsel') {
+                if (!this._isHeadAdmin(interaction.user.id)) {
+                    await interaction.reply({ content: this.msgs(interaction.guildId).noPermission, flags: ['Ephemeral'] });
+                    return;
+                }
+                if (customId === 'cc_chal_hsrv') await this._handleCcChallengeHistoryGuild(interaction, interaction.values[0], 0);
+                else await this._handleCcChallengeFinishSelect(interaction);
                 return;
             }
             if (customId === 'panel_ban_guild_sel') {
@@ -17187,6 +17239,326 @@ class InteractionHandler {
     // ── Sweep ─────────────────────────────────────────────────────────────────
 
     /** Uruchamiany z index.js po starcie bota */
+    // ── Centrum Dowodzenia: historia i ręczne zamykanie wyzwań ────────────────
+
+    /** Nazwa uczestnika w języku serwera, z etykietą usuniętego profilu */
+    _ccChalName(participant, msgs) {
+        return this.challengeService?.participantName(participant, msgs) ?? (participant?.username || '—');
+    }
+
+    /** Serwery, których dotyczy dane wyzwanie — cross-server pojedynek należy do OBU */
+    _ccChalGuildIds(challenge) {
+        return [...new Set(['challenger', 'opponent']
+            .map(side => challenge[side]?.guildId)
+            .filter(Boolean))];
+    }
+
+    /**
+     * Historia wyzwań z podziałem na serwery — krok 1: wybór serwera.
+     *
+     * Wyzwanie między graczami z dwóch serwerów liczy się do OBU list: head admin patrzy
+     * na historię pytaniem „co się działo u nich", a taki pojedynek działł się u jednych
+     * i u drugich.
+     */
+    async _handleCcChallengeHistory(interaction, offset = 0) {
+        const t = this._panelT(interaction.guildId);
+        const msgs = this.msgs(interaction.guildId);
+        const PAGE_SIZE = 25;
+
+        const closed = await this.challengeService.getClosed();
+        const perGuild = new Map();
+        for (const ch of closed) {
+            for (const guildId of this._ccChalGuildIds(ch)) {
+                if (!perGuild.has(guildId)) perGuild.set(guildId, []);
+                perGuild.get(guildId).push(ch);
+            }
+        }
+
+        const backRow = new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId('cc_chal_close').setEmoji('✖️').setLabel(t('Zamknij', 'Close')).setStyle(ButtonStyle.Secondary),
+        );
+
+        if (perGuild.size === 0) {
+            await this._panelRespond(interaction, {
+                embeds: [new EmbedBuilder().setColor(0xE67E22)
+                    .setTitle(t('📜 Historia wyzwań', '📜 Challenge History'))
+                    .setDescription(t('Żadne wyzwanie nie zostało jeszcze rozstrzygnięte.', 'No challenge has been resolved yet.'))],
+                components: [backRow],
+            });
+            return;
+        }
+
+        const servers = [...perGuild.entries()]
+            .map(([id, list]) => ({ id, label: this._challengeGuildName(interaction.client, id), count: list.length }))
+            .sort((a, b) => this._compareSortNames(a.label, b.label));
+
+        const safeOffset = Math.min(Math.max(0, offset), Math.max(0, (Math.ceil(servers.length / PAGE_SIZE) - 1) * PAGE_SIZE));
+        const page = servers.slice(safeOffset, safeOffset + PAGE_SIZE);
+
+        const selectRow = new ActionRowBuilder().addComponents(
+            new StringSelectMenuBuilder().setCustomId('cc_chal_hsrv')
+                .setPlaceholder(t('Wybierz serwer...', 'Select a server...'))
+                .addOptions(page.map(srv => ({
+                    label: srv.label.substring(0, 100),
+                    description: t(`${srv.count} rozstrzygniętych`, `${srv.count} resolved`).substring(0, 100),
+                    value: srv.id,
+                })))
+        );
+
+        // Rząd nawigacji zabiera jeden z pięciu slotów, więc zakresom zostają trzy
+        const rangeRows = servers.length > PAGE_SIZE
+            ? this._buildRangeButtons(servers, safeOffset, 'cc_chal_hsp_', 3)
+            : [];
+
+        await this._panelRespond(interaction, {
+            embeds: [new EmbedBuilder().setColor(0xE67E22)
+                .setTitle(t('📜 Historia wyzwań', '📜 Challenge History'))
+                .setDescription(t(
+                    `Rozstrzygniętych wyzwań: **${closed.length}** na **${servers.length}** serwerach.\nWybierz serwer:`,
+                    `Resolved challenges: **${closed.length}** across **${servers.length}** server(s).\nSelect a server:`
+                ))],
+            components: [...rangeRows, selectRow, backRow],
+        });
+    }
+
+    /** Historia wyzwań jednego serwera (8/stronę) */
+    async _handleCcChallengeHistoryGuild(interaction, guildId, page = 0) {
+        const t = this._panelT(interaction.guildId);
+        const msgs = this.msgs(interaction.guildId);
+        const PER_PAGE = 8;
+
+        const list = (await this.challengeService.getClosed())
+            .filter(ch => this._ccChalGuildIds(ch).includes(guildId));
+
+        const nazwaSerwera = this._challengeGuildName(interaction.client, guildId);
+        const backRow = new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId('cc_chal_history').setEmoji('◀️').setLabel(t('Lista serwerów', 'Server list')).setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('cc_chal_close').setEmoji('✖️').setLabel(t('Zamknij', 'Close')).setStyle(ButtonStyle.Secondary),
+        );
+
+        if (list.length === 0) {
+            await this._panelRespond(interaction, {
+                embeds: [new EmbedBuilder().setColor(0xE67E22)
+                    .setTitle(t(`📜 Historia — ${nazwaSerwera}`, `📜 History — ${nazwaSerwera}`).substring(0, 256))
+                    .setDescription(t('Brak rozstrzygniętych wyzwań.', 'No resolved challenges.'))],
+                components: [backRow],
+            });
+            return;
+        }
+
+        const maxPage = Math.ceil(list.length / PER_PAGE) - 1;
+        const safePage = Math.min(Math.max(0, page), maxPage);
+        const total = this.challengeService.scoresPerSide;
+
+        const opisStatusu = (ch) => {
+            if (ch.status === 'finished') {
+                if (!ch.winner) return t('🤝 remis', '🤝 draw');
+                return `🏆 **${this._ccChalName(ch[ch.winner], msgs)}**`;
+            }
+            return {
+                unresolved: t('❓ nierozstrzygnięte', '❓ unresolved'),
+                declined: t('🚫 odrzucone', '🚫 declined'),
+                expired: t('⌛ zaproszenie wygasło', '⌛ invite expired'),
+                cancelled: t('🗑️ anulowane', '🗑️ cancelled'),
+            }[ch.status] || ch.status;
+        };
+
+        const linie = list.slice(safePage * PER_PAGE, safePage * PER_PAGE + PER_PAGE).map((ch, idx) => {
+            const nr = safePage * PER_PAGE + idx + 1;
+            const kiedy = Date.parse(ch.finishedAt || 0);
+            const data = Number.isFinite(kiedy) ? ` · <t:${Math.floor(kiedy / 1000)}:d>` : '';
+            const obcy = this._ccChalGuildIds(ch).filter(id => id !== guildId);
+            const zInnego = obcy.length > 0 ? ` · 🔀 ${this._challengeGuildName(interaction.client, obcy[0])}` : '';
+            const wyniki = ch.status === 'finished' || ch.status === 'unresolved'
+                ? ` (${ch.challenger.scores?.length || 0}/${total} : ${ch.opponent.scores?.length || 0}/${total})`
+                : '';
+            return `**${nr}.** ${this._ccChalName(ch.challenger, msgs)} vs ${this._ccChalName(ch.opponent, msgs)}${wyniki}\n`
+                + `└ ${ch.boss || '—'} · ${opisStatusu(ch)}${data}${zInnego}`;
+        });
+
+        const components = [];
+        if (maxPage > 0) {
+            components.push(new ActionRowBuilder().addComponents(
+                new ButtonBuilder().setCustomId(`cc_chal_hpg_${guildId}_${safePage - 1}`).setEmoji('◀️')
+                    .setLabel(t('Poprzednia', 'Previous')).setStyle(ButtonStyle.Primary).setDisabled(safePage === 0),
+                new ButtonBuilder().setCustomId(`cc_chal_hpg_${guildId}_${safePage + 1}`).setEmoji('▶️')
+                    .setLabel(t('Następna', 'Next')).setStyle(ButtonStyle.Primary).setDisabled(safePage === maxPage),
+            ));
+        }
+        components.push(backRow);
+
+        await this._panelRespond(interaction, {
+            embeds: [new EmbedBuilder().setColor(0xE67E22)
+                .setTitle(`📜 ${nazwaSerwera}`.substring(0, 256))
+                .setDescription(t(`Rozstrzygniętych wyzwań: **${list.length}**\n\n`, `Resolved challenges: **${list.length}**\n\n`) + linie.join('\n'))
+                .setFooter({ text: t(`Strona ${safePage + 1}/${maxPage + 1}`, `Page ${safePage + 1}/${maxPage + 1}`) })],
+            components,
+        });
+    }
+
+    /** Ręczne zamknięcie wyzwania — krok 1: lista wyzwań w toku (25/stronę) */
+    async _handleCcChallengeFinish(interaction, offset = 0) {
+        const t = this._panelT(interaction.guildId);
+        const msgs = this.msgs(interaction.guildId);
+        const PAGE_SIZE = 25;
+
+        const active = await this.challengeService.getActive();
+        const backRow = new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId('cc_chal_close').setEmoji('✖️').setLabel(t('Zamknij', 'Close')).setStyle(ButtonStyle.Secondary),
+        );
+
+        if (active.length === 0) {
+            await this._panelRespond(interaction, {
+                embeds: [new EmbedBuilder().setColor(0x57F287)
+                    .setTitle(t('🏁 Zakończ wyzwanie', '🏁 End Challenge'))
+                    .setDescription(t('Żadne wyzwanie nie jest w toku.', 'No challenge is in progress.'))],
+                components: [backRow],
+            });
+            return;
+        }
+
+        const total = this.challengeService.scoresPerSide;
+        const safeOffset = Math.min(Math.max(0, offset), Math.max(0, (Math.ceil(active.length / PAGE_SIZE) - 1) * PAGE_SIZE));
+        const page = active.slice(safeOffset, safeOffset + PAGE_SIZE);
+
+        const selectRow = new ActionRowBuilder().addComponents(
+            new StringSelectMenuBuilder().setCustomId('cc_chal_fsel')
+                .setPlaceholder(t('Wybierz wyzwanie...', 'Select a challenge...'))
+                .addOptions(page.map(ch => ({
+                    label: `${this._ccChalName(ch.challenger, msgs)} vs ${this._ccChalName(ch.opponent, msgs)}`.substring(0, 100),
+                    description: `${ch.boss || '—'} · ${ch.challenger.scores?.length || 0}/${total} : ${ch.opponent.scores?.length || 0}/${total}`.substring(0, 100),
+                    value: ch.id,
+                })))
+        );
+
+        // Etykiety zakresów liczone z nicku wyzywającego — lista jest posortowana po terminie,
+        // więc zakresy alfabetyczne wprowadzałyby w błąd; przy dłuższej liście zostają same strony
+        const navRow = new ActionRowBuilder();
+        if (active.length > PAGE_SIZE) {
+            navRow.addComponents(
+                new ButtonBuilder().setCustomId(`cc_chal_fpg_${safeOffset - PAGE_SIZE}`).setEmoji('◀️')
+                    .setLabel(t('Poprzednia', 'Previous')).setStyle(ButtonStyle.Primary).setDisabled(safeOffset === 0),
+                new ButtonBuilder().setCustomId(`cc_chal_fpg_${safeOffset + PAGE_SIZE}`).setEmoji('▶️')
+                    .setLabel(t('Następna', 'Next')).setStyle(ButtonStyle.Primary).setDisabled(safeOffset + PAGE_SIZE >= active.length),
+            );
+        }
+        navRow.addComponents(
+            new ButtonBuilder().setCustomId('cc_chal_close').setEmoji('✖️').setLabel(t('Zamknij', 'Close')).setStyle(ButtonStyle.Secondary),
+        );
+
+        await this._panelRespond(interaction, {
+            embeds: [new EmbedBuilder().setColor(0xE67E22)
+                .setTitle(t('🏁 Zakończ wyzwanie', '🏁 End Challenge'))
+                .setDescription(t(
+                    `W toku: **${active.length}**. Wybierz wyzwanie, które ma zostać zamknięte teraz:`,
+                    `In progress: **${active.length}**. Select the challenge to close now:`
+                ))
+                .setFooter({ text: t(
+                    `Pozycje ${safeOffset + 1}-${safeOffset + page.length} z ${active.length} · lista wg terminu`,
+                    `Entries ${safeOffset + 1}-${safeOffset + page.length} of ${active.length} · sorted by deadline`
+                ) })],
+            components: [selectRow, navRow],
+        });
+    }
+
+    /** Ręczne zamknięcie wyzwania — krok 2: potwierdzenie */
+    async _handleCcChallengeFinishSelect(interaction) {
+        const t = this._panelT(interaction.guildId);
+        const msgs = this.msgs(interaction.guildId);
+        const id = interaction.values[0];
+        const ch = await this.challengeService.getById(id);
+
+        if (!ch || ch.status !== 'active') {
+            await this._panelRespond(interaction, {
+                embeds: [new EmbedBuilder().setColor(0xFF8C00)
+                    .setDescription(t('To wyzwanie nie jest już w toku.', 'That challenge is no longer in progress.'))],
+                components: [new ActionRowBuilder().addComponents(
+                    new ButtonBuilder().setCustomId('cc_chal_finish').setEmoji('◀️').setLabel(t('Wróć', 'Back')).setStyle(ButtonStyle.Secondary),
+                )],
+            });
+            return;
+        }
+
+        const total = this.challengeService.scoresPerSide;
+        const a = ch.challenger;
+        const b = ch.opponent;
+        const bezWynikow = (a.scores?.length || 0) === 0 && (b.scores?.length || 0) === 0;
+
+        const skutek = bezWynikow
+            ? t('Żadna ze stron nie wrzuciła wyniku, więc wyzwanie zostanie zamknięte jako **nierozstrzygnięte** (bez zwycięzcy i bez osiągnięć).',
+                'Neither side submitted a score, so the challenge will be closed as **unresolved** (no winner, no achievements).')
+            : t('Wyzwanie zostanie rozstrzygnięte po **aktualnych sumach** — wyższa wygrywa, równe = remis. Zwycięzca i przegrany dostaną osiągnięcia.',
+                'The challenge will be decided by the **current totals** — higher wins, equal = draw. Winner and loser get their achievements.');
+
+        await this._panelRespond(interaction, {
+            embeds: [new EmbedBuilder().setColor(0xFF6B35)
+                .setTitle(t('⚠️ Potwierdź zamknięcie wyzwania', '⚠️ Confirm Closing the Challenge'))
+                .setDescription(`**${this._ccChalName(a, msgs)}** vs **${this._ccChalName(b, msgs)}** — ${ch.boss || '—'}\n\n${skutek}`)
+                .addFields(
+                    { name: this._ccChalName(a, msgs).substring(0, 256), value: `${a.scores?.length || 0}/${total} · ${a.sum ? this.rankingService.formatScore(a.sum) : '—'}`, inline: true },
+                    { name: this._ccChalName(b, msgs).substring(0, 256), value: `${b.scores?.length || 0}/${total} · ${b.sum ? this.rankingService.formatScore(b.sum) : '—'}`, inline: true },
+                )],
+            components: [new ActionRowBuilder().addComponents(
+                new ButtonBuilder().setCustomId(`cc_chal_fok_${ch.id}`).setEmoji('✅').setLabel(t('Tak, zakończ', 'Yes, end it')).setStyle(ButtonStyle.Danger),
+                new ButtonBuilder().setCustomId('cc_chal_finish').setEmoji('❌').setLabel(t('Anuluj', 'Cancel')).setStyle(ButtonStyle.Secondary),
+            )],
+        });
+    }
+
+    /** Ręczne zamknięcie wyzwania — krok 3: wykonanie + powiadomienia */
+    async _handleCcChallengeFinishConfirm(interaction, id) {
+        const t = this._panelT(interaction.guildId);
+        const msgs = this.msgs(interaction.guildId);
+        const adminName = interaction.member?.displayName || interaction.user.displayName || interaction.user.username;
+
+        const wynik = await this.challengeService.forceFinish(id, adminName);
+        if (!wynik) {
+            await this._panelRespond(interaction, {
+                embeds: [new EmbedBuilder().setColor(0xFF8C00)
+                    .setDescription(t('To wyzwanie nie jest już w toku.', 'That challenge is no longer in progress.'))],
+                components: [new ActionRowBuilder().addComponents(
+                    new ButtonBuilder().setCustomId('cc_chal_finish').setEmoji('◀️').setLabel(t('Wróć', 'Back')).setStyle(ButtonStyle.Secondary),
+                )],
+            });
+            return;
+        }
+
+        const { challenge, outcome } = wynik;
+        // Powiadomienia idą tą samą drogą co przy naturalnym końcu: rozstrzygnięte dostaje
+        // osiągnięcia i przycisk „pochwal się", nierozstrzygnięte — komunikat jak po 72 h
+        try {
+            if (outcome === 'finished') {
+                await this._finishChallenges(interaction.client, [challenge]);
+            } else {
+                await this._handleChallengeSweep(interaction.client, { expiredInvites: [], unresolved: [challenge], stalePending: [] });
+            }
+        } catch (err) {
+            logger.error(`Błąd powiadomień po ręcznym zamknięciu wyzwania ${id}: ${err.message}`);
+        }
+
+        const a = this._ccChalName(challenge.challenger, msgs);
+        const b = this._ccChalName(challenge.opponent, msgs);
+        const werdykt = outcome === 'unresolved'
+            ? t('❓ nierozstrzygnięte', '❓ unresolved')
+            : (challenge.winner ? `🏆 **${this._ccChalName(challenge[challenge.winner], msgs)}**` : t('🤝 remis', '🤝 draw'));
+
+        this.logService._gl(challenge.challenger.guildId).warn(
+            `${this.logService.nickLink(adminName, interaction.user.id)} Ręcznie zamknął wyzwanie "${challenge.challenger.username}" vs "${challenge.opponent.username}" (${challenge.boss})`
+        );
+        this._ccAudit(interaction, `🏁 Zamknięto wyzwanie: ${a} vs ${b}`);
+        this.adminPanelService?.refresh();
+
+        await this._panelRespond(interaction, {
+            embeds: [new EmbedBuilder().setColor(0x57F287)
+                .setTitle(t('✅ Wyzwanie zamknięte', '✅ Challenge Closed'))
+                .setDescription(`**${a}** vs **${b}** — ${challenge.boss || '—'}\n${werdykt}`)],
+            components: [new ActionRowBuilder().addComponents(
+                new ButtonBuilder().setCustomId('cc_chal_finish').setEmoji('🏁').setLabel(t('Zamknij kolejne', 'Close another')).setStyle(ButtonStyle.Secondary),
+                new ButtonBuilder().setCustomId('cc_chal_close').setEmoji('✖️').setLabel(t('Zamknij', 'Close')).setStyle(ButtonStyle.Secondary),
+            )],
+        });
+    }
+
     startChallengeSweep(client) {
         if (!this.challengeService) return;
         this.challengeService.start(async (events) => {

--- a/EndersEcho/index.js
+++ b/EndersEcho/index.js
@@ -170,6 +170,7 @@ const adminPanelService = new AdminPanelService(config.ranking.dataDir, config, 
     profileRegistryService,
     webRankingSyncService,
     playerOfTheDayService,
+    challengeService,
 });
 // Globalne liczniki zapytań API AI (requests/rejected/fullFailures) — zapisywane przez OcrStatsService
 aiOcrService.setStatsService(ocrStatsService);

--- a/EndersEcho/services/adminPanelService.js
+++ b/EndersEcho/services/adminPanelService.js
@@ -176,6 +176,19 @@ class AdminPanelService {
         return this._messageIds.system || null;
     }
 
+    /**
+     * Czy dana wiadomość jest jedną z sekcji Centrum Dowodzenia.
+     *
+     * Panel to STAŁE, publiczne wiadomości na kanale head admina — handler przycisku musi
+     * wiedzieć, że został kliknięty właśnie tam, żeby odpowiedzieć efemerycznie zamiast
+     * `interaction.update()`. Update nadpisałby sekcję panelu widokiem dla jednej osoby
+     * (do najbliższego `refresh()`, więc bez śladu, że coś zniknęło).
+     */
+    isPanelMessage(messageId) {
+        if (!messageId) return false;
+        return Object.values(this._messageIds || {}).includes(messageId);
+    }
+
     async setupChannel(channelId) {
         this._channelId = channelId;
         this._messageIds = {};

--- a/EndersEcho/services/adminPanelService.js
+++ b/EndersEcho/services/adminPanelService.js
@@ -52,10 +52,28 @@ function capField(value, max = 1024) {
     return str.slice(0, max - 2) + '…';
 }
 
+// Jak capField, ale tnie CAŁYMI liniami i dopisuje, ilu pozycji nie widać.
+// capField ucina w połowie wiersza — przy listach wyzwań dawałoby to urwany nick bez wyniku.
+function capLines(lines, max = 1024, more = (n) => `\n… i ${n} więcej`) {
+    if (lines.length === 0) return '—';
+    const out = [];
+    let len = 0;
+    for (let i = 0; i < lines.length; i++) {
+        const add = (out.length ? 1 : 0) + lines[i].length;
+        // Zostawiamy zapas na dopisek o pominiętych pozycjach
+        if (len + add > max - 24 && out.length > 0) {
+            return out.join('\n') + more(lines.length - out.length);
+        }
+        out.push(lines[i]);
+        len += add;
+    }
+    return out.join('\n');
+}
+
 const MONTH_NAMES_PL = ['Sty', 'Lut', 'Mar', 'Kwi', 'Maj', 'Cze', 'Lip', 'Sie', 'Wrz', 'Paź', 'Lis', 'Gru'];
 
 // Klucze sekcji — kolejność = kolejność wiadomości na kanale
-const SECTION_KEYS = ['system', 'users', 'servers', 'bosses', 'stats', 'costs', 'tools'];
+const SECTION_KEYS = ['system', 'users', 'servers', 'bosses', 'challenges', 'stats', 'costs', 'tools'];
 
 /**
  * Centrum Dowodzenia Head Admina.
@@ -358,7 +376,10 @@ class AdminPanelService {
         // Zapamiętaj dzisiejszy koszt do alertu kosztowego
         this._lastTodayCost = todayTokens.cost;
 
-        // Kolejność MUSI odpowiadać SECTION_KEYS: system, users, servers, bosses, stats, costs, tools
+        // Dane sekcji Wyzwania (serwis opcjonalny — embed pokazuje '—' gdy brak)
+        const challengeData = await this._getChallengeData();
+
+        // Kolejność MUSI odpowiadać SECTION_KEYS: system, users, servers, bosses, challenges, stats, costs, tools
         return [
             {
                 embed: this._buildSystemEmbed(serverData.configured, lastUpdated, [...guildIds]),
@@ -375,6 +396,10 @@ class AdminPanelService {
             {
                 embed: this._buildBossesEmbed(bossData, globalRanking),
                 components: [this._buildBossesRow()],
+            },
+            {
+                embed: this._buildChallengesEmbed(challengeData),
+                components: [this._buildChallengesRow()],
             },
             {
                 embed: this._buildOcrEmbed(ocrStats, [...guildIds], globalRanking, playerActivityStats, cmdUsage),
@@ -1093,6 +1118,78 @@ class AdminPanelService {
                 { name: `⚠️ Nieznane nazwy do zmapowania (${unknownNames.length})`, value: capField(unknownValue), inline: false },
                 { name: `🖼️ Bez zdjęcia (${noImage.length})`, value: capField(noImageValue), inline: false },
             );
+    }
+
+    // ─── EMBED 5: Wyzwania ────────────────────────────────────────────────────
+
+    /** Nazwa uczestnika w panelu — panel jest polskojęzyczny, więc etykieta usuniętego profilu na sztywno */
+    _challengeName(participant) {
+        const svc = this._services.challengeService;
+        if (!svc) return participant?.username || '—';
+        return svc.participantName(participant, { challengeDeletedProfile: '🗑️ Profil usunięty' });
+    }
+
+    async _getChallengeData() {
+        const svc = this._services.challengeService;
+        if (!svc) return null;
+        try {
+            const [standings, active, closed] = await Promise.all([
+                svc.monthlyStandings(),
+                svc.getActive(),
+                svc.getClosed(),
+            ]);
+            return { standings, active, closed };
+        } catch (err) {
+            logger.warn(`Panel: nie udało się pobrać wyzwań: ${err.message}`);
+            return null;
+        }
+    }
+
+    _buildChallengesEmbed(data) {
+        const embed = new EmbedBuilder().setColor(0xE67E22).setTitle('⚔️ Wyzwania');
+        if (!data) return embed.setDescription('Brak danych o wyzwaniach.');
+
+        const { standings, active, closed } = data;
+        const [rok, mies] = String(standings.monthKey || '').split('-');
+        const etykietaMiesiaca = mies ? `${MONTH_NAMES_PL[Number(mies) - 1] || mies} ${rok}` : 'ten miesiąc';
+
+        const MEDALE = ['🥇', '🥈', '🥉'];
+        const top5 = (lista, pole) => lista.slice(0, 5).map((e, i) =>
+            `${MEDALE[i] || `\`${i + 1}.\``} **${this._challengeName(e)}** — ${e[pole]}`);
+
+        const wTokuLinie = active.map(ch => {
+            const termin = Date.parse(ch.expiresAt || 0);
+            const kiedy = Number.isFinite(termin) ? ` · <t:${Math.floor(termin / 1000)}:R>` : '';
+            const total = this._services.challengeService?.scoresPerSide ?? 3;
+            return `• **${this._challengeName(ch.challenger)}** ${ch.challenger.scores?.length || 0}/${total}`
+                + ` vs ${ch.opponent.scores?.length || 0}/${total} **${this._challengeName(ch.opponent)}**`
+                + ` — ${ch.boss || '—'}${kiedy}`;
+        });
+
+        const ZNACZNIK = { finished: '🏁', unresolved: '❓', declined: '🚫', expired: '⌛', cancelled: '🗑️' };
+        const historiaLinie = closed.slice(0, 10).map(ch => {
+            const a = this._challengeName(ch.challenger);
+            const b = this._challengeName(ch.opponent);
+            let wynik;
+            if (ch.status !== 'finished') wynik = { unresolved: 'nierozstrzygnięte', declined: 'odrzucone', expired: 'zaproszenie wygasło', cancelled: 'anulowane' }[ch.status] || ch.status;
+            else if (!ch.winner) wynik = '🤝 remis';
+            else wynik = `🏆 **${this._challengeName(ch[ch.winner])}**`;
+            return `${ZNACZNIK[ch.status] || '•'} ${a} vs ${b} — ${ch.boss || '—'} · ${wynik}`;
+        });
+
+        return embed.addFields(
+            { name: `🏆 TOP 5 zwycięzców (${etykietaMiesiaca})`, value: capLines(top5(standings.winners, 'wins'), 1024), inline: true },
+            { name: `💔 TOP 5 przegranych (${etykietaMiesiaca})`, value: capLines(top5(standings.losers, 'losses'), 1024), inline: true },
+            { name: `⚔️ W toku (${active.length})`, value: capLines(wTokuLinie), inline: false },
+            { name: `📜 Ostatnie rozstrzygnięte (${closed.length})`, value: capLines(historiaLinie, 1024, () => ''), inline: false },
+        );
+    }
+
+    _buildChallengesRow() {
+        return new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId('cc_chal_history').setEmoji('📜').setLabel('Historia').setStyle(ButtonStyle.Secondary),
+            new ButtonBuilder().setCustomId('cc_chal_finish').setEmoji('🏁').setLabel('Zakończ wyzwanie').setStyle(ButtonStyle.Danger),
+        );
     }
 
     _buildBossesRow() {

--- a/EndersEcho/services/challengeService.js
+++ b/EndersEcho/services/challengeService.js
@@ -29,6 +29,8 @@ const MAX_ACTIVE_PER_PLAYER = 1;
 const CLOSED_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000;
 
 const SIDES = ['challenger', 'opponent'];
+/** Statusy, po których wyzwanie już się nie toczy — historia w Centrum Dowodzenia */
+const CLOSED_STATUSES = new Set(['finished', 'unresolved', 'declined', 'expired', 'cancelled']);
 
 /**
  * System wyzwań 1 vs 1 (`/challenge`).
@@ -135,6 +137,111 @@ class ChallengeService {
     async getById(id) {
         const data = await this._data();
         return data.challenges[id] || null;
+    }
+
+    // ─── Widok globalny (Centrum Dowodzenia) ──────────────────────────────────
+
+    /** Wszystkie wyzwania, od najnowszych */
+    async getAll() {
+        const data = await this._data();
+        return Object.values(data.challenges)
+            .sort((a, b) => Date.parse(b.createdAt || 0) - Date.parse(a.createdAt || 0));
+    }
+
+    /** Wyzwania w toku — od najbliższego terminu, bo to one wymagają uwagi admina */
+    async getActive() {
+        return (await this.getAll())
+            .filter(c => c.status === 'active')
+            .sort((a, b) => Date.parse(a.expiresAt || 0) - Date.parse(b.expiresAt || 0));
+    }
+
+    /** Wyzwania zamknięte (dowolnym wynikiem), od ostatnio zamkniętego */
+    async getClosed() {
+        return (await this.getAll())
+            .filter(c => CLOSED_STATUSES.has(c.status))
+            .sort((a, b) => Date.parse(b.finishedAt || 0) - Date.parse(a.finishedAt || 0));
+    }
+
+    /**
+     * Bilans wygranych i przegranych w danym miesiącu.
+     *
+     * Miesiąc liczony po **czasie warszawskim**, nie UTC — panel pokazuje daty w tej strefie,
+     * więc wyzwanie zamknięte 1. dnia miesiąca o 00:30 czasu lokalnego musi trafić do nowego
+     * miesiąca, a nie do poprzedniego. `sv-SE` daje format `RRRR-MM-DD`, z którego bierzemy
+     * pierwsze 7 znaków — bez własnej arytmetyki na przesunięciach CET/CEST.
+     *
+     * Remisy i wyzwania nierozstrzygnięte nie liczą się żadnej ze stron.
+     */
+    async monthlyStandings(refDate = new Date()) {
+        const monthKey = ChallengeService.warsawMonth(refDate);
+        const stats = new Map();
+
+        const bump = (participant, field) => {
+            if (!participant?.playerKey) return;
+            const entry = stats.get(participant.playerKey) || {
+                playerKey: participant.playerKey,
+                username: participant.username,
+                guildId: participant.guildId,
+                profileDeleted: participant.profileDeleted === true,
+                profileIndex: participant.profileIndex,
+                wins: 0,
+                losses: 0,
+            };
+            entry[field] += 1;
+            // Nazwa z najnowszego wyzwania wygrywa — `getAll` daje je od najnowszych
+            stats.set(participant.playerKey, entry);
+        };
+
+        for (const ch of await this.getAll()) {
+            if (ch.status !== 'finished' || !ch.winner) continue;
+            if (ChallengeService.warsawMonth(ch.finishedAt) !== monthKey) continue;
+            bump(ch[ch.winner], 'wins');
+            bump(ch[this.otherSide(ch.winner)], 'losses');
+        }
+
+        const all = [...stats.values()];
+        const rank = (field) => all
+            .filter(e => e[field] > 0)
+            .sort((a, b) => b[field] - a[field] || String(a.username || '').localeCompare(String(b.username || ''), 'pl'));
+
+        return { monthKey, winners: rank('wins'), losers: rank('losses') };
+    }
+
+    /** Klucz miesiąca (`RRRR-MM`) w strefie Europe/Warsaw */
+    static warsawMonth(date) {
+        const d = date instanceof Date ? date : new Date(date || 0);
+        if (Number.isNaN(d.getTime())) return '';
+        return d.toLocaleDateString('sv-SE', { timeZone: 'Europe/Warsaw' }).slice(0, 7);
+    }
+
+    /**
+     * Ręczne zamknięcie wyzwania przez admina.
+     *
+     * Rozstrzygamy po AKTUALNYCH sumach, tak samo jak przy komplecie wyników — kto ma więcej,
+     * ten wygrywa, równo = remis. Wyjątkiem jest wyzwanie, w którym **nikt** nie wrzucił jeszcze
+     * wyniku: „remis 0:0" byłby kłamstwem i przyznawał osiągnięcia za coś, czego nie było,
+     * więc takie zamykamy jako `unresolved` — tym samym statusem, co wygaśnięcie po 72 h.
+     *
+     * @returns {Promise<{challenge: object, outcome: 'finished'|'unresolved'}|null>} null gdy nie ma czego zamykać
+     */
+    async forceFinish(id, adminName) {
+        let result = null;
+        await this._mutate(draft => {
+            const ch = draft.challenges[id];
+            if (!ch || ch.status !== 'active') return;
+
+            const anyScore = SIDES.some(side => (ch[side]?.scores?.length || 0) > 0);
+            if (anyScore) {
+                this._finalize(ch);
+            } else {
+                ch.status = 'unresolved';
+                ch.finishedAt = new Date().toISOString();
+                ch.winner = null;
+            }
+            ch.finishedBy = adminName || null;
+            result = { challenge: ch, outcome: ch.status };
+        });
+        return result;
     }
 
     /** Wszystkie wyzwania profilu (dowolny status), od najnowszych */


### PR DESCRIPTION
Dwa commity dotyczące Centrum Dowodzenia.

---

# 1. Przyciski panelu odpowiadają efemerycznie zamiast nadpisywać panel

## Problem

Sekcje Centrum Dowodzenia to **stałe, publiczne wiadomości** na kanale head admina, współdzielone przez wszystkich adminów. Cztery przyciski odpowiadały przez `interaction.update()`, czyli **nadpisywały sekcję panelu** prywatnym widokiem jednej osoby — do najbliższego `refresh()` reszta oglądała cudzy ekran zamiast statystyk.

Dotyczyło: `panel_ocr`, `panel_ban_guild`, `panel_guild_list`, `panel_delete_server_data`. Pozostałe przyciski panelu już wcześniej odpowiadały przez `reply`/`deferReply` z flagą `Ephemeral` albo otwierały modal.

## Rozwiązanie

- `adminPanelService.isPanelMessage(messageId)` — czy wiadomość jest jedną z sekcji panelu (porównanie z `_messageIds`)
- `_isCcInteraction(interaction)` + **`_panelRespond(interaction, payload)`** — w Centrum Dowodzenia `reply({ flags: ['Ephemeral'] })`, w efemerycznym panelu `/manage` `interaction.update()`

Rozstrzyga **pochodzenie wiadomości, nie customId** — te same handlery obsługują oba wejścia. Dalsze kroki flow (select menu, potwierdzenia, przyciski stron) klikane są już w wiadomości efemerycznej, więc `interaction.update()` jest w nich poprawne i zostaje nietknięte.

**Wyjątek zostawiony świadomie:** `cc_srv_pg_prev` / `cc_srv_pg_next` (paginacja sekcji Serwery) nadal działa na panelu — `deferUpdate()` + `changeServersPage()` + `refresh()`. Jej sensem jest przewinięcie wspólnej wiadomości, więc odpowiedź efemeryczna czyniłaby ją bezużyteczną.

---

# 2. Nowa sekcja panelu: ⚔️ Wyzwania

Wstawiona po sekcji Bossowie (`SECTION_KEYS`: `… bosses, challenges, stats …`), więc panel ma teraz 8 wiadomości zamiast 7.

- **🏆 TOP 5 zwycięzców** i **💔 TOP 5 przegranych** bieżącego miesiąca
- **⚔️ W toku** — wszystkie trwające, `2/3 : 1/3` + termin `<t:…:R>`
- **📜 Ostatnie rozstrzygnięte** — 10 ostatnich z werdyktem

Miesiąc liczony po **czasie warszawskim**, nie UTC — panel pokazuje daty w tej strefie, więc wyzwanie zamknięte 1. dnia miesiąca o 00:30 czasu lokalnego musi trafić do nowego miesiąca. Remisy i wyzwania nierozstrzygnięte nie liczą się żadnej ze stron.

## 📜 Historia — pełny widok z podziałem na serwery

Dwa kroki, oba efemeryczne: lista serwerów z licznikiem wyzwań (25/stronę + przyciski zakresów liter, ta sama normalizacja co `/challenge`) → historia jednego serwera po 8 na stronę: pary graczy, boss, wynik, werdykt, data, a przy pojedynku międzyserwerowym `🔀 nazwa drugiego serwera`.

**Pojedynek dwóch serwerów liczy się do OBU list** — head admin patrzy na historię pytaniem „co się działo u nich", a taki pojedynek działł się u jednych i u drugich; przypisanie go tylko jednej stronie ukrywałoby go przed drugą.

## 🏁 Zakończ wyzwanie

Lista wyzwań w toku (25/stronę z paginacją) → potwierdzenie → zamknięcie. Kolejność **wg terminu**, nie alfabetyczna — stąd zwykłe `◀️/▶️` zamiast zakresów liter, które przy takim sortowaniu wprowadzałyby w błąd.

`forceFinish(id, adminName)` rozstrzyga po **aktualnych sumach**, tak samo jak komplet wyników: wyższa wygrywa, równe = remis, `finishedBy` zapamiętuje admina. **Wyjątek: gdy żadna ze stron nie wrzuciła wyniku** → status `unresolved`, nie `finished` — „remis 0:0" byłby kłamstwem i przyznawałby osiągnięcia za pojedynek, którego nie było. Potwierdzenie mówi wprost, który z dwóch skutków nastąpi.

Powiadomienia idą **tą samą drogą co przy naturalnym końcu**, bez własnej ścieżki: `finished` → `_finishChallenges` (osiągnięcia + DM z przyciskiem „pochwal się"), `unresolved` → `_handleChallengeSweep({ unresolved: [ch] })`. Akcja trafia do dziennika akcji i odświeża panel.

## Pozostałe zmiany

- `challengeService`: `getAll()`, `getActive()`, `getClosed()`, `monthlyStandings()`, `ChallengeService.warsawMonth()`, `forceFinish()`, stała `CLOSED_STATUSES`
- `adminPanelService`: helper **`capLines`** — jak `capField`, ale tnie całymi liniami i dopisuje, ilu pozycji nie widać (`capField` ucinał w połowie wiersza, dając urwany nick bez wyniku)
- `challengeService` dopięty do serwisów panelu w `index.js`
- Wszystkie nowe widoki przechodzą przez `_panelRespond` z punktu 1; teksty dwujęzyczne przez `_panelT`

---

## Weryfikacja

**Punkt 1:**
- audyt wszystkich 31 `customId` renderowanych przez `adminPanelService` → pierwsza odpowiedź każdego handlera; po zmianie **żaden nie odpowiada przez `update`**
- ten sam audyt dla handlerów submitów modalowych osiągalnych z panelu — wszystkie ephemeral (jedyne `update` jest w `cfg_tag_modal`, spoza panelu)
- `isPanelMessage`: sekcja panelu / obca wiadomość / `undefined` / brak `_messageIds`
- `_panelRespond` w obu kontekstach: wiadomość panelu → `reply` z `['Ephemeral']`, wiadomość efemeryczna → `update`

**Punkt 2:**
- miesięczny bilans: remis nie liczy się nikomu, poprzedni miesiąc odfiltrowany, wyzwanie z 1.08 00:30 czasu PL wpada do sierpnia mimo lipcowego UTC
- kolejność `getActive`/`getClosed`; `forceFinish` w czterech wariantach (z wynikami → `finished`, bez wyników → `unresolved`, powtórne wywołanie → `null`, nieistniejące id → `null`) + potwierdzenie stanu zapisanego na dysku
- embed panelu i wszystkie cztery widoki wyrenderowane dla 0 / 1 / 3 / 40 wyzwań i 0–60 serwerów, ze sprawdzeniem limitów Discorda (≤5 rzędów, ≤5 komponentów w rzędzie, ≤25 opcji selecta, ≤100 znaków etykiety opcji i customId, ≤80 etykiety przycisku, ≤256 tytułu i nazwy pola, ≤1024 wartości pola, ≤4096 opisu, ≤6000 całego embeda) oraz stron spoza zakresu

`node --check` na wszystkich zmienionych plikach. Bot nie był uruchamiany (brak `node_modules` w sesji) — wygląd w Discordzie niezweryfikowany na żywo.

## Dokumentacja

`EndersEcho/CLAUDE.md`: reguła „każdy przycisk panelu odpowiada efemerycznie" wraz z mechanizmem `_panelRespond` i uzasadnieniem wyjątku paginacji; nowy wiersz tabeli embedów + przenumerowanie kolejnych; „7 wiadomości" → 8; sekcja opisująca oba widoki wyzwań i `forceFinish`; lista `customId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9TQHRKc9tG29q2UimiVPN