### PR TITLE
Centrum Dowodzenia zawsze aktualne + szybsze ładowanie listy graczy

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -1322,6 +1322,14 @@ Stan wizarda: `_challengeSessions` Map (RAM, TTL 15 min) — `guildId + playerKe
 - **przyciski zakresów buduje `_buildRangeButtons(items, activeOffset, prefix, maxRows)`** — wspólne dla graczy (`chal_page_`) i serwerów (`chal_spage_`); etykiety liczone z klucza znormalizowanego, nie z surowej nazwy
 - ta sama normalizacja obowiązuje sortowanie w `_getNotifSortedPlayers`, więc dotyczy również listy graczy w `/subscribe`
 
+⚠️ **Lista graczy to WYŁĄCZNIE osoby z wynikiem w rankingu tego serwera** (`getSortedPlayers` czyta `ranking.json`), nigdy wszyscy członkowie Discorda. Nicki serwerowe dociąga `_resolveGuildDisplayNames(guildId, client, userIds)`:
+
+- najpierw cache Discorda (`guild.members.cache`), resztę **batchami po 100 ID, równolegle** (`guild.members.fetch({ user: chunk })` w `Promise.allSettled`)
+- **dedup po `userId` przed pobraniem** — gracz z kilkoma profilami ma jeden nick, więc nie ma powodu pobierać go raz na profil
+- wynik cache'owany per serwer na **3 minuty**, żeby przewijanie stron (`chal_page_*`, `notif_page_*`) nie powtarzało całej operacji przy każdym kliknięciu. Cache'owana jest CAŁA mapa, więc osoby, których nie udało się pobrać (opuściły serwer), nie są odpytywane ponownie w obrębie TTL
+
+⚠️ **Wcześniej była tu pętla z `await targetGuild.members.fetch(player.userId)` na KAŻDY wpis rankingu** — tyle żądań do Discorda, ile wpisów, jedno po drugim. Przy kilkuset graczach lista otwierała się kilkanaście sekund i dłużej, a przy rate limicie jeszcze gorzej. Dokładając nowe miejsce, które potrzebuje nicków całej listy, użyj tego helpera zamiast pojedynczych `members.fetch(id)` w pętli.
+
 **⚠️ Jednocześnie można prowadzić TYLKO JEDNO wyzwanie** (`MAX_ACTIVE_PER_PLAYER = 1`). Slot zajmuje wyzwanie w toku (obojętnie po której stronie) **oraz WYSŁANE zaproszenie** czekające na odpowiedź. **OTRZYMANE zaproszenia slotu NIE zajmują** — inaczej gracz z dwoma zaproszeniami od różnych osób nie mógłby przyjąć żadnego, bo samo ich posiadanie wypełniałoby limit. Sprawdzane w dwóch miejscach: przy `chal_ok` (rzucający → `challengeErrLimit`, przeciwnik → `challengeErrOpponentBusy`) i przy `chal_acc_{id}` (przyjmujący → `challengeErrAcceptLimit`). **Zajętość przeciwnika sprawdzana PRZED wysłaniem DM** — bez tego dostawałby zaproszenie, którego i tak nie mógłby przyjąć, a rzucający czekałby do jego wygaśnięcia.
 
 **Rekord powstaje dopiero po UDANEJ wysyłce DM.** Gdy przeciwnik ma zamknięte wiadomości prywatne, wpis jest kasowany (`discard`), a wyzywający dostaje `challengeErrDmClosed`.

--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -1216,17 +1216,32 @@ Powiadomienia idą **tą samą drogą co przy naturalnym końcu**, bez własnej 
 **Widok `/manage → 📡 Centrum Dowodzenia`:**
 Prosta informacja o kanale panelu + przycisk `🔄 Odśwież Panel`.
 
+**⚠️ ZASADA: panel ma być ZAWSZE aktualny.** Każda zmiana danych, które któraś z ośmiu sekcji
+wyświetla, MUSI kończyć się wywołaniem `this.adminPanelService?.refresh()`. Nie ma tu „drobnych"
+zmian — admin patrzy na panel zamiast na pliki, więc nieodświeżona sekcja po prostu kłamie.
+Dokładając nową funkcję, sprawdź, czy dotyka którejkolwiek sekcji, i dopisz `refresh()`.
+Metoda jest **debounce'owana i tania** (patrz niżej), więc nadmiarowe wywołanie nic nie kosztuje —
+brakujące kosztuje wiarygodność panelu.
+
 **Triggery automatycznego refresh:**
-- ✅ Po każdym zapisie wyniku (`/update` — zarówno nowy rekord jak i brak rekordu, `!dryRun`)
-- ✅ Po analizie admina (`Analizuj` panel)
-- ✅ Po usunięciu gracza z rankingu (`panel_remove_confirm_*`)
-- ✅ Po zablokowaniu gracza (`panel_block_time_*`)
-- ✅ Po odblokowaniu gracza (`panel_unblock_select`)
-- ✅ Po akcji Community Verification (approve/remove/block)
-- ✅ Na żądanie: `🔄 cc_refresh` na wiadomości panelu lub `/manage → Centrum Dowodzenia → Odśwież`
-- ✅ Przy starcie bota (jeśli kanał skonfigurowany)
+
+| Sekcja | Kiedy |
+|---|---|
+| 👥 Użytkownicy | zapis wyniku (`/update`, `!dryRun`) · analiza admina (`Analizuj`) · usunięcie gracza (`panel_remove_confirm_*`) · usunięcie wyniku (`panel_remove_score_*`) · blokada (`panel_block_time_*`) i odblokowanie (`panel_unblock_select`) · akcje CV (approve/remove/block) · cofnięcie wyniku · czyszczenie cooldownu · **dodanie profilu, zaplanowanie i odwołanie usunięcia profilu**, przepalenie profilu (`_purgeProfileData`) |
+| 🖥️ Serwery | **`cfg_accept`** (serwer skonfigurowany) · **`guildCreate` / `guildDelete`** (`index.js`) · toggle AI OCR · ban/unban serwera · usunięcie danych serwera · kick z nieskonfigurowanego |
+| 👾 Bossowie | **dodanie / usunięcie / zmiana nazwy bossa, dodanie i usunięcie aliasu, przypisanie zdjęcia** · **zmapowanie nieznanej nazwy** z alertu (`boss_map_lang_sel`) |
+| ⚔️ Wyzwania | **wysłanie zaproszenia** (`chal_ok`) · **przyjęcie / odrzucenie** (`chal_acc_*` / `chal_rej_*`) · **zaliczenie wyniku** (`_registerChallengeScore`, gdy `notices` niepuste) · **rozstrzygnięcie** (`_finishChallenges` — jedno miejsce dla kompletu wyników, upływu czasu, ręcznego zamknięcia i doliczenia zaparkowanego wyniku) · **sweep** (wygasłe zaproszenia, nierozstrzygnięte) · **doliczenie zaparkowanych wyników** po zmapowaniu bossa · **anulowanie wyzwań usuniętego profilu** · cofnięcie wyniku otwierające wyzwanie |
+| 💰 Koszty | alert kosztowy · zmiana limitów |
+| ⚙️ Narzędzia | **dodanie / usunięcie testera** · globalny kill-switch OCR |
+| wszystkie | `🔄 cc_refresh` na wiadomości panelu · `/manage → Centrum Dowodzenia → Odśwież` · start bota (gdy kanał skonfigurowany) |
+
+⚠️ **`_finishChallenges` jest JEDYNYM miejscem odświeżania po rozstrzygnięciu wyzwania** — schodzą
+się w nim wszystkie cztery drogi (komplet wyników, upływ 72 h, `forceFinish` z panelu, doliczenie
+zaparkowanego wyniku). Dokładając piątą, nie dopisuj `refresh()` u siebie, tylko przepuść ją tędy.
 
 **Debouncing:** Maksymalnie 1 refresh naraz + 1 oczekujący (dodatkowe wywołania w trakcie odrzucane).
+`_doRefresh` dodatkowo wychodzi od razu bez klienta albo bez kanału, więc `refresh()` jest bezpieczne
+do wołania z dowolnego miejsca, także zanim panel zostanie skonfigurowany.
 
 **Persistencja:** `data/admin_panel.json` — `{ messageId, channelId }`. Jeśli wiadomość usunięta, serwis tworzy nową.
 

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -2347,6 +2347,8 @@ class InteractionHandler {
 
             await this.guildConfigService.saveConfig(interaction.guildId, newData);
             this._configWizard.delete(key);
+            // Serwer wchodzi do sekcji 🖥️ Serwery (albo znika z „nieskonfigurowanych")
+            this.adminPanelService?.refresh();
 
             // Re-register commands with new language
             try {
@@ -6115,6 +6117,7 @@ class InteractionHandler {
             const idx = parseInt(customId.slice('prof_delete_cancel_do_'.length), 10);
             const prof = registry.getProfiles(userId).find(pr => pr.index === idx);
             const res = await registry.cancelDeletion(userId, idx, interaction.member?.displayName || interaction.user.username);
+            this.adminPanelService?.refresh();
             if (!res.ok) {
                 await interaction.update({ content: msgs.profileCmdNoPendingDeletions, components: [] });
                 return;
@@ -6163,6 +6166,8 @@ class InteractionHandler {
             const idx = parseInt(customId.slice('prof_delete_confirm_'.length), 10);
             const prof = registry.getProfiles(userId).find(pr => pr.index === idx);
             const res = await registry.scheduleDeletion(userId, idx, interaction.member?.displayName || interaction.user.username);
+            // Profil czekający na usunięcie ma w panelu znacznik ⏳
+            this.adminPanelService?.refresh();
             if (!res.ok) {
                 await interaction.update({
                     content: res.reason === 'IS_MAIN' ? msgs.profileCmdDeleteMain : msgs.profileCmdNotFound,
@@ -6214,6 +6219,8 @@ class InteractionHandler {
 
         if (mode === 'add' || mode === 'addfirst') {
             const res = await registry.addProfile(interaction.user.id, label, interaction.member?.displayName || interaction.user.username);
+            // Sekcja 👥 Użytkownicy pokazuje graczy z dodatkowymi profilami
+            this.adminPanelService?.refresh();
             if (!res.ok) {
                 const content = res.reason === 'LIMIT'
                     ? formatMessage(msgs.profileCmdAddLimit, { limit: res.limit })
@@ -14973,6 +14980,8 @@ class InteractionHandler {
             username = member.displayName || member.user.username || null;
         } catch {}
         const added = await this.testerService.addTester(userId, interaction.user.id, username);
+        // Sekcja ⚙️ Narzędzia wypisuje testerów z nickami
+        this.adminPanelService?.refresh();
         if (!added) {
             await interaction.reply({ content: t(`⚠️ Użytkownik <@${userId}> jest już testerem.`, `⚠️ User <@${userId}> is already a tester.`), flags: ['Ephemeral'] });
             return;
@@ -15018,6 +15027,7 @@ class InteractionHandler {
         const t = this._panelT(interaction.guildId);
         const userId = interaction.values[0];
         const removed = await this.testerService.removeTester(userId);
+        this.adminPanelService?.refresh();
         if (!removed) {
             await interaction.reply({ content: t('❌ Nie znaleziono testera.', '❌ Tester not found.'), flags: ['Ephemeral'] });
             return;
@@ -16826,7 +16836,9 @@ class InteractionHandler {
         if (this.achievementService) {
             this.achievementService.trackChallengeSent(interaction.guildId, challengerKey).catch(() => {});
         }
-        gl.info(`⚔️ ${this.logService.nickLink(challengerName, interaction.user.id)} rzucił wyzwanie graczowi "${session.playerName}" na bossie "${session.boss}"`);
+        gl.info(`⚔️ ${this.logService.nickLink(challengerName, interaction.user.id)} rzuca wyzwanie graczowi "${session.playerName}" na bossie "${session.boss}"`);
+        // Sekcja ⚔️ Wyzwania w Centrum Dowodzenia liczy też zaproszenia czekające na odpowiedź
+        this.adminPanelService?.refresh();
         await done(formatMessage(msgs.challengeSent, { opponent: session.playerName, boss: session.boss }));
     }
 
@@ -16980,6 +16992,9 @@ class InteractionHandler {
         const notifAvatar = await this._challengeOpponentAvatar(interaction.client, [{ opponent: updated.opponent }]);
         if (notifAvatar) notifEmbed.setThumbnail(notifAvatar);
         await this._dmUser(interaction.client, updated.challenger.userId, { embeds: [notifEmbed] });
+
+        // Zaproszenie przeszło z „oczekujących" do „w toku" albo zniknęło — panel to pokazuje
+        this.adminPanelService?.refresh();
     }
 
     /** Bezpieczna wysyłka DM — zamknięte wiadomości prywatne nie mogą wywrócić flow */
@@ -17016,6 +17031,8 @@ class InteractionHandler {
                 playerKey, bossName, score, scoreValue, guildId, timestamp,
             });
             if (finished.length > 0) await this._finishChallenges(interaction.client, finished);
+            // Licznik postępu (`2/3 : 1/3`) w sekcji „W toku" zmienia się z każdym zaliczonym wynikiem
+            if (notices.length > 0) this.adminPanelService?.refresh();
             return { notices, duplicates, pending: false };
         } catch (err) {
             this.logService._gl(guildId).warn(`⚠️ Błąd zaliczania wyniku do wyzwania: ${err.message}`);
@@ -17234,6 +17251,7 @@ class InteractionHandler {
             }
 
             if (finished.length > 0) await this._finishChallenges(client, finished);
+            this.adminPanelService?.refresh();
         } catch (err) {
             logger.warn(`⚠️ Błąd doliczania wyników wyzwań po zatwierdzeniu bossa: ${err.message}`);
         }
@@ -17327,12 +17345,17 @@ class InteractionHandler {
                 }
 
                 this.logService._gl(challenge.challenger.guildId).info(
-                    `⚔️ Wyzwanie zakończone: "${challenge.challenger.username}" vs "${challenge.opponent.username}" (${challenge.boss}) — ${challenge.winner ? `wygrał ${challenge[challenge.winner].username}` : 'remis'}`
+                    `⚔️ Wyzwanie zakończone: "${challenge.challenger.username}" vs "${challenge.opponent.username}" (${challenge.boss}) — ${challenge.winner ? `zwycięstwo: ${challenge[challenge.winner].username}` : 'remis'}`
                 );
             } catch (err) {
                 logger.error(`Błąd finalizacji wyzwania ${challenge.id}: ${err.message}`);
             }
         }
+
+        // Jedno miejsce dla WSZYSTKICH dróg rozstrzygnięcia (komplet wyników, upływ czasu,
+        // ręczne zamknięcie z panelu, doliczenie zaparkowanego wyniku) — wyzwanie znika
+        // z „W toku", wchodzi do historii i rusza miesięczny bilans TOP 5
+        this.adminPanelService?.refresh();
     }
 
     /**
@@ -17963,6 +17986,10 @@ class InteractionHandler {
                 .setTimestamp();
             await this._dmUser(client, pending.userId, { embeds: [embed] });
         }
+
+        // Sweep chodzi co godzinę bez udziału człowieka — bez tego panel pokazywałby
+        // wygasłe zaproszenia i zakończone pojedynki aż do najbliższej akcji admina
+        this.adminPanelService?.refresh();
     }
 
     /** Wygasza przyciski pod DM z zaproszeniem */
@@ -18010,6 +18037,7 @@ class InteractionHandler {
                 await this._dmUser(client, other.userId, { embeds: [embed] });
                 await this._disableChallengeInvite(client, challenge);
             }
+            if (cancelled.length > 0) this.adminPanelService?.refresh();
         } catch (err) {
             logger.warn(`⚠️ Błąd anulowania wyzwań usuniętego profilu ${playerKey}: ${err.message}`);
         }
@@ -18176,6 +18204,8 @@ class InteractionHandler {
             return;
         }
         await this.bossAliasService.addEnglishName(rawName);
+        // Sekcja 👾 Bossowie w Centrum Dowodzenia liczy bossów w bazie
+        this.adminPanelService?.refresh();
         await interaction.deferUpdate();
         const { embed, components } = this._buildBossConfigPanel(interaction);
         await interaction.editReply({ embeds: [embed], components });
@@ -18264,6 +18294,7 @@ class InteractionHandler {
         }
         const lang = interaction.values[0];
         const addResult = await this.bossAliasService.addAlias(session.pendingBoss, session.pendingAlias, lang);
+        this.adminPanelService?.refresh();
         const backRow = [new ActionRowBuilder().addComponents(
             new ButtonBuilder().setCustomId('panel_boss_cfg').setEmoji('👾').setLabel(t('Powrót do konfiguracji bossów', 'Back to Boss Config')).setStyle(ButtonStyle.Primary),
         )];
@@ -18383,6 +18414,7 @@ class InteractionHandler {
         const [lang, ...aliasParts] = interaction.values[0].split('::');
         const alias = aliasParts.join('::');
         await this.bossAliasService.removeAlias(session.pendingBoss, lang, alias);
+        this.adminPanelService?.refresh();
         this._bossCfgSessions.delete(interaction.user.id);
         await interaction.update({
             embeds: [new EmbedBuilder().setColor(0x57F287)
@@ -18430,6 +18462,7 @@ class InteractionHandler {
         const t = this._panelT(interaction.guildId);
         const bossName = interaction.values[0];
         await this.bossAliasService.removeEnglishName(bossName);
+        this.adminPanelService?.refresh();
         const { embed, components } = this._buildBossConfigPanel(interaction);
         const confirmEmbed = new EmbedBuilder().setColor(0x57F287)
             .setTitle(t('✅ Boss usunięty', '✅ Boss Removed'))
@@ -18508,6 +18541,7 @@ class InteractionHandler {
             return;
         }
         await this.bossAliasService.renameEnglishName(oldName, newName);
+        this.adminPanelService?.refresh();
         await interaction.deferUpdate();
         const { embed, components } = this._buildBossConfigPanel(interaction);
         const confirmEmbed = new EmbedBuilder().setColor(0x57F287)
@@ -18792,6 +18826,8 @@ class InteractionHandler {
         }
         const lang = interaction.values[0];
         const addResult = await this.bossAliasService.addAlias(session.englishBoss, session.adjustedBoss, lang);
+        // Zmapowana nazwa znika z listy „nieznane do zmapowania"
+        this.adminPanelService?.refresh();
         const _langEntry = this.bossAliasService.getSupportedLanguages().find(l => l.code === lang);
         const langLabel = _langEntry?.label || lang;
         const langLabelEn = _langEntry?.labelEn || _langEntry?.label || lang;
@@ -18990,6 +19026,8 @@ class InteractionHandler {
             const buffer = await downloadBuffer(rawUrl);
             await fs.writeFile(path.join(imgDir, filename), buffer);
             await this.bossAliasService.setBossImage(bossName, filename);
+            // Boss schodzi z listy „bez zdjęcia"
+            this.adminPanelService?.refresh();
             const successMsg = (msgs.bossCfgImgSuccess || '✅ Zdjęcie przypisane do bossa **{bossName}**.').replace('{bossName}', bossName);
             await interaction.editReply({ content: successMsg });
             logger.info(`Zdjęcie bossa "${bossName}" zapisane jako ${filename}`);

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -194,6 +194,8 @@ class InteractionHandler {
         this._bossMapSessions = new Map();
         // Sesje wizarda /challenge (userId -> { guildId, playerKey, playerName, boss })
         this._challengeSessions = new Map();
+        // Nicki serwerowe do list wyboru gracza (guildId -> { at, names: Map<userId, nick> })
+        this._guildNickCache = new Map();
         this.challengeService = null;
         // Sesje robocze panelu konfiguracji bossów (userId -> { pendingBoss? })
         this._bossCfgSessions = new Map();
@@ -11731,21 +11733,67 @@ class InteractionHandler {
 
     async _getNotifSortedPlayers(guildId, client) {
         const players = await this.rankingService.getSortedPlayers(guildId);
-        const targetGuild = client.guilds.cache.get(guildId);
-        const result = [];
-        for (const player of players) {
-            let displayName = player.username || `ID:${player.userId}`;
-            if (targetGuild) {
-                try {
-                    const member = await targetGuild.members.fetch(player.userId);
-                    displayName = member.displayName;
-                } catch {}
-            }
+        const nicks = await this._resolveGuildDisplayNames(guildId, client, players.map(pl => pl.userId));
+
+        const result = players.map(player => {
+            const displayName = nicks.get(player.userId) || player.username || `ID:${player.userId}`;
             // Profil dodatkowy → nick ze znacznikiem, żeby lista rozróżniała konta jednej osoby
-            result.push({ ...player, displayName: formatProfileDisplayName(displayName, player.profileIndex || 1) });
-        }
+            return { ...player, displayName: formatProfileDisplayName(displayName, player.profileIndex || 1) };
+        });
         result.sort((a, b) => this._compareSortNames(a.displayName, b.displayName));
         return result;
+    }
+
+    /**
+     * Nicki serwerowe dla listy ID — z cache'u Discorda, resztę batchami po 100 równolegle.
+     *
+     * ⚠️ **Lista dotyczy WYŁĄCZNIE graczy z wynikiem w rankingu tego serwera**
+     * (`getSortedPlayers` czyta `ranking.json`), nigdy wszystkich członków Discorda.
+     *
+     * ⚠️ Wcześniej każdy gracz miał własne `members.fetch(userId)` w pętli z `await` — czyli
+     * tyle żądań do Discorda, ile wpisów w rankingu, **jedno po drugim**. Przy kilkuset
+     * graczach lista ładowała się kilkanaście sekund i więcej, a przy rate limicie jeszcze
+     * dłużej. Gracz z kilkoma profilami był dodatkowo pobierany raz na profil, choć nick
+     * ma jeden — stąd dedup po `userId` przed pobraniem.
+     *
+     * Wynik trzymamy przez `NICK_CACHE_TTL_MS`, żeby przewijanie stron listy
+     * (`chal_page_*`, `notif_page_*`) nie powtarzało całej operacji przy każdym kliknięciu.
+     * Cache'ujemy CAŁĄ mapę, więc osoby, których nie udało się pobrać (opuściły serwer),
+     * nie są odpytywane ponownie w obrębie TTL.
+     *
+     * @returns {Promise<Map<string, string>>} userId → nick serwerowy (tylko udane trafienia)
+     */
+    async _resolveGuildDisplayNames(guildId, client, userIds) {
+        const NICK_CACHE_TTL_MS = 3 * 60 * 1000;
+        const BATCH = 100;
+
+        const cached = this._guildNickCache.get(guildId);
+        if (cached && Date.now() - cached.at < NICK_CACHE_TTL_MS) return cached.names;
+
+        const names = new Map();
+        const guild = client?.guilds?.cache?.get(guildId);
+        if (!guild) return names;
+
+        const missing = [];
+        for (const userId of new Set(userIds)) {
+            const member = guild.members.cache.get(userId);
+            if (member) names.set(userId, member.displayName);
+            else missing.push(userId);
+        }
+
+        const chunks = [];
+        for (let i = 0; i < missing.length; i += BATCH) chunks.push(missing.slice(i, i + BATCH));
+
+        const results = await Promise.allSettled(
+            chunks.map(chunk => guild.members.fetch({ user: chunk }))
+        );
+        for (const res of results) {
+            if (res.status !== 'fulfilled') continue;
+            for (const [id, member] of res.value) names.set(id, member.displayName);
+        }
+
+        this._guildNickCache.set(guildId, { at: Date.now(), names });
+        return names;
     }
 
     /**

--- a/EndersEcho/index.js
+++ b/EndersEcho/index.js
@@ -452,6 +452,8 @@ client.on('guildCreate', async (guild) => {
             guildName: guild.name,
         });
         await interactionHandler.registerCommandsForGuild(client, guild.id);
+        // Sekcja 🖥️ Serwery liczy też serwery bez konfiguracji — panel ma o nim wiedzieć od razu
+        adminPanelService.refresh();
         if (guild.systemChannel) {
             await guild.systemChannel.send(
                 '⚙️ **EndersEcho** has been added to your server!\nAn administrator must run **/configure** to set up the bot before it can be used.'
@@ -494,6 +496,8 @@ client.on('guildDelete', async (guild) => {
     await guildDataRetentionService.schedule(guild.id, guild.name).catch(err =>
         logger.error(`Błąd planowania retencji dla "${guild.name}": ${err.message}`)
     );
+    // Serwer przechodzi w panelu do kategorii „skonfigurowane, brak bota"
+    adminPanelService.refresh();
     await sendAdminNotification(client, new EmbedBuilder()
         .setColor(0xED4245)
         .setTitle(tGD('🚪 Bot usunięty z serwera', '🚪 Bot removed from server'))


### PR DESCRIPTION
## 1. Panel nie odświeżał się po wysłaniu zaproszenia `/challenge`

Sekcja ⚔️ Wyzwania liczy też zaproszenia czekające na odpowiedź, więc licznik stał do najbliższej innej akcji admina.

**Audyt wykazał, że to nie był jedyny taki przypadek** — brakowało `refresh()` w 13 miejscach:

- **⚔️ Wyzwania** (cały cykl życia był głuchy): wysłanie zaproszenia, przyjęcie/odrzucenie, zaliczenie wyniku (licznik `2/3 : 1/3`), rozstrzygnięcie, sweep, doliczenie zaparkowanych wyników po zmapowaniu bossa, anulowanie wyzwań usuniętego profilu
- **👾 Bossowie**: dodanie / usunięcie / zmiana nazwy bossa, dodanie i usunięcie aliasu, przypisanie zdjęcia, zmapowanie nieznanej nazwy z alertu
- **⚙️ Narzędzia**: dodanie i usunięcie testera
- **👥 Użytkownicy**: dodanie profilu, zaplanowanie i odwołanie usunięcia profilu
- **🖥️ Serwery**: `cfg_accept` oraz `guildCreate` / `guildDelete` w `index.js`

`refresh()` jest debounce'owany (1 w locie + 1 oczekujący), a `_doRefresh` wychodzi od razu bez klienta albo bez kanału — nadmiarowe wywołanie nic nie kosztuje.

⚠️ **`_finishChallenges` to JEDYNE miejsce odświeżania po rozstrzygnięciu wyzwania** — schodzą się w nim wszystkie cztery drogi (komplet wyników, upływ 72 h, `forceFinish` z panelu, doliczenie zaparkowanego wyniku).

## 2. Lista graczy w `/challenge` i `/subscribe` ładowała się kilkanaście sekund

`_getNotifSortedPlayers` miał pętlę z `await targetGuild.members.fetch(player.userId)` **na każdy wpis rankingu** — tyle żądań do Discorda, ile wpisów, jedno po drugim. Gracz z kilkoma profilami był dodatkowo pobierany raz na profil.

Nowy helper `_resolveGuildDisplayNames(guildId, client, userIds)`:

- najpierw cache Discorda, resztę **batchami po 100 ID równolegle** (`guild.members.fetch({ user: chunk })` w `Promise.allSettled`) — ten sam wzorzec, którego używa już `roleRankingConfigService`
- **dedup po `userId` przed pobraniem** — nick jest jeden na osobę, niezależnie od liczby profili
- wynik cache'owany per serwer na **3 minuty**, więc przewijanie stron (`chal_page_*`, `notif_page_*`) nie powtarza operacji przy każdym kliknięciu; cache'owana jest cała mapa, więc osoby, które opuściły serwer, nie są odpytywane w kółko

Zakres danych bez zmian — lista zawsze pochodziła i nadal pochodzi **wyłącznie z `ranking.json` danego serwera** (osoby z wynikiem w EE), nigdy z listy wszystkich członków Discorda.

## 3. Przy okazji

Dwa komunikaty logu w rodzaju męskim zamienione na bezrodzajowe, zgodnie z zasadą z dokumentacji: `rzucił wyzwanie` → `rzuca wyzwanie`, `wygrał {nick}` → `zwycięstwo: {nick}`.

## Dokumentacja

`EndersEcho/CLAUDE.md`: sekcja „Triggery automatycznego refresh" przepisana na tabelę per sekcja panelu, z zasadą na przyszłość i notką o `_finishChallenges`; przy opisie list wyboru gracza dopisany zakres danych, mechanika batch-fetch z cache'em i ostrzeżenie przed powrotem do pętli pojedynczych `members.fetch(id)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9TQHRKc9tG29q2UimiVPN