### PR TITLE
Osobny embed wyzwania z generowaną ikoną postępu 1/3, 2/3, 3/3

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -221,7 +221,8 @@
        - **Opis nadpisany** (`specialDescription`, pierwsze dopasowanie wygrywa): `manualVerificationNote` (panel „Analizuj") > `crossServerScoreRemovedNote` (nowy wynik ściśle lepszy niż na innym serwerze — treść = `systemInfoAllGood` + notka `crossServerScoreRemovedNotice` z nazwą starego i nowego serwera) > `crossServerMigratedNote` (dokładne wyrównanie wyniku z innego serwera — notka `crossServerMigratedNotice`, BEZ prefiksu `systemInfoAllGood`)
        - **Pola dodatkowe** (`systemNotices`, mogą wystąpić RAZEM z opisem nadpisanym): `unknownBossRankingField`/`unknownBossRankingNotice` (nowy nierozpoznany boss), `crossServerBossKeptField`/`crossServerBossKeptValue` (rekord bossa pobity mimo duplikatu globalnego — rekord globalny zostaje na poprzednim serwerze)
        - **Ikona** (author iconURL + thumbnail, 3 stany): `manualVerificationNote` obecna → `.../emojis/1297532628395622440.webp` (zweryfikowano manualnie); jakiekolwiek inne uwagi/komunikaty → `.../emojis/1522939660278435993.webp` (nowa, statyczna); brak uwag → `.../emojis/1297531523477540894.webp` (domyślna, animowana)
-     - **Załączniki** (`files`): `[screenshot, score_history.png?, bossImage?]`
+     - **Embed 5 (opcjonalny) — ⚔️ Wyzwanie:** dokładany POZA `createRecordEmbeds`, przez `_appendChallengeEmbed(embeds, files, icon)` w `interactionHandlers.js`. Pojawia się tylko wtedy, gdy wynik ruszył jakieś wyzwanie. Author + thumbnail = **generowany pierścień postępu** `1/3` / `2/3` / `3/3` (`challenge_progress.png`), opis = ten sam tekst co dawniej w polu `⚔️ Wyzwanie`. Kolor: pomarańczowy w trakcie, zielony przy komplecie, żółty gdy wynik czeka na zatwierdzenie bossa. Szczegóły w sekcji „System Wyzwań 1 vs 1"
+     - **Załączniki** (`files`): `[screenshot, score_history.png?, bossImage?, challenge_progress.png?]`
      - **Guard 6000 znaków** (`_enforceEmbedCharLimit`) — przycina opisy/pola od końca, by zmieścić się w limicie wiadomości
      - **Ścieżka tylko-rekord-bossa** (globalny ranking niezmieniony): stos bez Embedu 2 (1 + 3 + 4)
      - **DM subskrybentów** (`createDmNotifEmbeds`): **cały stos embedów**; Embed 1 przekształcony (tytuł → author „pobił rekord", pola porównania z wynikiem subskrybenta), pozostałe embedy klonowane; załączniki odtwarzane z tymi samymi nazwami
@@ -719,6 +720,7 @@
   - Duplikat cross-server bez poprawy — `reasonLabel: resultDetailsField`, `reasonText` = boss + `resultNotBeatenCrossServer`
   - Boss nierozpoznany zaakceptowany bez poprawy (żółty, `color1: 0xFEE75C`) — `reasonLabel: resultDetailsField`, `reasonText` = boss + wynik + `unknownBossAccepted`
   - Panel Analizuj — nieudana analiza AI — `reasonLabel: analyzeFailReasonField`, `reasonText` = `aiResult.error`, `color2: 0xFF0000`
+- **Embed 3 (opcjonalny) — ⚔️ Wyzwanie:** gdy wynik został zaliczony do wyzwania, `_appendChallengeEmbed` dokłada embed z pierścieniem postępu (`1/3`, `2/3`, `3/3`) w miejscu ikony URL. Patrz sekcja „System Wyzwań 1 vs 1"
 - **Nie dotyczy:** stosu 4 embedów nowego rekordu (`createRecordEmbeds`) ani turkusowego ogłoszenia „pobito rekord bossa bez globalnego" — to prawdziwe ogłoszenia rekordu, używają pełnego stosu jak dotychczas. Raport na kanale odrzuconych screenów dla admina (`_sendInvalidScreenReport`) też ma inny, niezmieniony layout (author = tag/ikona serwera, nie status).
 
 **System blokowania per-użytkownik** — `userBlockService.js` + `data/user_blocks.json`:
@@ -1319,11 +1321,19 @@ Wpięcie w `_runUpdateFlow` **tuż po ustaleniu `bestScore`/`bossName`/`userName
 - Jeden wynik zalicza się do WSZYSTKICH aktywnych wyzwań tego profilu na tym bossie
 - **⚠️ TEN SAM WYNIK NIE LICZY SIĘ DWA RAZY.** Bez tej blokady wystarczyło wrzucić ten sam screen trzy razy, żeby wypełnić wszystkie sloty jednym rezultatem — wynik nierekordowy też jest zaliczany do wyzwania, więc powtórka nie odbijała się o żadną inną blokadę (cooldown `/update` tylko ją opóźnia). Porównujemy **`scoreValue`, nie napis** — `1000B` i `1T` to ten sam wynik. Zakres celowo **per UCZESTNIK**: przeciwnik może legalnie trafić tę samą wartość. Odrzucona powtórka wraca w `registerScore().duplicates` i gracz dostaje o niej komunikat (`challengeNoticeDuplicate`) — inaczej nie wiedziałby, czemu licznik nie drgnął. Po cofnięciu wyniku ta sama wartość może wejść ponownie (wypada z tablicy, więc blokada jej nie widzi)
 
-**Gdzie widać informację:**
-Komunikat składa `_challengeNoticeValue(notices, pending, msgs, duplicates)` — zaliczone wyniki i odrzucone powtórki lecą w jednym polu. Gdy **nic** nie zostało zaliczone (sama powtórka albo wynik czekający na zatwierdzenie bossa), DM dostaje żółty kolor i tytuł `challengeDmDroppedTitle` zamiast „Wynik zaliczony".
+**Gdzie widać informację — OSOBNY EMBED z ikoną postępu:**
 
-- **Jest publiczne ogłoszenie** → pole `⚔️ Wyzwanie` dokładane do `systemNotices` → trafia do **Embeda 4 (ℹ️ Informacje systemowe)**, bez żadnych zmian w `rankingService`. Dotyczy wszystkich trzech wywołań `createRecordEmbeds` w `_runUpdateFlow` (duplikat cross-server, „tylko rekord bossa", nowy rekord)
-- **Brak rekordu ogólnego i brak rekordu bossa** (nic nie idzie publicznie) → linia w `reasonText` embeda `createNoRecordEmbeds` **oraz DM** do gracza (`_sendChallengeScoreDm`)
+`_buildChallengeEmbed(result, msgs)` składa embed z opisu `_challengeNoticeValue(notices, pending, msgs, duplicates)` (zaliczone wyniki i odrzucone powtórki w jednej treści), a `_appendChallengeEmbed(embeds, files, icon)` dokłada go **na koniec KAŻDEJ ścieżki odpowiedzi** `_runUpdateFlow`: nowy rekord, „tylko rekord bossa", duplikat cross-server, „brak rekordu" i nierozpoznany boss bez poprawy. Gdy wynik nie ruszył żadnego wyzwania, embed w ogóle nie powstaje (`null`) — tak samo w `/test` (dryRun).
+
+- **Ikona = generowany pierścień postępu** (`generateChallengeProgressIcon(count, total)` w `positionIconService.js`) — `1/3`, `2/3`, `3/3`, a dla wyniku czekającego na zatwierdzenie bossa `?`. Idzie jednocześnie w `author.iconURL` i w `thumbnail` jako `attachment://challenge_progress.png`. Pełny okrąg rysowany jest elementem `<circle>`, nie łukiem — łuk o kącie 360° degeneruje się do punktu
+- **Kolor:** pomarańczowy `0xE67E22` w trakcie · zielony `0x57F287` przy komplecie · żółty `0xFEE75C` gdy wynik czeka na admina
+- **Licznik z PIERWSZEGO wpisu** (`notices`, w razie braku `duplicates`) — przy `MAX_ACTIVE_PER_PLAYER = 1` wpis jest i tak jeden; gdyby limit wzrósł, ikona pokaże najwyżej zaawansowane wyzwanie, a treść wyliczy wszystkie
+- **Błąd generowania ikony nie gubi informacji** — embed leci wtedy bez obrazka, z samym tytułem tekstowym
+- ⚠️ **Limit 6000 znaków przeliczany PO doklejeniu** (`_appendChallengeEmbed` woła `rankingService._enforceEmbedCharLimit`). `createRecordEmbeds` przycina stos do 5800, czyli z buforem 200 — a sam opis o zaliczeniu wyniku potrafi go zjeść w całości
+- ⚠️ **Ikona zwracana jako BUFOR**, `AttachmentBuilder` budowany osobno na każdą wysyłkę (`_challengeIconFiles`) — ten sam obrazek leci w ogłoszeniu i w DM subskrybentów, a jednego `AttachmentBuilder` nie da się wysłać dwa razy
+- **Brak rekordu ogólnego i brak rekordu bossa** (nic nie idzie publicznie) → ten sam embed doklejany do `createNoRecordEmbeds` **oraz DM** do gracza (`_sendChallengeScoreDm`)
+
+**⚠️ Zastąpiło to dwa dawne miejsca:** pole `⚔️ Wyzwanie` w Embedzie 4 (`systemNotices`) i dopisek w `reasonText` embeda „brak rekordu". Metoda `_challengeSystemNotice` została usunięta — informacja jest w jednym miejscu, nie w trzech.
 
 **Avatar przeciwnika w embedach wyzwania** (`_challengeOpponentAvatar(client, entries)`) — miniatura DM-ów o zaliczeniu wyniku, doliczeniu po zatwierdzeniu bossa i o przyjęciu/odrzuceniu wyzwania. Embed ma **jeden** slot na miniaturę, a wynik może zaliczyć się do kilku wyzwań na tym samym bossie naraz — przy więcej niż jednym przeciwniku avatar jest **pomijany**, zamiast arbitralnie wybierać pierwszego z brzegu. Usunięty profil też go nie dostaje (w treści widnieje „Profil usunięty", więc czyjaś twarz obok byłaby myląca), a błąd `users.fetch` kończy się `null`, nie wywrotką.
 
@@ -1411,6 +1421,7 @@ Progi **1/3/5/10/20/50/100** dla rzuconych (`chal_sent_*`), przyjętych (`chal_a
 - Każdy zapis przez `store.mutate()` (kolejka pod jednym zamkiem) — wyniki z dwóch serwerów mogą wpaść równocześnie
 - `id` = 8–11 znaków base36, żeby `chal_share_{id}_{c}` zmieścił się w limicie 100 znaków customId
 - **Ikona bossa zwracana jako BUFOR** (`_challengeBossImage` → `{buffer, name, thumb}`), a `AttachmentBuilder` budowany osobno dla każdej wysyłki (`_challengeBossFiles`) — ten sam obrazek leci w DM do obu graczy i w ogłoszeniu na serwerze
+- **Ikona postępu tak samo** (`_buildChallengeEmbed` → `{embed, buffer, name}`, `_challengeIconFiles`) — leci w ogłoszeniu i w DM subskrybentów
 
 ### CustomIDs
 

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -1,7 +1,7 @@
 const { SlashCommandBuilder, REST, Routes, AttachmentBuilder, StringSelectMenuBuilder, StringSelectMenuOptionBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, ModalBuilder, LabelBuilder, TextInputBuilder, TextInputStyle, PermissionFlagsBits, ChannelSelectMenuBuilder, ChannelType, RoleSelectMenuBuilder, ComponentType } = require('discord.js');
 const { downloadFile, downloadBuffer, formatMessage, compareByScoreThenTimestamp, makePlayerKey, getOwnerId, getProfileIndex, formatProfileDisplayName, getProfileButtonEmoji } = require('../utils/helpers');
 const { formatCooldownTime } = require('../services/updateCooldownService');
-const { generatePositionIcon } = require('../services/positionIconService');
+const { generatePositionIcon, generateChallengeProgressIcon } = require('../services/positionIconService');
 const ProfileService = require('../services/profileService');
 const MESSAGES = require('../config/messages');
 const fs = require('fs').promises;
@@ -6698,7 +6698,11 @@ class InteractionHandler {
                 timestamp: new Date().toISOString(),
                 wasUnknownBoss: aiResult.wasUnknownBoss === true,
             });
-            const _challengeNotice = this._challengeSystemNotice(_challengeResult, msgs);
+            // Osobny embed z ikoną postępu (1/3, 2/3, 3/3) — dokładany na końcu KAŻDEJ ścieżki
+            // odpowiedzi: ogłoszenia rekordu, „tylko rekord bossa", duplikatu cross-server,
+            // „brak rekordu" i nierozpoznanego bossa. Zastąpił pole `⚔️ Wyzwanie` w Embedzie 4
+            // i dopisek w `reasonText` — informacja jest w jednym miejscu, nie w trzech
+            const _challengeIcon = await this._buildChallengeEmbed(_challengeResult, msgs);
 
             // Stan globalny przed zapisem — liczony też w /test (dryRun), żeby podgląd był identyczny jak /update (read-only)
             const prevGlobalRanking = await this.rankingService.getGlobalRanking(new Set(interaction.client.guilds.cache.keys()));
@@ -6833,8 +6837,6 @@ class InteractionHandler {
                         );
                         csSystemNotices.push({ name: msgs.unknownBossRankingField || '⚠️ Unverified Boss Name', value: noticeVal });
                     }
-                    // ⚔️ Wyzwanie — informacja o zaliczeniu wyniku (Embed 4)
-                    if (_challengeNotice) csSystemNotices.push(_challengeNotice);
 
                     const safeUserNameCs = userName.replace(/[^a-zA-Z0-9]/g, '_');
                     const imageAttachmentCs = new AttachmentBuilder(tempImagePath, { name: `rekord_${safeUserNameCs}_${Date.now()}.${fileExtension}` });
@@ -6872,6 +6874,8 @@ class InteractionHandler {
                     });
                     const csFiles = [imageAttachmentCs];
                     if (csBossImageAttachment) csFiles.push(csBossImageAttachment);
+                    // ⚔️ Wyzwanie — osobny embed z ikoną postępu, na końcu stosu
+                    this._appendChallengeEmbed(csEmbeds, csFiles, _challengeIcon);
 
                     // /test (dryRun): podgląd ephemeral, bez publicznego ogłoszenia i bez sesji cofnięcia
                     if (dryRun) {
@@ -7076,11 +7080,8 @@ class InteractionHandler {
                     }
                     noRecordReasonLines.push(formatMessage(msgs.resultDifference, { diff: diffText }));
                     // ⚔️ Wyzwanie — ani rekord ogólny, ani rekord bossa nie padł, więc nie ma
-                    // publicznego ogłoszenia; informacja idzie do embeda odpowiedzi ORAZ na priv
-                    if (_challengeNotice) {
-                        noRecordReasonLines.push('');
-                        noRecordReasonLines.push(`**${_challengeNotice.name}**`);
-                        noRecordReasonLines.push(_challengeNotice.value);
+                    // publicznego ogłoszenia; informacja idzie osobnym embedem ORAZ na priv
+                    if (_challengeIcon) {
                         this._sendChallengeScoreDm(interaction.client, userId, guildId, _challengeResult).catch(() => {});
                     }
 
@@ -7093,8 +7094,11 @@ class InteractionHandler {
                         messages: msgs,
                     });
 
+                    const noRecordFiles = [imageAttachment];
+                    this._appendChallengeEmbed(resultEmbeds, noRecordFiles, _challengeIcon);
+
                     try {
-                        await interaction.editReply({ embeds: resultEmbeds, files: [imageAttachment] });
+                        await interaction.editReply({ embeds: resultEmbeds, files: noRecordFiles });
                         gl.info('✅ Wysłano embed z wynikiem (brak rekordu)');
                     } catch (editReplyError) {
                         gl.error(`❌ Błąd podczas wysyłania embed (brak rekordu): ${editReplyError.message}`);
@@ -7134,10 +7138,7 @@ class InteractionHandler {
                     unknownBossReasonLines.push(`**${msgs.resultScore}:** ${bestScore}`);
                     unknownBossReasonLines.push(statusVal);
                     // ⚔️ Wyzwanie — brak publicznego ogłoszenia, więc informacja też na priv
-                    if (_challengeNotice) {
-                        unknownBossReasonLines.push('');
-                        unknownBossReasonLines.push(`**${_challengeNotice.name}**`);
-                        unknownBossReasonLines.push(_challengeNotice.value);
+                    if (_challengeIcon) {
                         this._sendChallengeScoreDm(interaction.client, userId, guildId, _challengeResult).catch(() => {});
                     }
                     const warnEmbeds = this.rankingService.createNoRecordEmbeds({
@@ -7151,7 +7152,9 @@ class InteractionHandler {
                     });
                     _ocrEmbedParams = { profileIndex, profileLabel, type: 'no_record', userName, userId, score: bestScore, bossName, commandName, previousScore: currentScore?.score };
                     gl.info(`⚠️ [/${commandName}] Wynik zaakceptowany z nierozpoznanym bossem (bez poprawy rekordu): "${bossName || '???'}"`);
-                    await interaction.editReply({ embeds: warnEmbeds, files: [imageAttachmentAlt] });
+                    const warnFiles = [imageAttachmentAlt];
+                    this._appendChallengeEmbed(warnEmbeds, warnFiles, _challengeIcon);
+                    await interaction.editReply({ embeds: warnEmbeds, files: warnFiles });
                     return;
                 }
 
@@ -7236,7 +7239,6 @@ class InteractionHandler {
                     bossSystemNotices.push({ name: msgs.unknownBossRankingField || 'Unverified Boss Name', value: noticeVal });
                 }
                 // ⚔️ Wyzwanie — informacja o zaliczeniu wyniku (Embed 4)
-                if (_challengeNotice) bossSystemNotices.push(_challengeNotice);
 
                 // Ikona bossa (Embed 3) — gdy boss znany
                 let bossOnlyImageAttachment = null;
@@ -7286,6 +7288,8 @@ class InteractionHandler {
 
                 const bossPublicFiles = [imageAttachmentAlt];
                 if (bossOnlyImageAttachment) bossPublicFiles.push(bossOnlyImageAttachment);
+                // ⚔️ Wyzwanie — osobny embed z ikoną postępu, na końcu stosu
+                this._appendChallengeEmbed(bossPublicEmbeds, bossPublicFiles, _challengeIcon);
 
                 gl.info(`🎯 [/${commandName}] Pobito rekord na bossie "${bossName}"${wasUnknownBoss ? ' (nieznany boss)' : ''} (rekord globalny bez zmian)`);
 
@@ -7450,8 +7454,6 @@ class InteractionHandler {
                 );
                 systemNotices.push({ name: msgs.unknownBossRankingField || 'Unverified Boss Name', value: noticeVal });
             }
-            // ⚔️ Wyzwanie — informacja o zaliczeniu wyniku (Embed 4)
-            if (_challengeNotice) systemNotices.push(_challengeNotice);
             // Poprzedni wynik na innym serwerze zostaje ukryty (nowy wynik jest ściśle lepszy) — nadpisuje opis Embedu 4
             let crossServerScoreRemovedNote = null;
             if (_prevGlobalUser && _newScoreValue > _prevGlobalUser.scoreValue && _prevGlobalUser.sourceGuildId !== guildId) {
@@ -7584,6 +7586,8 @@ class InteractionHandler {
             if (chartAttachment) publicFiles.push(chartAttachment);
             if (positionIconAttachment) publicFiles.push(positionIconAttachment);
             if (bossImageAttachment) publicFiles.push(bossImageAttachment);
+            // ⚔️ Wyzwanie — osobny embed z ikoną postępu, na końcu stosu
+            this._appendChallengeEmbed(publicEmbeds, publicFiles, _challengeIcon);
 
             let _newRecordPublicMsg = null;
             let _recordRevertSession = null;
@@ -7745,6 +7749,8 @@ class InteractionHandler {
                             if (chartAttachment) dmFiles.push(new AttachmentBuilder(chartAttachment.attachment, { name: chartName }));
                             if (positionIconAttachment) dmFiles.push(new AttachmentBuilder(positionIconAttachment.attachment, { name: positionIconName }));
                             if (bossImageAttachment) dmFiles.push(new AttachmentBuilder(bossImageAttachment.attachment, { name: bossImageName }));
+                            // Embed wyzwania jest klonowany razem ze stosem, więc jego ikona musi tu być
+                            dmFiles.push(...this._challengeIconFiles(_challengeIcon));
                             await subscriberUser.send({ embeds: dmEmbeds, files: dmFiles });
                             gl.info(`✅ Wysłano DM powiadomienie do ${subscriberId}`);
                         } catch (dmError) {
@@ -16939,10 +16945,74 @@ class InteractionHandler {
         return lines.length ? lines.join('\n\n') : null;
     }
 
-    /** Pole do `systemNotices` (Embed 4) albo null, gdy nie ma o czym informować */
-    _challengeSystemNotice(result, msgs) {
-        const value = this._challengeNoticeValue(result?.notices || [], result?.pending, msgs, result?.duplicates || []);
-        return value ? { name: msgs.challengeNoticeField, value } : null;
+    /**
+     * Osobny embed „wynik zaliczony do wyzwania" — dokładany do stosu ogłoszenia rekordu
+     * ORAZ do odpowiedzi „brak rekordu".
+     *
+     * ⚠️ Zastępuje dawne pole `⚔️ Wyzwanie` w Embedzie 4 i dopisek w `reasonText` — informacja
+     * jest w jednym miejscu, nie w trzech. Ikoną jest **generowany pierścień postępu**
+     * (`1/3`, `2/3`, `3/3`, `?` dla wyniku czekającego na zatwierdzenie bossa), więc stan
+     * wyzwania widać rzutem oka, bez czytania treści.
+     *
+     * Licznik bierzemy z PIERWSZEGO wpisu (`notices`, w razie braku `duplicates`) — przy
+     * `MAX_ACTIVE_PER_PLAYER = 1` wpis jest i tak jeden; gdyby limit kiedyś wzrósł, ikona
+     * pokazuje najwyżej zaawansowane wyzwanie, a treść i tak wylicza wszystkie.
+     *
+     * @returns {Promise<{embed: EmbedBuilder, buffer: Buffer|null, name: string}|null>}
+     */
+    async _buildChallengeEmbed(result, msgs) {
+        const notices = result?.notices || [];
+        const duplicates = result?.duplicates || [];
+        const value = this._challengeNoticeValue(notices, result?.pending, msgs, duplicates);
+        if (!value) return null;
+
+        const wpisy = notices.length ? notices : duplicates;
+        const najdalszy = wpisy.reduce((a, b) => ((b.count || 0) > (a?.count || 0) ? b : a), null);
+        const count = result?.pending ? null : (najdalszy?.count ?? null);
+        const total = najdalszy?.total ?? this.challengeService?.scoresPerSide ?? 3;
+
+        const komplet = count !== null && count >= total;
+        const embed = new EmbedBuilder()
+            .setColor(result?.pending ? 0xFEE75C : (komplet ? 0x57F287 : 0xE67E22))
+            .setDescription(value);
+
+        const name = 'challenge_progress.png';
+        let buffer = null;
+        try {
+            buffer = await generateChallengeProgressIcon(count, total);
+        } catch (err) {
+            logger.warn(`Nie udało się wygenerować ikony postępu wyzwania: ${err.message}`);
+        }
+
+        // Bez ikony embed nadal ma sens — leci wtedy z samym tytułem tekstowym
+        if (buffer) {
+            embed.setAuthor({ name: msgs.challengeNoticeField, iconURL: `attachment://${name}` })
+                .setThumbnail(`attachment://${name}`);
+        } else {
+            embed.setAuthor({ name: msgs.challengeNoticeField });
+        }
+
+        return { embed, buffer, name };
+    }
+
+    /** Świeży załącznik ikony postępu — ten sam obrazek leci w ogłoszeniu i w DM subskrybentów */
+    _challengeIconFiles(icon) {
+        return icon?.buffer ? [new AttachmentBuilder(icon.buffer, { name: icon.name })] : [];
+    }
+
+    /**
+     * Dokleja embed wyzwania na koniec stosu i dorzuca jego ikonę do załączników.
+     *
+     * ⚠️ Po doklejeniu limit 6000 znaków na wiadomość liczony jest PONOWNIE
+     * (`_enforceEmbedCharLimit`) — `createRecordEmbeds` przycina stos do 5800 znaków, czyli
+     * z buforem 200, a sam opis o zaliczeniu wyniku potrafi go zjeść w całości. Bez tego
+     * przy maksymalnie rozdmuchanym ogłoszeniu Discord odrzuciłby wiadomość.
+     */
+    _appendChallengeEmbed(embeds, files, icon) {
+        if (!icon) return;
+        embeds.push(icon.embed);
+        files.push(...this._challengeIconFiles(icon));
+        this.rankingService._enforceEmbedCharLimit(embeds);
     }
 
     /**

--- a/EndersEcho/services/positionIconService.js
+++ b/EndersEcho/services/positionIconService.js
@@ -204,4 +204,55 @@ async function generatePositionIcon(position) {
     return sharp(Buffer.from(svg)).png().toBuffer();
 }
 
-module.exports = { generatePositionIcon };
+/**
+ * Ikona postępu w wyzwaniu — pierścień „ile z ilu wyników" (`1/3`, `2/3`, `3/3`).
+ *
+ * Trafia w miejsce ikony URL embeda o zaliczeniu wyniku do wyzwania: liczba w treści
+ * mówi to samo, ale postęp widać wtedy dopiero po przeczytaniu, a nie rzutem oka.
+ *
+ * @param {number|null} count - ile wyników już zaliczono; `null` = wynik czeka na
+ *                              zatwierdzenie nazwy bossa (pierścień pusty, znak zapytania)
+ * @param {number} total - ile wyników składa się na wyzwanie
+ * @returns {Promise<Buffer|null>} bufor PNG albo null przy nieprawidłowych danych
+ */
+async function generateChallengeProgressIcon(count, total) {
+    const suma = parseInt(total, 10);
+    if (!Number.isFinite(suma) || suma < 1) return null;
+
+    const oczekuje = count === null || count === undefined;
+    const ile = oczekuje ? 0 : Math.max(0, Math.min(suma, parseInt(count, 10) || 0));
+    const komplet = !oczekuje && ile >= suma;
+
+    // Żółty = wynik zaparkowany do zatwierdzenia, zielony = komplet, pomarańczowy = w trakcie
+    const kolor = oczekuje ? '#FEE75C' : (komplet ? '#57F287' : '#E67E22');
+    const cx = 128, cy = 128, r = 92, grubosc = 18;
+
+    // Pełny okrąg rysujemy elementem <circle> — łuk o kącie 360° degeneruje się do punktu
+    let postep;
+    if (komplet) {
+        postep = `<circle cx="${cx}" cy="${cy}" r="${r}" fill="none" stroke="${kolor}" stroke-width="${grubosc}" stroke-linecap="round"/>`;
+    } else if (ile > 0) {
+        const kat = (ile / suma) * 2 * Math.PI;
+        const x = cx + r * Math.sin(kat);
+        const y = cy - r * Math.cos(kat);
+        const duzyLuk = kat > Math.PI ? 1 : 0;
+        postep = `<path d="M ${cx} ${cy - r} A ${r} ${r} 0 ${duzyLuk} 1 ${x.toFixed(2)} ${y.toFixed(2)}"`
+            + ` fill="none" stroke="${kolor}" stroke-width="${grubosc}" stroke-linecap="round"/>`;
+    } else {
+        postep = '';
+    }
+
+    const napis = oczekuje ? '?' : `${ile}/${suma}`;
+    const rozmiar = napis.length > 3 ? 62 : 72;
+
+    const svg = `<svg width="${SIZE}" height="${SIZE}" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="${cx}" cy="${cy}" r="${r}" fill="#2B2D31" stroke="#1E1F22" stroke-width="4"/>
+  <circle cx="${cx}" cy="${cy}" r="${r}" fill="none" stroke="#4E5058" stroke-width="${grubosc}"/>
+  ${postep}
+  ${_numberText(napis, cx, cy, rozmiar, '#FFFFFF', '#1E1F22')}
+</svg>`;
+
+    return sharp(Buffer.from(svg)).png().toBuffer();
+}
+
+module.exports = { generatePositionIcon, generateChallengeProgressIcon };


### PR DESCRIPTION
## Zmiana

Informacja o zaliczeniu wyniku do wyzwania dostaje **własny embed** zamiast doklejki do cudzych. Jego ikoną (author + thumbnail) jest **generowany pierścień postępu**: `1/3`, `2/3`, `3/3`, a dla wyniku czekającego na zatwierdzenie nazwy bossa `?`.

Embed dokłada się na koniec **każdej** ścieżki odpowiedzi `_runUpdateFlow`:
- nowy rekord (stos 4 embedów → 5)
- „tylko rekord bossa"
- duplikat cross-server
- **brak rekordu** (`createNoRecordEmbeds`) — tu też z ikoną w miejscu ikony URL
- nierozpoznany boss bez poprawy

Gdy wynik nie ruszył żadnego wyzwania, embed w ogóle nie powstaje. `/test` (dryRun) nadal nie zalicza niczego, więc i tu go nie ma.

**Zastąpiło to dwa dawne miejsca:** pole `⚔️ Wyzwanie` w Embedzie 4 (`systemNotices`) i dopisek w `reasonText` embeda „brak rekordu". `_challengeSystemNotice` usunięte — informacja jest w jednym miejscu, nie w trzech.

## Generator ikony

`generateChallengeProgressIcon(count, total)` w `positionIconService.js` — SVG→PNG przez sharp, tą samą techniką co istniejące ikony pozycji globalnej.

- pierścień tła + łuk postępu proporcjonalny do `count/total`, liczba `N/3` na środku
- **pełny okrąg rysowany elementem `<circle>`, nie łukiem** — łuk o kącie 360° degeneruje się do punktu i zniknąłby
- kolor: pomarańczowy `0xE67E22` w trakcie · zielony `0x57F287` przy komplecie · żółty `0xFEE75C` dla wyniku czekającego na admina
- `count` poza zakresem jest przycinany (5/3 → 3/3), `total < 1` i `null` zwracają `null`

## Szczegóły implementacji

- `_buildChallengeEmbed(result, msgs)` → `{ embed, buffer, name }`; **bufor, nie `AttachmentBuilder`** — ten sam obrazek leci w ogłoszeniu i w DM subskrybentów, a jednego `AttachmentBuilder` nie da się wysłać dwa razy (`_challengeIconFiles` buduje świeży na każdą wysyłkę)
- `_appendChallengeEmbed(embeds, files, icon)` — jedno miejsce doklejania, **przelicza limit 6000 znaków po doklejeniu** (`rankingService._enforceEmbedCharLimit`). `createRecordEmbeds` przycina stos do 5800, czyli z buforem 200, a sam opis o zaliczeniu wyniku potrafi go zjeść w całości
- licznik brany z pierwszego wpisu `notices` (w razie braku — `duplicates`); przy `MAX_ACTIVE_PER_PLAYER = 1` wpis jest i tak jeden
- **błąd generowania ikony nie gubi informacji** — embed leci wtedy bez obrazka, z samym tytułem tekstowym

## Weryfikacja

- ikona wyrenderowana dla `0/3`, `1/3`, `2/3`, `3/3`, `?` oraz przypadków brzegowych (`5/3` → przycięte do `3/3`, `1/5`, `total=0` → `null`, `total=null` → `null`) i obejrzana jako obraz
- embed zbudowany w **obu językach** dla pięciu stanów: 1/2/3 zaliczone wyniki, sama powtórka, wynik oczekujący; plus dwa przypadki bez embeda (brak wyzwania, dryRun) — sprawdzone kolory, author, `attachment://` w ikonie i miniaturze, treść i długość opisu
- potwierdzone, że dwa wywołania `_challengeIconFiles` dają **niezależne** załączniki o tej samej nazwie
- limit 6000: stos dopchany do progu, na jakim zostawia go `createRecordEmbeds`, po doklejeniu embeda nadal mieści się w limicie; `_appendChallengeEmbed(…, null)` nie rusza stosu
- `node --check` na zmienionych plikach

Bot nie był uruchamiany (brak `node_modules` w sesji) — wygląd w Discordzie niezweryfikowany na żywo.

## Dokumentacja

`EndersEcho/CLAUDE.md`: Embed 5 w opisie stosu ogłoszenia rekordu, Embed 3 w `createNoRecordEmbeds`, przepisana sekcja „Gdzie widać informację" w systemie wyzwań (ikona, kolory, limit znaków, bufor zamiast `AttachmentBuilder`), lista załączników.

## Changelog na stronie

Wpisu **nie dodawałem** — `/challenge` jest wciąż wyłącznie dla head admina, więc żaden gracz tego embeda jeszcze nie zobaczy. Gotowy wpis do wklejenia razem z udostępnieniem komendy graczom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9TQHRKc9tG29q2UimiVPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9TQHRKc9tG29q2UimiVPN)_