### PR TITLE
Cofnięcie wyniku otwiera zamknięte wyzwanie; embed wyzwania przedostatni, bez ikony mieczy

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -221,7 +221,7 @@
        - **Opis nadpisany** (`specialDescription`, pierwsze dopasowanie wygrywa): `manualVerificationNote` (panel „Analizuj") > `crossServerScoreRemovedNote` (nowy wynik ściśle lepszy niż na innym serwerze — treść = `systemInfoAllGood` + notka `crossServerScoreRemovedNotice` z nazwą starego i nowego serwera) > `crossServerMigratedNote` (dokładne wyrównanie wyniku z innego serwera — notka `crossServerMigratedNotice`, BEZ prefiksu `systemInfoAllGood`)
        - **Pola dodatkowe** (`systemNotices`, mogą wystąpić RAZEM z opisem nadpisanym): `unknownBossRankingField`/`unknownBossRankingNotice` (nowy nierozpoznany boss), `crossServerBossKeptField`/`crossServerBossKeptValue` (rekord bossa pobity mimo duplikatu globalnego — rekord globalny zostaje na poprzednim serwerze)
        - **Ikona** (author iconURL + thumbnail, 3 stany): `manualVerificationNote` obecna → `.../emojis/1297532628395622440.webp` (zweryfikowano manualnie); jakiekolwiek inne uwagi/komunikaty → `.../emojis/1522939660278435993.webp` (nowa, statyczna); brak uwag → `.../emojis/1297531523477540894.webp` (domyślna, animowana)
-     - **Embed 5 (opcjonalny) — ⚔️ Wyzwanie:** dokładany POZA `createRecordEmbeds`, przez `_appendChallengeEmbed(embeds, files, icon)` w `interactionHandlers.js`. Pojawia się tylko wtedy, gdy wynik ruszył jakieś wyzwanie. Author (lewy górny róg) = **zdjęcie bossa**, thumbnail = **generowany pierścień postępu** `1/3` / `2/3` / `3/3` (`challenge_progress.png`), opis = ten sam tekst co dawniej w polu `⚔️ Wyzwanie`. Kolor: pomarańczowy w trakcie, zielony przy komplecie, żółty gdy wynik czeka na zatwierdzenie bossa. Szczegóły w sekcji „System Wyzwań 1 vs 1"
+     - **Embed wyzwania (opcjonalny) — PRZEDOSTATNI w stosie:** dokładany POZA `createRecordEmbeds`, przez `_appendChallengeEmbed(embeds, files, icon)` w `interactionHandlers.js`. Pojawia się tylko wtedy, gdy wynik ruszył jakieś wyzwanie. **Wchodzi PRZED ostatni embed stosu** (`splice(length - 1, 0, …)`), czyli tuż przed „Informacjami systemowymi" — tamten domyka ogłoszenie zrzutem ekranu i ma zostać na końcu. Author (lewy górny róg) = **zdjęcie bossa**, nazwa autora = `challengeNoticeField` — **samo `Wyzwanie` / `Challenge`, BEZ ikony mieczy** (miecze stały wcześniej w tekście, mając tuż obok obrazek bossa; ikona i emoji w tym samym miejscu dublowały się). Thumbnail = **generowany pierścień postępu** `1/3` / `2/3` / `3/3` (`challenge_progress.png`), opis = informacja o zaliczeniu wyniku. Kolor: pomarańczowy w trakcie, zielony przy komplecie, żółty gdy wynik czeka na zatwierdzenie bossa. Szczegóły w sekcji „System Wyzwań 1 vs 1"
      - **Załączniki** (`files`): `[screenshot, score_history.png?, bossImage?, challenge_progress.png?]`
      - **Guard 6000 znaków** (`_enforceEmbedCharLimit`) — przycina opisy/pola od końca, by zmieścić się w limicie wiadomości
      - **Ścieżka tylko-rekord-bossa** (globalny ranking niezmieniony): stos bez Embedu 2 (1 + 3 + 4)
@@ -720,7 +720,7 @@
   - Duplikat cross-server bez poprawy — `reasonLabel: resultDetailsField`, `reasonText` = boss + `resultNotBeatenCrossServer`
   - Boss nierozpoznany zaakceptowany bez poprawy (żółty, `color1: 0xFEE75C`) — `reasonLabel: resultDetailsField`, `reasonText` = boss + wynik + `unknownBossAccepted`
   - Panel Analizuj — nieudana analiza AI — `reasonLabel: analyzeFailReasonField`, `reasonText` = `aiResult.error`, `color2: 0xFF0000`
-- **Embed 3 (opcjonalny) — ⚔️ Wyzwanie:** gdy wynik został zaliczony do wyzwania, `_appendChallengeEmbed` dokłada embed ze **zdjęciem bossa** w miejscu ikony URL (author) i **pierścieniem postępu** (`1/3`, `2/3`, `3/3`) jako miniaturą. Patrz sekcja „System Wyzwań 1 vs 1"
+- **Embed wyzwania (opcjonalny) — PRZEDOSTATNI:** gdy wynik został zaliczony do wyzwania, `_appendChallengeEmbed` wstawia embed ze **zdjęciem bossa** w miejscu ikony URL (author) i **pierścieniem postępu** (`1/3`, `2/3`, `3/3`) jako miniaturą — **przed** embedem z powodem i zrzutem ekranu, nie za nim. Patrz sekcja „System Wyzwań 1 vs 1"
 - **Nie dotyczy:** stosu 4 embedów nowego rekordu (`createRecordEmbeds`) ani turkusowego ogłoszenia „pobito rekord bossa bez globalnego" — to prawdziwe ogłoszenia rekordu, używają pełnego stosu jak dotychczas. Raport na kanale odrzuconych screenów dla admina (`_sendInvalidScreenReport`) też ma inny, niezmieniony layout (author = tag/ikona serwera, nie status).
 
 **System blokowania per-użytkownik** — `userBlockService.js` + `data/user_blocks.json`:
@@ -1327,8 +1327,11 @@ Wpięcie w `_runUpdateFlow` **tuż po ustaleniu `bestScore`/`bossName`/`userName
 
 **Gdzie widać informację — OSOBNY EMBED z ikoną postępu:**
 
-`_buildChallengeEmbed(result, msgs)` składa embed z opisu `_challengeNoticeValue(notices, pending, msgs, duplicates)` (zaliczone wyniki i odrzucone powtórki w jednej treści), a `_appendChallengeEmbed(embeds, files, icon)` dokłada go **na koniec KAŻDEJ ścieżki odpowiedzi** `_runUpdateFlow`: nowy rekord, „tylko rekord bossa", duplikat cross-server, „brak rekordu" i nierozpoznany boss bez poprawy. Gdy wynik nie ruszył żadnego wyzwania, embed w ogóle nie powstaje (`null`) — tak samo w `/test` (dryRun).
+`_buildChallengeEmbed(result, msgs)` składa embed z opisu `_challengeNoticeValue(notices, pending, msgs, duplicates)` (zaliczone wyniki i odrzucone powtórki w jednej treści), a `_appendChallengeEmbed(embeds, files, icon)` wstawia go jako **PRZEDOSTATNI embed KAŻDEJ ścieżki odpowiedzi** `_runUpdateFlow`: nowy rekord, „tylko rekord bossa", duplikat cross-server, „brak rekordu" i nierozpoznany boss bez poprawy. Gdy wynik nie ruszył żadnego wyzwania, embed w ogóle nie powstaje (`null`) — tak samo w `/test` (dryRun).
 
+⚠️ **Wstawiany przez `splice(length - 1, 0, …)`, nie `push`.** Ostatni embed każdego stosu (Informacje systemowe przy rekordzie, powód przy „brak rekordu") niesie zrzut ekranu i domyka ogłoszenie — wyzwanie idzie tuż przed nim. Przy stosie jednoelementowym `Math.max(0, …)` sprowadza to do wstawienia na początek.
+
+- **Nazwa autora BEZ ikony mieczy** — `challengeNoticeField` to samo `Wyzwanie` / `Challenge`. Emoji ⚔️ stało w tekście dokładnie tam, gdzie obok wyświetla się obrazek bossa, więc dublowało ikonę
 - **Dwie ikony, dwa różne pytania:** `author.iconURL` (lewy górny róg) = **zdjęcie bossa** (`_challengeBossImage` → `data/boss_images/`), `thumbnail` (prawy górny róg) = **generowany pierścień postępu** (`generateChallengeProgressIcon(count, total)` w `positionIconService.js`) — `1/3`, `2/3`, `3/3`, a dla wyniku czekającego na zatwierdzenie bossa `?`. Pełny okrąg rysowany jest elementem `<circle>`, nie łukiem — łuk o kącie 360° degeneruje się do punktu
 - **Gdy bossa nie ma w bazie zdjęć**, `author` bierze pierścień — pusty lewy róg wyglądałby na błąd. Wszystkie wpisy dotyczą tego samego bossa (wynik ma jedną nazwę), więc nazwa brana jest z pierwszego
 - ⚠️ **Załączniki doklejane z pominięciem duplikatów nazwy** (`_pushUniqueFiles`) — Embed 3 stosu ogłoszenia (ranking bossa) używa **dokładnie tego samego pliku**, a dwa załączniki o tej samej nazwie w jednej wiadomości to nieprzewidywalne rozwiązanie `attachment://`. `setAuthor` i tak wskazuje po nazwie, więc wystarczy jeden
@@ -1370,6 +1373,7 @@ Gdy obaj uczestnicy mają po 3 wyniki: sumy z `scoreValue`, wyższa wygrywa, ró
   - publikuje ten sam embed na kanale bota (`allowedChannelId`) serwera **tego** gracza, zbudowany **w języku serwera docelowego**, nie odbiorcy DM
   - potem przycisk zmienia się w **nieaktywny** `✅ Pochwalono się`
   - stan `result.shared.{challenger|opponent}` siedzi w pliku, więc przycisk działa raz **także po restarcie bota**
+  - **adres opublikowanej wiadomości ląduje w `result.announcements[]`** (`attachSharedMessage`) — cofnięcie wyniku kasuje po niej ogłoszenie
   - **⚠️ Ten sam serwer = JEDNO ogłoszenie, oba przyciski gasną naraz.** Gdy obaj gracze siedzą na tym samym serwerze, publikacja przez jednego zamyka sprawę także drugiemu: `markShared` zwraca `alsoClosed` z drugą stroną, a handler od razu wygasza jej przycisk w DM (`_disableChallengeShareButton`). Wcześniej przycisk zostawał aktywny i dopiero kliknięcie kończyło się komunikatem „już opublikowano". Kliknięcie mimo wszystko (wyścig dwóch kliknięć) nadal jest bezpieczne — `sharedGuildIds` nie dopuści duplikatu ogłoszenia
   - **Różne serwery = każdy publikuje osobno, u siebie** — wtedy `alsoClosed` jest `null` i przycisk drugiego gracza zostaje aktywny
 
@@ -1390,7 +1394,20 @@ Osiągnięcia: zwycięzca `+1 wygrana`, przegrany `+1 przegrana`. **Remis, `unre
 - **`renamePlayerKey(from, to)` dopisany do `_migratePlayerKey`** — plik jest kluczowany `playerKey`, a numery slotów zjeżdżają po usunięciu profilu (2→1, 3→2). Bez tego dane osierocieją
 - **`_cancelChallengesForProfile(client, playerKey)` wołane z `_purgeProfileData`:** wyzwania `pending`/`active` → `cancelled` z DM do przeciwnika; wpisy **rozstrzygnięte ZOSTAJĄ** (to również historia przeciwnika), a uczestnik dostaje flagę `profileDeleted: true`
 - **⚠️ W pliku trzymamy FLAGĘ, nie napis „Profil usunięty".** Etykietę składa `participantName(participant, msgs)` w języku odbiorcy (`challengeDeletedProfile` → PL `🗑️ Profil usunięty`, EN `🗑️ Deleted profile`). Zapisanie polskiego stringa do pliku złamałoby dwujęzyczność na serwerach `eng`
-- **Cofnięcie wyniku** (`_cvRemoveRecord` — przycisk gracza/admina, CV, panel „Analizuj"; oraz panel `🧹 Usuń wynik`) → `removeScore(playerKey, timestamp)` wypisuje wynik z wyzwań **BĘDĄCYCH W TOKU**. Wyzwania rozstrzygnięte zostają nietknięte: rezultat już padł i obie strony dostały powiadomienie
+### Cofnięcie wyniku otwiera wyzwanie z powrotem
+
+`removeScore(playerKey, timestamp, { andAfter })` → `{ removed, reopened }`. Wołane z dwóch miejsc: `_cvRemoveRecord` (przycisk cofnięcia gracza/admina, CV, panel „Analizuj" — z `andAfter: true`, bo tamta ścieżka tnie historię OD cofniętego rekordu w górę) oraz panelu `🧹 Usuń wynik` (pojedynczy wpis, bez `andAfter`).
+
+- **Wynik wypisywany jest z wyzwań o statusie `active`, `finished` i `unresolved`** (`REVERTABLE_STATUSES`). Wyzwanie zamknięte KOMPLETEM WYNIKÓW albo BRAKIEM CZASU traci wraz z cofniętym wynikiem podstawę rozstrzygnięcia, więc wraca do `active` (`winner`, `finishedAt`, `finishedBy` i `result` czyszczone). `declined`, `expired` i `cancelled` zamknęła decyzja człowieka, nie wynik — **tych nie wskrzeszamy**
+- ⚠️ **`expiresAt` NIE jest przedłużane.** Gdy 72 h zdążyło minąć, najbliższy przebieg sweepa zamknie wyzwanie jako `unresolved` ze standardowym powiadomieniem. Dorysowanie czasu, którego nikt nie przyznał, byłoby gorsze niż uczciwe „skończyło się"
+- **`reopened` niesie stan sprzed otwarcia** — adresy DM-ów i ogłoszeń oraz strony do cofnięcia osiągnięć. Sprząta po nim `_undoChallengeResolution(client, reopened)` w `interactionHandlers.js`:
+  1. **kasuje DM z rezultatem** u obu graczy (`result.dm[side]`)
+  2. **kasuje ogłoszenia** opublikowane przyciskiem „pochwal się" (`result.announcements[]`)
+  3. **cofa osiągnięcia** — `achievementService.revertChallengeOutcome(guildId, playerKey, 'challengesWon'|'challengesLost')` dekrementuje licznik (podłoga 0) i odbiera osiągnięcia o ID `chal_*`, których warunek przestał być spełniony. Bez tego ponowne rozstrzygnięcie naliczyłoby wygraną drugi raz
+  4. **odświeża Centrum Dowodzenia** (`adminPanelService.refresh()`) — sekcja ⚔️ Wyzwania pokazuje wyzwanie znów w toku
+- **Nowego powiadomienia „wynik cofnięty" NIE wysyłamy** — komunikat o cofnięciu rekordu idzie osobno, ze ścieżki cofania wyniku. Werdykt po prostu znika
+- ⚠️ **Adresy wiadomości muszą być ZAPISANE, żeby dało się je skasować.** `attachResultDm(id, side, channelId, messageId)` (DM rezultatu — także tego po 72 h bez kompletu wyników, `_handleChallengeSweep`) i `attachSharedMessage(id, guildId, channelId, messageId)` (ogłoszenie z „pochwal się"). `sharedGuildIds` mówi tylko, ŻE ogłoszenie poszło, nie GDZIE ono jest — dokładając kolejne miejsce publikacji rezultatu, zapisz jego adres tak samo
+- **Po ponownym otwarciu ta sama wartość wyniku może wejść jeszcze raz** — wypadła z tablicy, więc blokada powtórek jej nie widzi
 
 ### Zakładka `⚔️ Wyzwania` w `/profile`
 

--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -546,7 +546,7 @@ const pol = {
     challengeDmInviteExpiredNotice: '⏳ Brak odpowiedzi od **{opponent}** na Twoje wyzwanie na bossie **{boss}** w ciągu 48 godzin — zaproszenie wygasło.',
 
     // ⚔️ Wyzwania — zaliczanie wyników
-    challengeNoticeField: '⚔️ Wyzwanie',
+    challengeNoticeField: 'Wyzwanie',
     challengeNoticeCounted: 'Wynik zaliczony do wyzwania z **{opponent}**\nBoss **{boss}** — **{count}/{total}**.\n\nTwoja suma: **{sum}**.',
     challengeNoticePending: 'Nazwa bossa nie została rozpoznana, więc wynik **czeka na zatwierdzenie przez administratora**. Po weryfikacji zostanie doliczony do Twojego wyzwania.',
     challengeNoticeDuplicate: 'Wynik **{score}** jest już zaliczony do wyzwania z **{opponent}** (boss **{boss}**) — ten sam rezultat nie liczy się drugi raz. Nadal masz **{count}/{total}**.',
@@ -1145,7 +1145,7 @@ const eng = {
     challengeDmInviteExpiredNotice: '⏳ **{opponent}** did not respond to your challenge on boss **{boss}** within 48 hours — the invitation expired.',
 
     // ⚔️ Challenges — score qualification
-    challengeNoticeField: '⚔️ Challenge',
+    challengeNoticeField: 'Challenge',
     challengeNoticeCounted: 'Score counted towards your challenge with **{opponent}**\nBoss **{boss}** — **{count}/{total}**.\n\nYour total: **{sum}**.',
     challengeNoticePending: 'The boss name was not recognised, so the score is **awaiting administrator approval**. Once verified, it will be counted towards your challenge.',
     challengeNoticeDuplicate: 'Score **{score}** is already counted towards your challenge with **{opponent}** (boss **{boss}**) — the same result does not count twice. You still have **{count}/{total}**.',

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -4220,10 +4220,13 @@ class InteractionHandler {
                 ? await this.scoreHistoryService.removeEntryByTimestamp(targetGuildId, targetPlayerKey, tsMs)
                 : null;
 
-            // ⚔️ Wyzwania — ten sam wynik przestaje liczyć się w wyzwaniach w toku
+            // ⚔️ Wyzwania — wynik przestaje liczyć się w wyzwaniach w toku, a wyzwanie, które
+            // ten wynik zamknął, wraca do gry (rezultat traci podstawę)
             if (removed && this.challengeService) {
-                await this.challengeService.removeScore(targetPlayerKey, removed.timestamp)
-                    .catch(e => logger.warn(`⚠️ Błąd wypisywania wyniku z wyzwań: ${e.message}`));
+                const chalRevert = await this.challengeService.removeScore(targetPlayerKey, removed.timestamp)
+                    .catch(e => { logger.warn(`⚠️ Błąd wypisywania wyniku z wyzwań: ${e.message}`); return null; });
+                await this._undoChallengeResolution(interaction.client, chalRevert?.reopened)
+                    .catch(e => logger.warn(`⚠️ Błąd cofania rozstrzygnięcia wyzwania: ${e.message}`));
             }
 
             if (!removed) {
@@ -9791,12 +9794,15 @@ class InteractionHandler {
                 session.guildId, (session.playerKey || session.userId), session.newRecord.timestamp
             ).catch(e => { logger.error(`CV _cvRemoveRecord revert history error: ${e.message}`); return 0; });
         }
-        // ⚔️ Wyzwania — wynik wypisany z wyzwań BĘDĄCYCH W TOKU. Wyzwania rozstrzygnięte
-        // zostają nietknięte: rezultat już padł i obie strony dostały powiadomienie.
+        // ⚔️ Wyzwania — ta ścieżka tnie historię OD cofniętego rekordu w górę
+        // (`removeEntriesAfter` kasuje A + B + C), więc z wyzwań wypisujemy tak samo:
+        // `andAfter`. Wyzwanie zamknięte którymkolwiek z tych wyników wraca do gry.
         if (this.challengeService && session.newRecord?.timestamp) {
-            await this.challengeService.removeScore(
-                (session.playerKey || session.userId), session.newRecord.timestamp
-            ).catch(e => logger.warn(`⚠️ Błąd wypisywania wyniku z wyzwań: ${e.message}`));
+            const chalRevert = await this.challengeService.removeScore(
+                (session.playerKey || session.userId), session.newRecord.timestamp, { andAfter: true }
+            ).catch(e => { logger.warn(`⚠️ Błąd wypisywania wyniku z wyzwań: ${e.message}`); return null; });
+            await this._undoChallengeResolution(opts.client, chalRevert?.reopened)
+                .catch(e => logger.warn(`⚠️ Błąd cofania rozstrzygnięcia wyzwania: ${e.message}`));
         }
         // Cofnij tylko osiągnięcia score/records zdobyte od momentu zgłoszonego rekordu — wcześniejsze zostają
         try {
@@ -17043,7 +17049,9 @@ class InteractionHandler {
      */
     _appendChallengeEmbed(embeds, files, icon) {
         if (!icon) return;
-        embeds.push(icon.embed);
+        // PRZEDOSTATNI, nie ostatni — ostatni embed stosu (informacje systemowe / powód braku
+        // rekordu) niesie zrzut ekranu i domyka ogłoszenie, więc wyzwanie wchodzi tuż przed nim
+        embeds.splice(Math.max(0, embeds.length - 1), 0, icon.embed);
         this._pushUniqueFiles(files, this._challengeIconFiles(icon));
         this.rankingService._enforceEmbedCharLimit(embeds);
     }
@@ -17238,6 +17246,65 @@ class InteractionHandler {
         }
     }
 
+    /**
+     * Sprząta po ponownym otwarciu wyzwania zamkniętego cofniętym wynikiem.
+     *
+     * Rozstrzygnięcie zostawia po sobie trzy ślady: DM z rezultatem u obu graczy,
+     * ewentualne ogłoszenie opublikowane przyciskiem „pochwal się" i naliczoną
+     * wygraną/przegraną w osiągnięciach. Wszystkie trzy trzeba zdjąć — inaczej gracze
+     * oglądaliby werdykt pojedynku, który znowu trwa, a ponowne rozstrzygnięcie
+     * naliczyłoby osiągnięcia drugi raz.
+     *
+     * ⚠️ Nowego powiadomienia o cofnięciu NIE wysyłamy — komunikat „wynik cofnięty"
+     * przychodzi osobno, ze ścieżki cofania rekordu.
+     */
+    async _undoChallengeResolution(client, reopened) {
+        if (!client || !Array.isArray(reopened) || reopened.length === 0) return;
+
+        for (const wpis of reopened) {
+            const { challenge, dm, announcements, winnerSide, loserSide } = wpis;
+            try {
+                // 1. DM z rezultatem u obu graczy
+                for (const side of ['challenger', 'opponent']) {
+                    const ref = dm?.[side];
+                    if (!ref?.channelId || !ref?.messageId) continue;
+                    try {
+                        const channel = await client.channels.fetch(ref.channelId);
+                        await channel.messages.delete(ref.messageId);
+                    } catch { /* DM skasowany albo zamknięty — nic do zrobienia */ }
+                }
+
+                // 2. Ogłoszenia opublikowane przyciskiem „pochwal się"
+                for (const ogl of announcements || []) {
+                    if (!ogl?.channelId || !ogl?.messageId) continue;
+                    try {
+                        const channel = client.channels.cache.get(ogl.channelId)
+                            || await client.channels.fetch(ogl.channelId);
+                        await channel.messages.delete(ogl.messageId);
+                    } catch { /* wiadomość mógł już skasować moderator */ }
+                }
+
+                // 3. Naliczone osiągnięcia — tylko przy rozstrzygnięciu ze zwycięzcą
+                if (this.achievementService && winnerSide && loserSide) {
+                    const winner = challenge[winnerSide];
+                    const loser = challenge[loserSide];
+                    await this.achievementService
+                        .revertChallengeOutcome(winner.guildId, winner.playerKey, 'challengesWon').catch(() => {});
+                    await this.achievementService
+                        .revertChallengeOutcome(loser.guildId, loser.playerKey, 'challengesLost').catch(() => {});
+                }
+
+                this.logService._gl(challenge.challenger.guildId).info(
+                    `⚔️ Wyzwanie otwarte ponownie po cofnięciu wyniku: "${challenge.challenger.username}" vs "${challenge.opponent.username}" (${challenge.boss})`
+                );
+            } catch (err) {
+                logger.warn(`⚠️ Błąd cofania rozstrzygnięcia wyzwania ${wpis?.challenge?.id}: ${err.message}`);
+            }
+        }
+
+        this.adminPanelService?.refresh();
+    }
+
     /** Osiągnięcia za wygraną/przegraną — remis i nierozstrzygnięcie nie liczą się */
     async _applyChallengeAchievements(challenge) {
         if (!this.achievementService || challenge.status !== 'finished' || !challenge.winner) return;
@@ -17325,7 +17392,9 @@ class InteractionHandler {
             const embed = this._buildChallengeResultEmbed(challenge, guildMsgs, {
                 thumb: bossImage.thumb, publicView: true, client: interaction.client,
             });
-            await channel.send({ embeds: [embed], files: this._challengeBossFiles(bossImage) });
+            const announcement = await channel.send({ embeds: [embed], files: this._challengeBossFiles(bossImage) });
+            // Zapamiętujemy adres ogłoszenia — cofnięcie wyniku musi umieć je skasować
+            await this.challengeService.attachSharedMessage(challengeId, guildId, channel.id, announcement.id).catch(() => {});
             await interaction.reply({ content: formatMessage(msgs.challengeSharedOk, { guild: guildName }), flags: ['Ephemeral'] });
             await disableButton(msgs.challengeBtnShared, ButtonStyle.Secondary);
             // Drugi gracz z TEGO SAMEGO serwera nie ma już czego publikować — gasimy mu przycisk
@@ -17762,10 +17831,13 @@ class InteractionHandler {
                         boss: challenge.boss,
                     }),
                 ].join('\n'));
-                await this._dmUser(client, participant.userId, {
+                const dm = await this._dmUser(client, participant.userId, {
                     embeds: [embed],
                     files: this._challengeBossFiles(bossImage),
                 });
+                // Zapamiętujemy adres także tutaj — cofnięcie wyniku otwiera wyzwanie zamknięte
+                // z braku czasu tak samo jak rozstrzygnięte, więc i ten DM trzeba umieć skasować
+                if (dm) await this.challengeService.attachResultDm(challenge.id, side, dm.channelId, dm.id);
             }
         }
 

--- a/EndersEcho/services/achievementService.js
+++ b/EndersEcho/services/achievementService.js
@@ -442,6 +442,42 @@ class AchievementService {
     }
 
     /**
+     * Cofa naliczenie wygranej/przegranej po ponownym otwarciu rozstrzygniętego wyzwania
+     * (cofnięcie wyniku wypisało go z wyzwania, więc rezultat traci podstawę).
+     *
+     * Bez tego ponowne rozstrzygnięcie naliczyłoby to samo drugi raz — a licznik wygranych
+     * jest podstawą siedmiu osiągnięć.
+     *
+     * ⚠️ Odbieramy WYŁĄCZNIE osiągnięcia o ID zaczynającym się od `chal_`. Przelecenie
+     * `check(p, {})` po całej kategorii `explorer` odebrałoby te, które do warunku potrzebują
+     * kontekstu (`ctx`) — pusty obiekt zawsze im go odmawia.
+     *
+     * @param {'challengesWon'|'challengesLost'} field
+     */
+    async revertChallengeOutcome(guildId, playerKey, field) {
+        if (!['challengesWon', 'challengesLost'].includes(field)) return;
+        return this._enqueue(guildId, async () => {
+            try {
+                const data = await this.loadData(guildId);
+                const userData = data[playerKey];
+                if (!userData) return;
+
+                const p = userData.progress || (userData.progress = {});
+                p[field] = Math.max(0, (p[field] || 0) - 1);
+
+                for (const ach of ACHIEVEMENTS) {
+                    if (!ach.id.startsWith('chal_') || !userData.unlocked[ach.id]) continue;
+                    try {
+                        if (!ach.check(p, {})) delete userData.unlocked[ach.id];
+                    } catch {}
+                }
+
+                await this.saveData(guildId, data);
+            } catch {}
+        });
+    }
+
+    /**
      * Tworzy embed i komponenty dla komendy /achievements.
      * @param {string} guildId
      * @param {string} playerKey

--- a/EndersEcho/services/challengeService.js
+++ b/EndersEcho/services/challengeService.js
@@ -31,6 +31,12 @@ const CLOSED_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000;
 const SIDES = ['challenger', 'opponent'];
 /** Statusy, po których wyzwanie już się nie toczy — historia w Centrum Dowodzenia */
 const CLOSED_STATUSES = new Set(['finished', 'unresolved', 'declined', 'expired', 'cancelled']);
+/**
+ * Statusy, z których cofnięcie wyniku potrafi wyzwanie odzyskać: trwające (samo wypisanie
+ * wyniku) oraz zamknięte KOMPLETEM WYNIKÓW albo brakiem czasu. `declined`, `expired`
+ * i `cancelled` zamknęła decyzja człowieka, nie wynik — tych nie wskrzeszamy.
+ */
+const REVERTABLE_STATUSES = new Set(['active', 'finished', 'unresolved']);
 
 /**
  * System wyzwań 1 vs 1 (`/challenge`).
@@ -566,6 +572,22 @@ class ChallengeService {
     }
 
     /**
+     * Zapamiętuje ogłoszenie opublikowane przyciskiem „pochwal się".
+     *
+     * Bez tego cofnięcie wyniku nie miałoby czego skasować — `sharedGuildIds` mówi tylko,
+     * ŻE ogłoszenie poszło, nie GDZIE ono jest.
+     */
+    async attachSharedMessage(id, guildId, channelId, messageId) {
+        await this._mutate(draft => {
+            const ch = draft.challenges[id];
+            if (!ch) return;
+            if (!ch.result) ch.result = { dm: {}, shared: { challenger: false, opponent: false }, sharedGuildIds: [] };
+            if (!Array.isArray(ch.result.announcements)) ch.result.announcements = [];
+            ch.result.announcements.push({ guildId, channelId, messageId });
+        });
+    }
+
+    /**
      * Oznacza publikację wyniku przez jednego z uczestników. Przycisk działa RAZ —
      * stan siedzi w pliku, więc restart bota go nie resetuje.
      * @returns {Promise<{ ok: boolean, reason?: 'already_shared'|'guild_shared'|'not_found', guildId?: string }>}
@@ -722,29 +744,71 @@ class ChallengeService {
 
     /**
      * Cofnięcie wyniku (przycisk gracza / panel admina) — wypisuje wynik z wyzwań
-     * BĘDĄCYCH W TOKU. Wyzwania rozstrzygnięte zostają nietknięte: rezultat już padł
-     * i obie strony dostały powiadomienie.
-     * @returns {Promise<number>} liczba wypisanych wyników
+     * w toku ORAZ z tych, które ten wynik zamknął.
+     *
+     * Wyzwanie zamknięte KOMPLETEM WYNIKÓW (`finished`) albo BRAKIEM CZASU (`unresolved`)
+     * traci podstawę rozstrzygnięcia razem z cofniętym wynikiem, więc wraca do statusu
+     * `active`. `declined`, `expired` i `cancelled` zamknęła decyzja człowieka, nie wynik —
+     * tych nie wskrzeszamy.
+     *
+     * ⚠️ `expiresAt` NIE jest przedłużane. Gdy 72 h zdążyło minąć, najbliższy przebieg sweepa
+     * zamknie wyzwanie jako `unresolved` ze standardowym powiadomieniem — to uczciwsze niż
+     * dorysowanie czasu, którego nikt nie przyznał.
+     *
+     * @param {boolean} [opts.andAfter] kasuj też wyniki PÓŹNIEJSZE niż `timestamp`
+     *   (ścieżka `_cvRemoveRecord` tnie historię od cofniętego rekordu w górę)
+     * @returns {Promise<{removed: number, reopened: Array<{challenge, dm, announcements, winnerSide, loserSide}>}>}
+     *   `reopened` niesie stan sprzed otwarcia — adresy DM-ów i ogłoszeń do skasowania oraz
+     *   strony, którym trzeba cofnąć osiągnięcia
      */
-    async removeScore(playerKey, timestamp) {
-        if (!playerKey || !timestamp) return 0;
+    async removeScore(playerKey, timestamp, { andAfter = false } = {}) {
         const target = Date.parse(timestamp);
-        if (!Number.isFinite(target)) return 0;
+        if (!playerKey || !timestamp || !Number.isFinite(target)) return { removed: 0, reopened: [] };
+
         let removed = 0;
+        const reopened = [];
+
         await this._mutate(draft => {
             for (const ch of Object.values(draft.challenges)) {
-                if (ch.status !== 'active') continue;
+                if (!REVERTABLE_STATUSES.has(ch.status)) continue;
                 const side = this._sideOf(ch, playerKey);
                 if (!side) continue;
+
                 const me = ch[side];
-                const idx = me.scores.findIndex(s => Date.parse(s.timestamp) === target);
-                if (idx === -1) continue;
-                me.scores.splice(idx, 1);
+                const przed = me.scores.length;
+                me.scores = me.scores.filter(sc => {
+                    const ts = Date.parse(sc.timestamp);
+                    if (!Number.isFinite(ts)) return true;
+                    return andAfter ? ts < target : ts !== target;
+                });
+                if (me.scores.length === przed) continue;
+
+                removed += przed - me.scores.length;
                 this._recalcSum(me);
-                removed++;
+                if (ch.status === 'active') continue;
+
+                // Wyzwanie było zamknięte TYM wynikiem — rozstrzygnięcie traci podstawę,
+                // więc wraca do gry. Stan `result` (DM-y i ogłoszenia) oddajemy wywołującemu
+                // do skasowania i czyścimy, żeby kolejne rozstrzygnięcie zaczynało od zera.
+                const byloFinished = ch.status === 'finished';
+                const zwyciezca = byloFinished ? ch.winner : null;
+                reopened.push({
+                    challenge: { ...ch },
+                    dm: { ...(ch.result?.dm || {}) },
+                    announcements: [...(ch.result?.announcements || [])],
+                    winnerSide: zwyciezca,
+                    loserSide: zwyciezca ? this.otherSide(zwyciezca) : null,
+                });
+
+                ch.status = 'active';
+                ch.winner = null;
+                ch.finishedAt = null;
+                ch.finishedBy = null;
+                ch.result = { dm: {}, shared: { challenger: false, opponent: false }, sharedGuildIds: [], announcements: [] };
             }
         });
-        return removed;
+
+        return { removed, reopened };
     }
 
     // ─── Prezentacja ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Cofnięcie wyniku cofa też rozstrzygnięcie wyzwania

`challengeService.removeScore(playerKey, timestamp, { andAfter })` zwraca teraz `{ removed, reopened }` i obejmuje statusy `active`, `finished` i `unresolved` (`REVERTABLE_STATUSES`) zamiast samego `active`.

- wyzwanie zamknięte **kompletem wyników** albo **brakiem czasu** traci wraz z cofniętym wynikiem podstawę rozstrzygnięcia → wraca do `active`, a `winner` / `finishedAt` / `finishedBy` / `result` są czyszczone
- `declined`, `expired` i `cancelled` zamknęła decyzja człowieka, nie wynik — tych nie wskrzeszamy
- `expiresAt` **nie jest przedłużane**: gdy 72 h minęło, najbliższy sweep zamknie wyzwanie jako `unresolved` ze standardowym powiadomieniem

Nowy `_undoChallengeResolution(client, reopened)` w `interactionHandlers.js` sprząta po otwartym wyzwaniu:

1. kasuje DM z rezultatem u obu graczy (`result.dm[side]`)
2. kasuje ogłoszenia opublikowane przyciskiem „pochwal się" (`result.announcements[]`)
3. cofa naliczone osiągnięcia — nowy `achievementService.revertChallengeOutcome(guildId, playerKey, field)` dekrementuje licznik (podłoga 0) i odbiera osiągnięcia o ID `chal_*`, których warunek przestał być spełniony
4. odświeża Centrum Dowodzenia (`adminPanelService.refresh()`)

Żeby było co kasować, adresy wiadomości są teraz zapisywane:

- `attachSharedMessage(id, guildId, channelId, messageId)` — ogłoszenie z „pochwal się" (`sharedGuildIds` mówiło tylko, ŻE ogłoszenie poszło, nie GDZIE)
- `attachResultDm(...)` wołane dodatkowo dla DM-a o nierozstrzygnięciu po 72 h

Oba wywołania `removeScore` zaktualizowane do nowego kształtu zwrotki. `_cvRemoveRecord` przekazuje `{ andAfter: true }` — ta ścieżka tnie historię od cofniętego rekordu w górę (`removeEntriesAfter` kasuje A + B + C), więc z wyzwań wypisuje tak samo.

Nowego powiadomienia „wynik cofnięty" nie wysyłamy — komunikat o cofnięciu rekordu idzie osobno, ze ścieżki cofania wyniku.

## Embed wyzwania: przedostatni, bez ikony mieczy

- `_appendChallengeEmbed` używa `splice(length - 1, 0, …)` zamiast `push` — ostatni embed stosu (Informacje systemowe / powód braku rekordu) niesie zrzut ekranu i domyka ogłoszenie, więc wyzwanie wchodzi tuż przed nim
- `challengeNoticeField` → `Wyzwanie` / `Challenge` bez `⚔️`; emoji stało w tekście dokładnie tam, gdzie obok wyświetla się obrazek bossa

## Dokumentacja

`EndersEcho/CLAUDE.md` zaktualizowany: nowa sekcja „Cofnięcie wyniku otwiera wyzwanie z powrotem", opis miejsca wstawienia embeda i nazwy autora, wzmianka o `result.announcements[]`.

Lista komend w Muteuszu bez zmian — nie doszła ani nie zmieniła się żadna komenda slash. Changelog na stronie pominięty: `/challenge` jest nadal wyłącznie dla head admina, więc dla gracza nic się tu nie zmienia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9TQHRKc9tG29q2UimiVPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9TQHRKc9tG29q2UimiVPN)_