### PR TITLE
Wyzwania otwarte dla graczy, zaproszenie 24 h, osiągnięcie za remis, rozstrzyganie po czasie

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -282,7 +282,7 @@
 
 7. **System Osiągnięć** — `achievementService.js` + `config/achievements.js`:
    - **101 stałych osiągnięć** w 5 kategoriach + 1 dynamiczny status (`status_top1` — rewokowany gdy wynik usunięty)
-   - **Kategorie:** 🏆 Wyniki (9) · 🔁 Rekordy (8) · 🎯 Bossowie (8: 1/3/5/7/10/13/16/20 różnych bossów, dwa najwyższe: ☄️ Nieśmiertelny Łowca i 👑 Bóg Łowów, oba mythic) · 🕵️ Eksplorator/ukryte (65 — w tym 22 sekretne za wyzwania `/challenge`) · 💎 Prestiż (13)
+   - **Kategorie:** 🏆 Wyniki (9) · 🔁 Rekordy (8) · 🎯 Bossowie (8: 1/3/5/7/10/13/16/20 różnych bossów, dwa najwyższe: ☄️ Nieśmiertelny Łowca i 👑 Bóg Łowów, oba mythic) · 🕵️ Eksplorator/ukryte (64 — w tym 23 sekretne za wyzwania `/challenge`) · 💎 Prestiż (13)
    - **Rarities:** ⬜ Common · 🟩 Uncommon · 🟦 Rare · 🟪 Epic · 🟧 Legendary · 🔴 Mythic
    - **Odblokowanie:** osiągnięcia score/records/bosses/prestige blokowane przy każdym nowym rekordzie; ukryte (explorer) blokowane natychmiast przy przegladzie rankingu lub subskrypcji
    - **Kasowanie częściowe:** `clearUserAchievements(guildId, userId)` — usuwa WSZYSTKIE osiągnięcia kategorii `score` i `records` oraz resetuje `recordCount`/`lastRecordAt`/`lastRecordBeatAt`; pozostałe kategorie (bosses, explorer, prestige) zostają; wywoływane przy usunięciu gracza z rankingu (panel admina + komenda `/remove` — usunięcie całego gracza)
@@ -302,7 +302,7 @@
    - **Widok osiągnięć** (zakładka `🏆 Osiągnięcia` w `/profile` — osobnej komendy `/achievements` NIE MA): ephemeral embed — każda kategoria na osobnej stronie + przycisk podsumowania + przycisk "Sprawdź gracza". Wiersz 1: 5 przycisków kategorii (`🏆 Wyniki`, `🔁 Rekordy`, `🎯 Łowy`, `💎 Prestiż`, `🕵️ Eksplorator`). Wiersz 2: `📊 Podsumowanie` + `🔍 Sprawdź gracza`. Tytuł embeda = etykieta kategorii. Odblokowane: `emoji **nazwa** *(rarity)* \n└ opis — data`. Zablokowane nieukryte: `🔒 ~~nazwa~~`. Zablokowane ukryte: `🔒 **???**`. Stopka: `X/Y odblokowanych` (ukryte: `X/? odblokowanych`). Domyślna strona po wejściu w zakładkę: kategoria `score`. **Osiągnięcia cross-server:** `buildAchievementsViewGlobal(allGuildIds, userId, ...)` merguje dane ze WSZYSTKICH serwerów (`_mergeAchievements`); to samo dla `/profile` i "Sprawdź gracza".
    - **Sprawdź gracza (`ach_check_player`):** otwiera modal z polem nicku → wyszukuje cross-server przez `getGlobalRanking()` → jeśli 1 trafienie: od razu pokazuje osiągnięcia; jeśli wiele: StringSelectMenu (`ach_check_sel`). Wyświetla osiągnięcia ze **wszystkich serwerów** (`buildAchievementsViewForUserGlobal`). **Bez opisów jak zdobyć** — format: `emoji (rarity_emoji) **nazwa** *(rarity)* — data`. Przyciski nawigacji osadzają userId+guildId w customId (`ach_vc_{cat}_{userId}_{guildId}`, `ach_vo_{userId}_{guildId}`). Powrót do własnych osiągnięć przez `ach_vb`.
    - **Tracking:** `trackRankingView(guildId, userId)` — wołane w `handleRankingCommand`; `trackSubscription(guildId, userId)` — wołane w `_handleNotifConfirm`; `trackNonRecord(guildId, userId)` — wołane w `_runUpdateFlow` gdy `!isNewRecord && !dryRun`; `trackCvApproved(guildId, userId)` — wołane w CV approve handler; `trackAiAnalyzed(guildId, userId)` — wołane w `_handleAnalyzeButton` po zapisaniu wyniku; `trackProfileSearch(guildId, userId)` — wołane w `_handleProfileSearchModal` gdy znaleziono ≥1 wynik; `trackChallengeSent/Accepted/Won/Lost(guildId, playerKey)` — wyzwania `/challenge`
-   - **Progress:** `progress.recordCount`, `progress.bossesEncountered[]`, `progress.rankingViews`, `progress.subscriptions`, `progress.lastRecordAt`, `progress.lastRecordBeatAt`, `progress.todayRecordDate` (YYYY-MM-DD UTC), `progress.todayRecordCount`, `progress.nonRecordCount`, `progress.cvApprovedCount`, `progress.aiRescuedCount`, `progress.profileSearches`, `progress.challengesSent`, `progress.challengesAccepted`, `progress.challengesWon`, `progress.challengesLost`
+   - **Progress:** `progress.recordCount`, `progress.bossesEncountered[]`, `progress.rankingViews`, `progress.subscriptions`, `progress.lastRecordAt`, `progress.lastRecordBeatAt`, `progress.todayRecordDate` (YYYY-MM-DD UTC), `progress.todayRecordCount`, `progress.nonRecordCount`, `progress.cvApprovedCount`, `progress.aiRescuedCount`, `progress.profileSearches`, `progress.challengesSent`, `progress.challengesAccepted`, `progress.challengesWon`, `progress.challengesLost`, `progress.challengesDraws`
    - **Context w processSubmission:** `ctx.scoreValue`, `ctx.isNewRecord`, `ctx.prevScoreValue`, `ctx.currentPosition` (pozycja na serwerze), `ctx.bossName`, `ctx.globalPosition` (pozycja w rankingu globalnym — 0 jeśli brak)
    - **CustomIDs:** `ach_cat_{categoryKey}` (score/records/bosses/prestige/explorer) | `ach_overview` | `ach_check_player` | `ach_check_modal` | `ach_check_sel` | `ach_vc_{cat}_{userId}_{guildId}` | `ach_vo_{userId}_{guildId}` | `ach_vb`
 
@@ -743,8 +743,7 @@
 - `/configure`: Administrator Discord LUB Head Admin (`ENDERSECHO_BLOCK_OCR_USER_IDS`); gdy `ENDERSECHO_CONFIGURE_ADMIN_ONLY=true` → tylko Administrator; błąd: `configureNotAdmin`
 - `/manage`: Administrator Discord LUB Head Admin LUB moderator gry (z `guild_configs.json → moderators[]`); błąd: `manageNotAdmin`
 - Wymaga konfiguracji, dowolny kanał: `/test` (Administrator + `ENDERSECHO_BLOCK_OCR_USER_IDS`)
-- Wymaga konfiguracji, dowolny kanał: `/challenge` (Administrator + `ENDERSECHO_BLOCK_OCR_USER_IDS` — na razie wyłącznie head admin)
-- Wymaga konfiguracji + bot channel: `/update`, `/ranking`, `/profile`
+- Wymaga konfiguracji + bot channel: `/update`, `/ranking`, `/profile`, `/challenge`
 - Panel Admina (tryb Admin): Administrator Discord lub moderator gry → usuń gracza, odblokuj, tokeny
 - Panel Admina (tryb Head Admin): `ENDERSECHO_BLOCK_OCR_USER_IDS` → wszystko + info, OCR toggle, limit
 
@@ -1196,7 +1195,7 @@ Dalsze kroki flow (select menu, potwierdzenia, przyciski stron) klikane są już
 
 **`⏳ cc_chal_pending` — WSZYSTKIE zaproszenia czekające na odpowiedź** (8/stronę, `cc_chal_ppg_{page}`): `wyzywający → przeciwnik`, boss, kiedy wysłane i kiedy wygasa, a przy pojedynku międzyserwerowym linia `🔀 serwer wyzywającego → serwer przeciwnika` (przy jednym serwerze pomijana, bo niczego nie wnosi). Embed panelu pokazuje tylko 5 ostatnich — ten przycisk daje komplet.
 
-`getPending()` sortuje **od NAJNOWSZEGO**, odwrotnie niż `getActive()` (tam decyduje najbliższy termin). Zaproszenie samo wygaśnie po 48 h i nie wymaga niczyjej interwencji, a admin patrzy na tę listę pytaniem „kto właśnie kogo wyzwał".
+`getPending()` sortuje **od NAJNOWSZEGO**, odwrotnie niż `getActive()` (tam decyduje najbliższy termin). Zaproszenie samo wygaśnie po 24 h i nie wymaga niczyjej interwencji, a admin patrzy na tę listę pytaniem „kto właśnie kogo wyzwał".
 
 **`🏁 cc_chal_finish` — ręczne zamknięcie wyzwania** (trzy kroki): lista wyzwań w toku (25/stronę, `cc_chal_fpg_{offset}`, kolejność **wg terminu**, nie alfabetycznie — stąd zwykłe `◀️/▶️` zamiast zakresów liter) → `cc_chal_fsel` → potwierdzenie → `cc_chal_fok_{id}`.
 
@@ -1274,14 +1273,16 @@ Pojedynek dwóch graczy na wybranym bossie: liczą się **3 kolejne wyniki** ka�
 
 **⚠️ Uczestnikiem jest PROFIL (`playerKey`), nie osoba** — wyzywający startuje ze swojego **maina** (`_mainPlayerKey`), przeciwnika wybiera z rankingu wskazanego serwera (lista pokazuje profile ze znacznikami `②`/`③`).
 
-**⚠️ Komenda `/challenge` jest na razie WYŁĄCZNIE dla head admina** — widoczna tylko dla administratorów (`setDefaultMemberPermissions(Administrator)`), a wykonać może ją tylko użytkownik z `ENDERSECHO_BLOCK_OCR_USER_IDS` (jak `/generate`). Routing jak `/test`: dowolny kanał, wymaga skonfigurowanego serwera. **Przyjęcie wyzwania, zaliczanie wyników i osiągnięcia działają dla KAŻDEGO gracza** — ograniczenie dotyczy wyłącznie rzucania wyzwania.
+**Komenda `/challenge` jest dostępna dla KAŻDEGO gracza** — bez `setDefaultMemberPermissions` i bez bramki head admina. Routing zwykły, jak `/update` i `/ranking`: wymaga skonfigurowanego serwera **i kanału bota** (`isAllowedChannel`).
+
+⚠️ **Wcześniej komenda była zamknięta dla head admina i szła własną ścieżką routingu**, przed sprawdzeniem kanału. Otwierając ją dla graczy przeniesiono ją do zwykłego `switch`, żeby podlegała tej samej zasadzie „komendy gracza tylko na kanale bota" co reszta. Select menu `chal_*` nadal routowane są przed `isAllowedChannel` — wizard jest efemeryczny i tak czy owak żyje w wiadomości, która powstała już na dozwolonym kanale.
 
 ### Terminy i limity
 
 | Parametr | Wartość | Stała |
 |---|---|---|
 | Wyniki na uczestnika | 3 | `SCORES_PER_SIDE` |
-| Zaproszenie bez odpowiedzi | 48 h → `expired` | `INVITE_TTL_MS` |
+| Zaproszenie bez odpowiedzi | **24 h** → `expired` | `INVITE_TTL_MS` |
 | Przyjęte wyzwanie | **72 h** → `unresolved` (nierozstrzygnięte) | `CHALLENGE_TTL_MS` |
 | Wynik czekający na zatwierdzenie bossa | 72 h → porzucony | `PENDING_SCORE_TTL_MS` |
 | Otwarte wyzwania na profil | **1** — jednocześnie można prowadzić tylko jedno wyzwanie | `MAX_ACTIVE_PER_PLAYER` |
@@ -1387,7 +1388,7 @@ Osiągnięcia: zwycięzca `+1 wygrana`, przegrany `+1 przegrana`. **Remis, `unre
 
 | Warunek | Efekt |
 |---|---|
-| `pending` starsze niż 48 h | → `expired`, DM do wyzywającego, wygaszenie przycisków w DM zaproszenia |
+| `pending` starsze niż 24 h | → `expired`, DM do wyzywającego, wygaszenie przycisków w DM zaproszenia |
 | `active` starsze niż 72 h | → `unresolved`, DM do obu z aktualnymi wynikami, bez zwycięzcy i bez osiągnięć |
 | `pendingScore` starszy niż 72 h | porzucony, DM do gracza |
 
@@ -1430,12 +1431,14 @@ Stan `chalPage`/`chalMaxPage` w `_profileStates`; komunikaty przez **`_msgsByLan
 
 **CustomIDs `/profile`:** `profile_challenges` | `profile_chal_prev` | `profile_chal_next` — jak każdy nowy `profile_*` **MUSZĄ być na whiteliście** w `handleButtonInteraction`, inaczej przycisk nie zadziała.
 
-### Osiągnięcia (22, sekretne)
+### Osiągnięcia (23, sekretne)
 
 Kategoria **`explorer`** (`hidden: true`) — bez zmian w UI kategorii (rząd ma już komplet 5 przycisków), a `_trackExplorer` odblokowuje wyłącznie tę kategorię. Dodatkowa zaleta: `clearUserAchievements` i `clearRecordAchievementsAfter` **pomijają `explorer`**, więc cofnięcie wyniku nie odbiera osiągnięć za wyzwania.
 
-Liczniki w `progress`: `challengesSent`, `challengesAccepted`, `challengesWon`, `challengesLost`.
-Metody: `trackChallengeSent/Accepted/Won/Lost(guildId, playerKey)` — naliczane na serwerze danego uczestnika.
+Liczniki w `progress`: `challengesSent`, `challengesAccepted`, `challengesWon`, `challengesLost`, `challengesDraws`.
+Metody: `trackChallengeSent/Accepted/Won/Lost/Draw(guildId, playerKey)` — naliczane na serwerze danego uczestnika.
+
+**Remis nalicza osiągnięcie OBU stronom** (`_applyChallengeAchievements`: `finished` bez zwycięzcy → `trackChallengeDraw` dla obu). **`unresolved` nadal nie nalicza niczego** — pojedynek się nie odbył. Cofnięcie wyniku, które otwiera zremisowane wyzwanie, zdejmuje je obu stronom: `removeScore` oddaje w `reopened` flagę `wasDraw` (remis to `finished` z `winner === null`, więc same `winnerSide`/`loserSide` by go nie wykryły), a `_undoChallengeResolution` woła `revertChallengeOutcome(..., 'challengesDraws')`.
 
 Progi **1/3/5/10/20/50/100** dla rzuconych (`chal_sent_*`), przyjętych (`chal_acc_*`) i wygranych (`chal_win_*`) + jedno za przegraną (`chal_lost_1`):
 
@@ -1445,6 +1448,7 @@ Progi **1/3/5/10/20/50/100** dla rzuconych (`chal_sent_*`), przyjętych (`chal_a
 | Przyjęte | Podjęte Wyzwanie/Challenge Accepted ⬜ · Honorowy/Honorable 🟩 · Nieustępliwy/Unyielding 🟩 · Gladiator/Gladiator 🟦 · Mur Nie Do Przejścia/Immovable Wall 🟪 · Lew Areny/Lion of the Arena 🟧 · Zawsze Gotowy/Ever Ready 🔴 |
 | Wygrane | Pierwsza Krew/First Blood 🟩 · Triumfator/Triumphant 🟩 · Pogromca/Vanquisher 🟦 · Dziesięciu Pokonanych/Ten Fallen 🟦 · Mistrz Areny/Arena Master 🟪 · Kolekcjoner Czaszek/Skull Collector 🟧 · Legenda Pojedynków/Duel Legend 🔴 |
 | Przegrana | Gorzka Lekcja/Bitter Lesson ⬜ |
+| Remis | Godny Przeciwnik/Worthy Opponent 🟦 |
 
 ### Pułapki magazynu (`jsonStore`)
 

--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -1283,12 +1283,12 @@ Pojedynek dwóch graczy na wybranym bossie: liczą się **3 kolejne wyniki** ka�
 |---|---|---|
 | Wyniki na uczestnika | 3 | `SCORES_PER_SIDE` |
 | Zaproszenie bez odpowiedzi | **24 h** → `expired` | `INVITE_TTL_MS` |
-| Przyjęte wyzwanie | **72 h** → `unresolved` (nierozstrzygnięte) | `CHALLENGE_TTL_MS` |
+| Przyjęte wyzwanie | **72 h** → rozstrzygnięcie po sumach albo `unresolved` (patrz niżej) | `CHALLENGE_TTL_MS` |
 | Wynik czekający na zatwierdzenie bossa | 72 h → porzucony | `PENDING_SCORE_TTL_MS` |
 | Otwarte wyzwania na profil | **1** — jednocześnie można prowadzić tylko jedno wyzwanie | `MAX_ACTIVE_PER_PLAYER` |
 | Zamknięte bez rezultatu (`declined`/`expired`) | kasowane po 90 dniach | `CLOSED_MAX_AGE_MS` |
 
-Statusy: `pending` (czeka na odpowiedź) · `active` (trwa) · `finished` (rozstrzygnięte, zwycięzca albo remis) · `declined` · `expired` (zaproszenie) · `unresolved` (72 h bez kompletu wyników) · `cancelled` (uczestnik usunął profil).
+Statusy: `pending` (czeka na odpowiedź) · `active` (trwa) · `finished` (rozstrzygnięte, zwycięzca albo remis) · `declined` · `expired` (zaproszenie) · `unresolved` (72 h i kompletu nie zebrał NIKT) · `cancelled` (uczestnik usunął profil).
 
 ### Wizard (ephemeral, wzorzec `/subscribe`)
 
@@ -1368,7 +1368,14 @@ Dopiero wtedy gracz dostaje DM (`challengeDmVerifiedTitle`). Wynik, który nie t
 
 ### Rozstrzygnięcie i „pochwal się wynikami"
 
-Gdy obaj uczestnicy mają po 3 wyniki: sumy z `scoreValue`, wyższa wygrywa, równe = **remis**. Wyniku **NIE ogłaszamy automatycznie** — zamiast tego:
+Pojedynek rozstrzyga się **po sumach `scoreValue`** — wyższa wygrywa, równe = **remis**. Dzieje się to w dwóch momentach:
+
+1. **Obaj uczestnicy mają po 3 wyniki** — `registerScore` domyka wyzwanie od razu
+2. **Minęły 72 h, a komplet zebrała PRZYNAJMNIEJ JEDNA strona** — `sweep()` rozstrzyga po aktualnych sumach
+
+⚠️ **Sam komplet nie przesądza o wygranej — decyduje suma.** Gracz z trzema słabszymi wynikami przegra z kimś, kto wrzucił jeden lepszy: komplet jest warunkiem *rozstrzygnięcia*, nie *zwycięstwa*. `unresolved` zostaje wyłącznie na sytuację, w której po 72 h kompletu nie ma **nikt** — wtedy nie ma czego porównywać i nikt nie dostaje osiągnięć.
+
+Wyniku **NIE ogłaszamy automatycznie** — zamiast tego:
 
 - **DM do OBU graczy**, każdy w języku swojego serwera: embed z ikoną bossa, wynikami i sumami obu stron, osobistym werdyktem (`challengeResultWin`/`Loss`/`Draw`) i linią zwycięzcy
 - **Nazwa serwera przy każdym graczu, gdy pojedynek łączy DWA serwery** (`⚔️ Ala — Polski Squad`) — sama para nicków nie mówi wtedy, kto skąd jest. Przy obu graczach z jednego serwera nazwa niczego nie wnosi, więc jej nie ma. Wymaga przekazania `client` do `_buildChallengeResultEmbed` (robią to wszystkie cztery wywołania: DM rezultatu, ogłoszenie po „pochwal się", DM o nierozstrzygnięciu). Etykieta pola przycinana do 256 znaków — limit Discorda
@@ -1389,7 +1396,8 @@ Osiągnięcia: zwycięzca `+1 wygrana`, przegrany `+1 przegrana`. **Remis, `unre
 | Warunek | Efekt |
 |---|---|
 | `pending` starsze niż 24 h | → `expired`, DM do wyzywającego, wygaszenie przycisków w DM zaproszenia |
-| `active` starsze niż 72 h | → `unresolved`, DM do obu z aktualnymi wynikami, bez zwycięzcy i bez osiągnięć |
+| `active` starsze niż 72 h, **komplet po którejś ze stron** | → `finished` po sumach, dalej normalną drogą `_finishChallenges` (osiągnięcia + DM z werdyktem + „pochwal się") |
+| `active` starsze niż 72 h, **kompletu nie ma nikt** | → `unresolved`, DM do obu z aktualnymi wynikami, bez zwycięzcy i bez osiągnięć |
 | `pendingScore` starszy niż 72 h | porzucony, DM do gracza |
 
 ### Spójność z profilami
@@ -1409,7 +1417,7 @@ Osiągnięcia: zwycięzca `+1 wygrana`, przegrany `+1 przegrana`. **Remis, `unre
   3. **cofa osiągnięcia** — `achievementService.revertChallengeOutcome(guildId, playerKey, 'challengesWon'|'challengesLost')` dekrementuje licznik (podłoga 0) i odbiera osiągnięcia o ID `chal_*`, których warunek przestał być spełniony. Bez tego ponowne rozstrzygnięcie naliczyłoby wygraną drugi raz
   4. **odświeża Centrum Dowodzenia** (`adminPanelService.refresh()`) — sekcja ⚔️ Wyzwania pokazuje wyzwanie znów w toku
 - **Nowego powiadomienia „wynik cofnięty" NIE wysyłamy** — komunikat o cofnięciu rekordu idzie osobno, ze ścieżki cofania wyniku. Werdykt po prostu znika
-- ⚠️ **Adresy wiadomości muszą być ZAPISANE, żeby dało się je skasować.** `attachResultDm(id, side, channelId, messageId)` (DM rezultatu — także tego po 72 h bez kompletu wyników, `_handleChallengeSweep`) i `attachSharedMessage(id, guildId, channelId, messageId)` (ogłoszenie z „pochwal się"). `sharedGuildIds` mówi tylko, ŻE ogłoszenie poszło, nie GDZIE ono jest — dokładając kolejne miejsce publikacji rezultatu, zapisz jego adres tak samo
+- ⚠️ **Adresy wiadomości muszą być ZAPISANE, żeby dało się je skasować.** `attachResultDm(id, side, channelId, messageId)` (DM rezultatu — także tego po 72 h bez kompletu po obu stronach, `_handleChallengeSweep`) i `attachSharedMessage(id, guildId, channelId, messageId)` (ogłoszenie z „pochwal się"). `sharedGuildIds` mówi tylko, ŻE ogłoszenie poszło, nie GDZIE ono jest — dokładając kolejne miejsce publikacji rezultatu, zapisz jego adres tak samo
 - **Po ponownym otwarciu ta sama wartość wyniku może wejść jeszcze raz** — wypadła z tablicy, więc blokada powtórek jej nie widzi
 
 **Przycisk „↩️ Cofnij wynik wyzwania" (`ocr_chal_undo_{playerKey}_{tsMs}`, head admin)** — pod embedem OCR typu `challenge`, czyli tam, gdzie rekord NIE padł, a wynik i tak wszedł do wyzwania.

--- a/EndersEcho/config/achievements.js
+++ b/EndersEcho/config/achievements.js
@@ -569,6 +569,12 @@ const ACHIEVEMENTS = [
         descPol: 'Przegraj wyzwanie', descEng: 'Lose a challenge',
         check: (p, _ctx) => (p.challengesLost || 0) >= 1,
     },
+    {
+        id: 'chal_draw_1', category: 'explorer', rarity: 'rare', hidden: true, icon: '🤝',
+        namePol: 'Godny Przeciwnik',   nameEng: 'Worthy Opponent',
+        descPol: 'Zremisuj wyzwanie', descEng: 'Draw a challenge',
+        check: (p, _ctx) => (p.challengesDraws || 0) >= 1,
+    },
 
     // ===== PRESTIŻ (PRESTIGE) =====
     {

--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -577,7 +577,7 @@ const pol = {
     challengeShareFailed: '❌ Nie udało się opublikować wyniku na serwerze **{guild}**.',
     challengePublicTitle: '⚔️ Zakończone wyzwanie',
     challengeDmUnresolvedTitle: '❓ Wyzwanie nierozstrzygnięte',
-    challengeDmUnresolvedDesc: 'Wyzwanie z **{opponent}** na bossie **{boss}** trwało **72 godziny** i nie zostało dokończone — pozostaje nierozstrzygnięte.',
+    challengeDmUnresolvedDesc: 'Wyzwanie z **{opponent}** na bossie **{boss}** trwało **72 godziny** i żadna ze stron nie zebrała kompletu wyników — pozostaje nierozstrzygnięte.',
     challengeDmCancelledTitle: '🚫 Wyzwanie anulowane',
     challengeDmCancelledDesc: 'Wyzwanie z **{opponent}** na bossie **{boss}** zostało anulowane — przeciwnik usunął swój profil.',
 
@@ -1176,7 +1176,7 @@ const eng = {
     challengeShareFailed: '❌ Could not publish the result on **{guild}**.',
     challengePublicTitle: '⚔️ Challenge finished',
     challengeDmUnresolvedTitle: '❓ Challenge unresolved',
-    challengeDmUnresolvedDesc: 'Your challenge with **{opponent}** on boss **{boss}** ran for **72 hours** and was not completed — it stays unresolved.',
+    challengeDmUnresolvedDesc: 'Your challenge with **{opponent}** on boss **{boss}** ran for **72 hours** and neither side completed their scores — it stays unresolved.',
     challengeDmCancelledTitle: '🚫 Challenge cancelled',
     challengeDmCancelledDesc: 'Your challenge with **{opponent}** on boss **{boss}** was cancelled — your opponent deleted their profile.',
 

--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -523,7 +523,7 @@ const pol = {
     challengeErrOpponentBusy: '❌ **{name}** prowadzi już inne wyzwanie — jednocześnie można prowadzić tylko jedno. Spróbuj ponownie, gdy je zakończy.',
     challengeErrDuplicate: '❌ Masz już otwarte wyzwanie z tym graczem na bossie **{boss}**.',
     challengeErrDmClosed: '❌ Gracz **{opponent}** nie odbiera wiadomości od bota — nie można rzucić mu wyzwania.',
-    challengeSent: '✅ Wyzwanie wysłane do gracza **{opponent}** (boss **{boss}**). Masz **48 godzin** na jego odpowiedź.',
+    challengeSent: '✅ Wyzwanie wysłane do gracza **{opponent}** (boss **{boss}**). Masz **24 godziny** na jego odpowiedź.',
 
     // ⚔️ Wyzwania — DM z zaproszeniem
     challengeDmInviteTitle: '⚔️ Rzucono Ci wyzwanie!',
@@ -543,7 +543,7 @@ const pol = {
     challengeDmDeclinedTitle: '❌ Wyzwanie odrzucone',
     challengeDmAcceptedNotice: '**{opponent}** podejmuje Twoje wyzwanie na bossie **{boss}**!\nWrzuć **3 wyniki** komendą `/update`.',
     challengeDmDeclinedNotice: '**{opponent}** odrzuca Twoje wyzwanie na bossie **{boss}**.',
-    challengeDmInviteExpiredNotice: '⏳ Brak odpowiedzi od **{opponent}** na Twoje wyzwanie na bossie **{boss}** w ciągu 48 godzin — zaproszenie wygasło.',
+    challengeDmInviteExpiredNotice: '⏳ Brak odpowiedzi od **{opponent}** na Twoje wyzwanie na bossie **{boss}** w ciągu 24 godzin — zaproszenie wygasło.',
 
     // ⚔️ Wyzwania — zaliczanie wyników
     challengeNoticeField: 'Wyzwanie',
@@ -1122,7 +1122,7 @@ const eng = {
     challengeErrOpponentBusy: '❌ **{name}** is already in another challenge — only one at a time is allowed. Try again once it is finished.',
     challengeErrDuplicate: '❌ You already have an open challenge with this player on boss **{boss}**.',
     challengeErrDmClosed: '❌ **{opponent}** does not accept messages from the bot — they cannot be challenged.',
-    challengeSent: '✅ Challenge sent to **{opponent}** (boss **{boss}**). They have **48 hours** to respond.',
+    challengeSent: '✅ Challenge sent to **{opponent}** (boss **{boss}**). They have **24 hours** to respond.',
 
     // ⚔️ Challenges — invitation DM
     challengeDmInviteTitle: '⚔️ You have been challenged!',
@@ -1142,7 +1142,7 @@ const eng = {
     challengeDmDeclinedTitle: '❌ Challenge declined',
     challengeDmAcceptedNotice: '**{opponent}** accepted your challenge on boss **{boss}**!\nSubmit **3 scores** using `/update`.',
     challengeDmDeclinedNotice: '**{opponent}** declined your challenge on boss **{boss}**.',
-    challengeDmInviteExpiredNotice: '⏳ **{opponent}** did not respond to your challenge on boss **{boss}** within 48 hours — the invitation expired.',
+    challengeDmInviteExpiredNotice: '⏳ **{opponent}** did not respond to your challenge on boss **{boss}** within 24 hours — the invitation expired.',
 
     // ⚔️ Challenges — score qualification
     challengeNoticeField: 'Challenge',

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -17911,7 +17911,12 @@ class InteractionHandler {
         });
     }
 
-    async _handleChallengeSweep(client, { expiredInvites, unresolved, stalePending }) {
+    async _handleChallengeSweep(client, { expiredInvites = [], unresolved = [], finished = [], stalePending = [] }) {
+        // Pojedynek rozstrzygnięty upływem czasu (komplet wyników po jednej ze stron)
+        // domykamy tą samą drogą co naturalny koniec: osiągnięcia, DM z werdyktem
+        // i jednorazowy przycisk „pochwal się"
+        if (finished.length) await this._finishChallenges(client, finished);
+
         for (const challenge of expiredInvites) {
             const msgs = this.msgs(challenge.challenger.guildId);
             await this._dmUser(client, challenge.challenger.userId, {

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -275,8 +275,7 @@ class InteractionHandler {
             new SlashCommandBuilder()
                 .setName('challenge')
                 .setDescription('Challenge another player to a 1v1 duel on a chosen boss')
-                .setDescriptionLocalizations(pl('Rzuć innemu graczowi wyzwanie 1 na 1 na wybranym bossie'))
-                .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+                .setDescriptionLocalizations(pl('Rzuć innemu graczowi wyzwanie 1 na 1 na wybranym bossie')),
 
             new SlashCommandBuilder()
                 .setName('profile')
@@ -399,13 +398,6 @@ class InteractionHandler {
                 return;
             }
 
-            // /challenge — na razie wyłącznie head admin (dowolny kanał, wymaga konfiguracji)
-            if (interaction.commandName === 'challenge') {
-                if (!this._checkConfigured(interaction)) return;
-                await this.handleChallengeCommand(interaction);
-                return;
-            }
-
             // Komendy admin — dowolny kanał, ale wymagają konfiguracji serwera
             if (interaction.commandName === 'test') {
                 if (!this._checkConfigured(interaction)) return;
@@ -427,6 +419,7 @@ class InteractionHandler {
             }
 
             switch (interaction.commandName) {
+                case 'challenge':    await this.handleChallengeCommand(interaction);      break;
                 case 'ranking':      await this.handleRankingCommand(interaction);        break;
                 case 'update':       await this.handleUpdateCommand(interaction);         break;
                 case 'subscribe':    await this.handleNotificationsCommand(interaction);  break;
@@ -16553,10 +16546,6 @@ class InteractionHandler {
      */
     async handleChallengeCommand(interaction) {
         const msgs = this.msgs(interaction.guildId);
-        if (!this._isHeadAdmin(interaction.user.id)) {
-            await interaction.reply({ content: msgs.noPermission, flags: ['Ephemeral'] });
-            return;
-        }
         if (!this.challengeService) {
             await interaction.reply({ content: msgs.updateError, flags: ['Ephemeral'] });
             return;
@@ -17362,7 +17351,7 @@ class InteractionHandler {
         if (!client || !Array.isArray(reopened) || reopened.length === 0) return;
 
         for (const wpis of reopened) {
-            const { challenge, dm, announcements, winnerSide, loserSide } = wpis;
+            const { challenge, dm, announcements, winnerSide, loserSide, wasDraw } = wpis;
             try {
                 // 1. DM z rezultatem u obu graczy
                 for (const side of ['challenger', 'opponent']) {
@@ -17384,7 +17373,8 @@ class InteractionHandler {
                     } catch { /* wiadomość mógł już skasować moderator */ }
                 }
 
-                // 3. Naliczone osiągnięcia — tylko przy rozstrzygnięciu ze zwycięzcą
+                // 3. Naliczone osiągnięcia — przy rozstrzygnięciu ze zwycięzcą oraz przy remisie
+                // (ten dostały OBIE strony). `unresolved` niczego nie naliczyło, więc nic nie cofamy
                 if (this.achievementService && winnerSide && loserSide) {
                     const winner = challenge[winnerSide];
                     const loser = challenge[loserSide];
@@ -17392,6 +17382,12 @@ class InteractionHandler {
                         .revertChallengeOutcome(winner.guildId, winner.playerKey, 'challengesWon').catch(() => {});
                     await this.achievementService
                         .revertChallengeOutcome(loser.guildId, loser.playerKey, 'challengesLost').catch(() => {});
+                } else if (this.achievementService && wasDraw) {
+                    for (const side of ['challenger', 'opponent']) {
+                        const p = challenge[side];
+                        await this.achievementService
+                            .revertChallengeOutcome(p.guildId, p.playerKey, 'challengesDraws').catch(() => {});
+                    }
                 }
 
                 this.logService._gl(challenge.challenger.guildId).info(
@@ -17405,9 +17401,21 @@ class InteractionHandler {
         this.adminPanelService?.refresh();
     }
 
-    /** Osiągnięcia za wygraną/przegraną — remis i nierozstrzygnięcie nie liczą się */
+    /**
+     * Osiągnięcia za rozstrzygnięty pojedynek: wygrana, przegrana albo remis (obie strony).
+     * Nierozstrzygnięcie (`unresolved`) nie nalicza niczego — pojedynek się nie odbył.
+     */
     async _applyChallengeAchievements(challenge) {
-        if (!this.achievementService || challenge.status !== 'finished' || !challenge.winner) return;
+        if (!this.achievementService || challenge.status !== 'finished') return;
+
+        if (!challenge.winner) {
+            for (const side of ['challenger', 'opponent']) {
+                const p = challenge[side];
+                await this.achievementService.trackChallengeDraw(p.guildId, p.playerKey).catch(() => {});
+            }
+            return;
+        }
+
         const winner = challenge[challenge.winner];
         const loser = challenge[challenge.winner === 'challenger' ? 'opponent' : 'challenger'];
         await this.achievementService.trackChallengeWon(winner.guildId, winner.playerKey).catch(() => {});

--- a/EndersEcho/services/achievementService.js
+++ b/EndersEcho/services/achievementService.js
@@ -441,8 +441,12 @@ class AchievementService {
         return this._trackExplorer(guildId, playerKey, p => { p.challengesLost = (p.challengesLost || 0) + 1; });
     }
 
+    async trackChallengeDraw(guildId, playerKey) {
+        return this._trackExplorer(guildId, playerKey, p => { p.challengesDraws = (p.challengesDraws || 0) + 1; });
+    }
+
     /**
-     * Cofa naliczenie wygranej/przegranej po ponownym otwarciu rozstrzygniętego wyzwania
+     * Cofa naliczenie wygranej/przegranej/remisu po ponownym otwarciu rozstrzygniętego wyzwania
      * (cofnięcie wyniku wypisało go z wyzwania, więc rezultat traci podstawę).
      *
      * Bez tego ponowne rozstrzygnięcie naliczyłoby to samo drugi raz — a licznik wygranych
@@ -452,10 +456,10 @@ class AchievementService {
      * `check(p, {})` po całej kategorii `explorer` odebrałoby te, które do warunku potrzebują
      * kontekstu (`ctx`) — pusty obiekt zawsze im go odmawia.
      *
-     * @param {'challengesWon'|'challengesLost'} field
+     * @param {'challengesWon'|'challengesLost'|'challengesDraws'} field
      */
     async revertChallengeOutcome(guildId, playerKey, field) {
-        if (!['challengesWon', 'challengesLost'].includes(field)) return;
+        if (!['challengesWon', 'challengesLost', 'challengesDraws'].includes(field)) return;
         return this._enqueue(guildId, async () => {
             try {
                 const data = await this.loadData(guildId);

--- a/EndersEcho/services/challengeService.js
+++ b/EndersEcho/services/challengeService.js
@@ -10,8 +10,8 @@ const logger = createBotLogger('EndersEcho');
 
 /** Ile wyników składa się na wyzwanie (per uczestnik) */
 const SCORES_PER_SIDE = 3;
-/** Zaproszenie bez odpowiedzi wygasa po 48 h */
-const INVITE_TTL_MS = 48 * 60 * 60 * 1000;
+/** Zaproszenie bez odpowiedzi wygasa po 24 h */
+const INVITE_TTL_MS = 24 * 60 * 60 * 1000;
 /** Przyjęte wyzwanie trwa maksymalnie 72 h — potem kończy się jako nierozstrzygnięte */
 const CHALLENGE_TTL_MS = 72 * 60 * 60 * 1000;
 /**
@@ -165,7 +165,7 @@ class ChallengeService {
      * Zaproszenia czekające na odpowiedź — od NAJNOWSZEGO.
      *
      * Odwrotnie niż `getActive()` (tam decyduje najbliższy termin): zaproszenie samo wygaśnie
-     * po 48 h i nie wymaga niczyjej interwencji, a admin patrzy na tę listę pytaniem
+     * po 24 h i nie wymaga niczyjej interwencji, a admin patrzy na tę listę pytaniem
      * „kto właśnie kogo wyzwał".
      */
     async getPending() {
@@ -798,6 +798,9 @@ class ChallengeService {
                     announcements: [...(ch.result?.announcements || [])],
                     winnerSide: zwyciezca,
                     loserSide: zwyciezca ? this.otherSide(zwyciezca) : null,
+                    // Remis to `finished` BEZ zwycięzcy — osiągnięcie dostały obie strony,
+                    // więc obu trzeba je cofnąć. `unresolved` nie nalicza niczego
+                    wasDraw: byloFinished && !zwyciezca,
                 });
 
                 ch.status = 'active';

--- a/EndersEcho/services/challengeService.js
+++ b/EndersEcho/services/challengeService.js
@@ -237,7 +237,11 @@ class ChallengeService {
      * Rozstrzygamy po AKTUALNYCH sumach, tak samo jak przy komplecie wyników — kto ma więcej,
      * ten wygrywa, równo = remis. Wyjątkiem jest wyzwanie, w którym **nikt** nie wrzucił jeszcze
      * wyniku: „remis 0:0" byłby kłamstwem i przyznawał osiągnięcia za coś, czego nie było,
-     * więc takie zamykamy jako `unresolved` — tym samym statusem, co wygaśnięcie po 72 h.
+     * więc takie zamykamy jako `unresolved`.
+     *
+     * ⚠️ Próg jest tu NIŻSZY niż przy wygaśnięciu po 72 h (tam trzeba kompletu po którejś ze
+     * stron, patrz `sweep()`). Świadomie: zamknięcie ręczne to wyraźna decyzja admina o tym,
+     * że pojedynek ma się rozstrzygnąć teraz, a nie automat działający pod nieobecność ludzi.
      *
      * @returns {Promise<{challenge: object, outcome: 'finished'|'unresolved'}|null>} null gdy nie ma czego zamykać
      */
@@ -647,6 +651,7 @@ class ChallengeService {
         const now = Date.now();
         const expiredInvites = [];
         const unresolved = [];
+        const finished = [];
         const stalePending = [];
 
         await this._mutate(draft => {
@@ -661,10 +666,20 @@ class ChallengeService {
                 } else if (ch.status === 'active') {
                     const due = Date.parse(ch.expiresAt || 0);
                     if (Number.isFinite(due) && due <= now) {
-                        ch.status = 'unresolved';
-                        ch.finishedAt = new Date().toISOString();
-                        ch.winner = null;
-                        unresolved.push(ch);
+                        // Czas minął. Gdy KTÓRAKOLWIEK strona dowiozła komplet wyników,
+                        // rozstrzygamy po sumach — druga miała dokładnie tyle samo czasu
+                        // i go nie wykorzystała, więc „nierozstrzygnięte" byłoby dla tej
+                        // pierwszej karą za cudzą bezczynność. `unresolved` zostaje na
+                        // sytuację, w której kompletu nie zebrał NIKT.
+                        if (SIDES.some(side => this._isComplete(ch[side]))) {
+                            this._finalize(ch);
+                            finished.push(ch);
+                        } else {
+                            ch.status = 'unresolved';
+                            ch.finishedAt = new Date().toISOString();
+                            ch.winner = null;
+                            unresolved.push(ch);
+                        }
                     }
                 }
             }
@@ -677,14 +692,14 @@ class ChallengeService {
             }
         });
 
-        if (this._onSweep && (expiredInvites.length || unresolved.length || stalePending.length)) {
+        if (this._onSweep && (expiredInvites.length || unresolved.length || finished.length || stalePending.length)) {
             try {
-                await this._onSweep({ expiredInvites, unresolved, stalePending });
+                await this._onSweep({ expiredInvites, unresolved, finished, stalePending });
             } catch (err) {
                 logger.error(`Błąd powiadomień o wyzwaniach: ${err.message}`);
             }
         }
-        return { expiredInvites, unresolved, stalePending };
+        return { expiredInvites, unresolved, finished, stalePending };
     }
 
     // ─── Spójność z profilami ─────────────────────────────────────────────────

--- a/Muteusz/config/all_commands.json
+++ b/Muteusz/config/all_commands.json
@@ -644,7 +644,7 @@
           "name": "/challenge",
           "description": "Rzuć innemu graczowi wyzwanie 1 na 1 na wybranym bossie (3 kolejne wyniki, wyższa suma wygrywa)",
           "usage": "/challenge",
-          "requiredPermission": "administrator"
+          "requiredPermission": "public"
         },
         {
           "name": "/configure",


### PR DESCRIPTION
## `/challenge` dostępne dla każdego gracza

- zdjęte `setDefaultMemberPermissions(Administrator)` z rejestracji komendy
- zdjęta bramka `_isHeadAdmin` w `handleChallengeCommand`
- komenda przeniesiona z własnej ścieżki routingu (przed sprawdzeniem kanału) do zwykłego `switch`, więc podlega tej samej zasadzie co `/update`, `/ranking` i `/profile`: **wymaga skonfigurowanego serwera i kanału bota**. Wcześniej działała na dowolnym kanale, bo dotyczyła wyłącznie head admina

Select menu `chal_*` nadal routowane są przed `isAllowedChannel` — wizard jest efemeryczny i żyje w wiadomości, która powstała już na dozwolonym kanale.

## Zaproszenie wygasa po 24 h zamiast 48 h

`INVITE_TTL_MS` = 24 h. Zaktualizowane komunikaty w obu językach (`challengeSent`, `challengeDmInviteExpiredNotice`) oraz komentarze i dokumentacja.

## Po upływie 72 h wygrywa wyższa suma

Dotąd każde wyzwanie bez kompletu wyników po obu stronach kończyło się jako `unresolved` — gracz, który dowiózł swoje trzy wyniki, nie dostawał nic za bezczynność przeciwnika.

`sweep()` rozstrzyga teraz po sumach, gdy komplet zebrała **przynajmniej jedna** strona (`_finalize`, ten sam kod co przy naturalnym końcu). `unresolved` zostaje wyłącznie na sytuację, w której kompletu nie ma **nikt**.

- ⚠️ **Sam komplet nie przesądza o wygranej — decyduje suma.** Trzy słabsze wyniki przegrają z jednym lepszym; komplet jest warunkiem *rozstrzygnięcia*, nie *zwycięstwa*
- pojedynki domknięte czasem idą **tą samą drogą co naturalny koniec** — `sweep()` oddaje je w `finished`, a `_handleChallengeSweep` woła `_finishChallenges`: osiągnięcia, DM z werdyktem i jednorazowy przycisk „pochwal się"
- `_handleChallengeSweep` destrukturyzuje zdarzenia z domyślnymi `[]` — drugi wywołujący (ręczne zamknięcie z Centrum Dowodzenia) nie przekazuje nowego klucza
- `forceFinish` (ręczne zamknięcie przez admina) **celowo zachowuje niższy próg**: wystarczy jeden wynik po dowolnej stronie. To wyraźna decyzja człowieka, a nie automat działający pod nieobecność ludzi — różnica opisana w komentarzu przy metodzie
- `challengeDmUnresolvedDesc` (pol + eng) mówi teraz wprost, że kompletu nie zebrała żadna ze stron

## Osiągnięcie za remis

Nowe `chal_draw_1` — **Godny Przeciwnik / Worthy Opponent** 🤝 (rare, ukryte), warunek `challengesDraws >= 1`.

- nowy licznik `progress.challengesDraws` + `achievementService.trackChallengeDraw()`
- `_applyChallengeAchievements` obsługuje teraz `finished` **bez zwycięzcy** → nalicza remis **obu stronom**. `unresolved` nadal nie nalicza niczego — pojedynek się nie odbył
- **cofanie działa symetrycznie:** remis to `finished` z `winner === null`, więc same `winnerSide`/`loserSide` by go nie wykryły — `removeScore` oddaje w `reopened` dodatkową flagę `wasDraw`, a `_undoChallengeResolution` woła `revertChallengeOutcome(..., 'challengesDraws')` dla obu stron
- `revertChallengeOutcome` przyjmuje trzecie pole; odbieranie osiągnięć nadal ograniczone do ID `chal_*`

## Dokumentacja

`EndersEcho/CLAUDE.md`: uprawnienia i routing `/challenge`, TTL zaproszenia, obie ścieżki rozstrzygnięcia wraz z ostrzeżeniem „komplet ≠ zwycięstwo", rozbita tabela sweepa, licznik `challengesDraws`, opis naliczania i cofania remisu, wiersz w tabeli osiągnięć. Poprawione zweryfikowane liczby osiągnięć (kategoria `explorer` 64, w tym 23 za wyzwania).

`Muteusz/config/all_commands.json`: `/challenge` → `requiredPermission: "public"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9TQHRKc9tG29q2UimiVPN