### PR TITLE
Zakładka wyzwań w /profile: rzucone zaproszenia i stan punktowy pojedynku

### DIFF
--- a/EndersEcho/CLAUDE.md
+++ b/EndersEcho/CLAUDE.md
@@ -1456,7 +1456,14 @@ Rząd 1 mieści 5 przycisków, więc układ się przesunął:
 - **Własny profil, rząd 1:** `👤 Profil` · `🎯 Bossowie` · `🏆 Osiągnięcia` · `⚔️ Wyzwania` · `🔔 Subskrypcje`; **`🔍 Szukaj gracza` zeszło do rzędu narzędzi** (to narzędzie, nie zakładka)
 - **Cudzy profil, rząd 1:** `👤` · `🎯` · `🏆` · `⚔️` · `🔍 Szukaj gracza`
 
-Widok: bilans (`🏆 wygrane · 💔 przegrane · 🤝 remisy · ❓ nierozstrzygnięte · ⚔️ rzucone · 🛡️ przyjęte`), sekcja **W toku** (tylko własny profil — `2/3 : 1/3` + termin `<t:…:R>`, a wyniki oczekujące jedną notką pod listą, bo nie są jeszcze przypisane do konkretnego wyzwania) i **Historia** (8/stronę, paginacja `profile_chal_prev`/`profile_chal_next`).
+Widok składa się z czterech części:
+
+1. **Bilans** (opis embeda) — `🏆 wygrane · 💔 przegrane · 🤝 remisy · ❓ nierozstrzygnięte · ⚔️ rzucone · 🛡️ przyjęte`
+2. **📨 Rzucone — czekają na odpowiedź** — zaproszenia WYSŁANE przez tego gracza, z czasem, jaki został przeciwnikowi (`inviteExpiresAt` jako `<t:…:R>`). Otrzymanych zaproszeń tu nie ma: obsługuje je przycisk w DM i tak czy owak nie zajmują slotu, więc nie są stanem gry tego gracza
+3. **⚔️ W toku** — przeciwnik i boss, a pod spodem **licznik screenów ORAZ aktualna suma obu stron**: `**2/3** (12.5Sx) : **1/3** (8.1Sx)`, w trzeciej linii termin `⏳ <t:…:R>`. Kolejność jak w historii — najpierw moja strona, potem przeciwnik. **Sam licznik nie mówi, kto prowadzi**, dlatego suma stoi obok niego. Wyniki oczekujące na zmapowanie bossa idą jedną notką pod listą, bo nie są jeszcze przypisane do konkretnego wyzwania
+4. **📜 Historia** — 8/stronę, paginacja `profile_chal_prev`/`profile_chal_next`
+
+⚠️ **Punkty 2 i 3 pokazujemy WYŁĄCZNIE na własnym profilu.** To stan gry w toku, a nie dorobek — na cudzym profilu byłby podglądaniem cudzej kartki (widać by było, ile przeciwnik zdążył wrzucić i z jakim wynikiem). Bilans i historia są jawne dla każdego.
 
 Stan `chalPage`/`chalMaxPage` w `_profileStates`; komunikaty przez **`_msgsByLang(state.lang)`**, nie `this.msgs(guildId)` — widok profilu trzyma własny język (`_getProfileLang`), który nie musi pokrywać się z językiem serwera wywołania.
 

--- a/EndersEcho/config/messages.js
+++ b/EndersEcho/config/messages.js
@@ -584,7 +584,9 @@ const pol = {
     // ⚔️ Wyzwania — profil
     challengeProfileTitle: '⚔️ Wyzwania — {name}',
     challengeProfileSummary: '🏆 Wygrane: **{won}** · 💔 Przegrane: **{lost}** · 🤝 Remisy: **{draw}** · ❓ Nierozstrzygnięte: **{unresolved}**\n⚔️ Rzucone: **{sent}** · 🛡️ Przyjęte: **{accepted}**',
-    challengeProfileActive: '⏳ W toku',
+    challengeProfileActive: '⚔️ W toku',
+    challengeProfileSent: '📨 Rzucone — czekają na odpowiedź',
+    challengeProfileSentWait: 'czas na odpowiedź:',
     challengeProfileHistory: '📜 Historia',
     challengeProfileEmpty: 'Ten gracz nie brał jeszcze udziału w żadnym wyzwaniu.',
     challengeProfilePendingSuffix: ' *(+{count} oczekujący)*',
@@ -1183,7 +1185,9 @@ const eng = {
     // ⚔️ Challenges — profile
     challengeProfileTitle: '⚔️ Challenges — {name}',
     challengeProfileSummary: '🏆 Won: **{won}** · 💔 Lost: **{lost}** · 🤝 Draws: **{draw}** · ❓ Unresolved: **{unresolved}**\n⚔️ Sent: **{sent}** · 🛡️ Accepted: **{accepted}**',
-    challengeProfileActive: '⏳ In progress',
+    challengeProfileActive: '⚔️ In progress',
+    challengeProfileSent: '📨 Sent — awaiting a reply',
+    challengeProfileSentWait: 'time to answer:',
     challengeProfileHistory: '📜 History',
     challengeProfileEmpty: 'This player has not taken part in any challenge yet.',
     challengeProfilePendingSuffix: ' *(+{count} pending)*',

--- a/EndersEcho/handlers/interactionHandlers.js
+++ b/EndersEcho/handlers/interactionHandlers.js
@@ -18094,7 +18094,11 @@ class InteractionHandler {
     // ── Widok w /profile ──────────────────────────────────────────────────────
 
     /**
-     * Zakładka `⚔️ Wyzwania` — bilans, wyzwania w toku (tylko własny profil) i historia.
+     * Zakładka `⚔️ Wyzwania` — bilans, rzucone zaproszenia, wyzwania w toku i historia.
+     *
+     * Rzucone zaproszenia i wyzwania w toku pokazujemy **tylko na własnym profilu**: to stan
+     * gry w toku, a nie dorobek, więc na cudzym profilu byłby podglądaniem cudzej kartki.
+     * Historia i bilans są jawne dla każdego.
      * @returns {Promise<{ embed: EmbedBuilder, maxPage: number }>}
      */
     async _buildChallengeProfileEmbed(playerKey, displayName, msgs, page = 0, isOwnProfile = false) {
@@ -18109,6 +18113,20 @@ class InteractionHandler {
             .setTitle(formatMessage(msgs.challengeProfileTitle, { name: displayName }))
             .setDescription(formatMessage(msgs.challengeProfileSummary, stats));
 
+        // Rzucone zaproszenia czekające na odpowiedź — z czasem, jaki został przeciwnikowi.
+        // Liczą się WYSŁANE przez tego gracza; otrzymane obsługuje przycisk w DM, a i tak
+        // nie zajmują slotu, więc nie są jego stanem gry
+        const sent = isOwnProfile
+            ? all.filter(c => c.status === 'pending' && c.challenger?.playerKey === playerKey)
+            : [];
+        if (sent.length > 0) {
+            const lines = sent.map(c =>
+                `📨 **${cs.participantName(c.opponent, msgs)}** — \`${c.boss}\`\n`
+                + `└ ${msgs.challengeProfileSentWait} ${this._discordTs(c.inviteExpiresAt, 'R')}`
+            );
+            embed.addFields({ name: msgs.challengeProfileSent, value: lines.join('\n').slice(0, 1024), inline: false });
+        }
+
         const active = all.filter(c => c.status === 'active');
         if (isOwnProfile && active.length > 0) {
             const lines = active.map(c => {
@@ -18116,8 +18134,13 @@ class InteractionHandler {
                 const other = c[cs.otherSide(side)];
                 const mine = c[side].scores.length;
                 const theirs = other.scores.length;
+                // Licznik screenów ORAZ aktualna suma — sam licznik nie mówi, kto prowadzi.
+                // Kolejność jak w historii: najpierw moja strona, potem przeciwnik
+                const mySum = this.rankingService.formatScore(c[side].sum);
+                const theirSum = this.rankingService.formatScore(other.sum);
                 return `⚔️ **${cs.participantName(other, msgs)}** — \`${c.boss}\`\n`
-                    + `└ ${mine}/${cs.scoresPerSide} : ${theirs}/${cs.scoresPerSide} · ${this._discordTs(c.expiresAt, 'R')}`;
+                    + `└ **${mine}/${cs.scoresPerSide}** (${mySum}) : **${theirs}/${cs.scoresPerSide}** (${theirSum})\n`
+                    + `└ ⏳ ${this._discordTs(c.expiresAt, 'R')}`;
             });
             // Wynik oczekujący na zatwierdzenie nazwy bossa nie jest jeszcze przypisany
             // do konkretnego wyzwania, więc idzie jedną notką pod listą — nie przy wierszach


### PR DESCRIPTION
Zakładka `⚔️ Wyzwania` w `/profile` pokazywała bilans, listę „w toku" z samymi licznikami screenów i historię. Brakowało dwóch rzeczy: rzuconych zaproszeń i informacji, kto właściwie prowadzi.

## 📨 Rzucone — czekają na odpowiedź

Nowa sekcja z zaproszeniami **wysłanymi** przez tego gracza: przeciwnik, boss i czas, jaki mu został (`inviteExpiresAt` jako `<t:…:R>`).

Otrzymanych zaproszeń celowo tu nie ma — obsługuje je przycisk w DM, a przy tym nie zajmują slotu, więc nie są stanem gry tego gracza. Jeśli chcesz je też widzieć, dopisanie drugiej sekcji to kilka linijek.

## ⚔️ W toku — licznik + aktualna suma

Było: `2/3 : 1/3` i termin.

Jest:
```
⚔️ Nick — `Boss`
└ **2/3** (12.5Sx) : **1/3** (8.1Sx)
└ ⏳ za 2 dni
```

Kolejność jak w historii — najpierw moja strona, potem przeciwnik. **Sam licznik nie mówił, kto prowadzi**, a od zmiany rozstrzygania po czasie (`sweep` decyduje po sumach) to informacja, której gracz potrzebuje przed ostatnim podejściem.

Przy `MAX_ACTIVE_PER_PLAYER = 1` obie sekcje mieszczą po jednej pozycji, ale kod nie zakłada tego limitu — listy nadal przechodzą przez `.slice(0, 1024)`.

## Zakres widoczności

Obie sekcje pokazują się **wyłącznie na własnym profilu**, tak samo jak dotąd lista „w toku". To stan gry w toku, a nie dorobek — na cudzym profilu widać by było, ile przeciwnik zdążył wrzucić i z jakim wynikiem. Bilans i historia zostają jawne dla każdego.

## Nowe klucze (pol + eng)

`challengeProfileSent`, `challengeProfileSentWait`. Przy okazji `challengeProfileActive` zmienia ikonę z `⏳` na `⚔️` — klepsydra przeszła do nowej sekcji zaproszeń, gdzie oznacza realny licznik czasu.

## Dokumentacja

`EndersEcho/CLAUDE.md`: opis zakładki rozbity na cztery części z formatem linii, uzasadnieniem sumy przy liczniku i regułą widoczności.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9TQHRKc9tG29q2UimiVPN

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9TQHRKc9tG29q2UimiVPN)_